### PR TITLE
Move control unit to common folder.

### DIFF
--- a/src/common/control.circ
+++ b/src/common/control.circ
@@ -1,0 +1,6230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project source="2.7.1" version="1.0">
+  This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
+
+  <lib desc="#Wiring" name="0">
+    <tool name="Splitter">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Pin">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+    </tool>
+    <tool name="Tunnel">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="Pull Resistor">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Clock">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Constant">
+      <a name="value" val="0x0"/>
+    </tool>
+    <tool name="Bit Extender">
+      <a name="type" val="sign"/>
+    </tool>
+  </lib>
+  <lib desc="#Gates" name="1">
+    <tool name="Buffer">
+      <a name="width" val="3"/>
+    </tool>
+    <tool name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="OR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="NOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="XOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="Odd Parity">
+      <a name="facing" val="south"/>
+      <a name="inputs" val="3"/>
+    </tool>
+  </lib>
+  <lib desc="#Plexers" name="2">
+    <tool name="Multiplexer">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="Demultiplexer">
+      <a name="select" val="5"/>
+    </tool>
+  </lib>
+  <lib desc="#Arithmetic" name="3">
+    <tool name="Subtractor">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Multiplier">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Divider">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Negator">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Comparator">
+      <a name="width" val="32"/>
+    </tool>
+  </lib>
+  <lib desc="#Memory" name="4">
+    <tool name="Register">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="ROM">
+      <a name="contents">addr/data: 8 8
+0
+</a>
+    </tool>
+  </lib>
+  <lib desc="#I/O" name="5"/>
+  <lib desc="#Base" name="6">
+    <tool name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+  </lib>
+  <main name="Control"/>
+  <options>
+    <a name="gateUndefined" val="ignore"/>
+    <a name="simlimit" val="1000"/>
+    <a name="simrand" val="0"/>
+  </options>
+  <mappings>
+    <tool lib="6" map="Button2" name="Menu Tool"/>
+    <tool lib="6" map="Button3" name="Menu Tool"/>
+    <tool lib="6" map="Ctrl Button1" name="Menu Tool"/>
+  </mappings>
+  <toolbar>
+    <tool lib="6" name="Poke Tool"/>
+    <tool lib="6" name="Edit Tool"/>
+    <tool lib="6" name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+    <sep/>
+    <tool lib="0" name="Pin">
+      <a name="tristate" val="false"/>
+    </tool>
+    <tool lib="0" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="labelloc" val="east"/>
+    </tool>
+    <tool lib="1" name="NOT Gate"/>
+    <tool lib="1" name="AND Gate"/>
+    <tool lib="1" name="OR Gate"/>
+  </toolbar>
+  <circuit name="Control">
+    <a name="circuit" val="Control"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <rect fill="#4b00ff" height="342" stroke="#ffffff" stroke-width="2" width="33" x="60" y="160"/>
+      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="74" y="300">Ctrl</text>
+      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="75" y="323">Unit</text>
+      <circ-port height="8" pin="240,130" width="8" x="56" y="256"/>
+      <circ-port height="8" pin="460,130" width="8" x="56" y="336"/>
+      <circ-port height="10" pin="980,360" width="10" x="85" y="375"/>
+      <circ-port height="10" pin="260,170" width="10" x="85" y="175"/>
+      <circ-port height="10" pin="260,210" width="10" x="85" y="415"/>
+      <circ-port height="10" pin="260,250" width="10" x="85" y="215"/>
+      <circ-port height="10" pin="260,290" width="10" x="85" y="195"/>
+      <circ-port height="10" pin="480,170" width="10" x="85" y="275"/>
+      <circ-port height="10" pin="480,210" width="10" x="85" y="255"/>
+      <circ-port height="10" pin="480,250" width="10" x="85" y="355"/>
+      <circ-port height="10" pin="480,290" width="10" x="85" y="315"/>
+      <circ-port height="10" pin="480,330" width="10" x="85" y="455"/>
+      <circ-port height="10" pin="260,330" width="10" x="85" y="335"/>
+      <circ-port height="10" pin="260,370" width="10" x="85" y="395"/>
+      <circ-port height="10" pin="480,370" width="10" x="85" y="295"/>
+      <circ-port height="10" pin="260,410" width="10" x="85" y="435"/>
+      <circ-port height="10" pin="480,410" width="10" x="85" y="235"/>
+      <circ-port height="10" pin="260,450" width="10" x="85" y="475"/>
+      <circ-port height="10" pin="480,440" width="10" x="65" y="495"/>
+      <circ-port height="10" pin="480,470" width="10" x="75" y="495"/>
+      <circ-anchor facing="east" height="6" width="6" x="57" y="157"/>
+    </appear>
+    <wire from="(910,470)" to="(910,480)"/>
+    <wire from="(820,740)" to="(820,750)"/>
+    <wire from="(840,720)" to="(840,730)"/>
+    <wire from="(140,50)" to="(580,50)"/>
+    <wire from="(140,850)" to="(580,850)"/>
+    <wire from="(140,490)" to="(580,490)"/>
+    <wire from="(750,220)" to="(750,310)"/>
+    <wire from="(930,170)" to="(930,190)"/>
+    <wire from="(820,370)" to="(820,450)"/>
+    <wire from="(830,740)" to="(850,740)"/>
+    <wire from="(230,170)" to="(260,170)"/>
+    <wire from="(910,300)" to="(930,300)"/>
+    <wire from="(1080,50)" to="(1080,550)"/>
+    <wire from="(460,250)" to="(480,250)"/>
+    <wire from="(460,130)" to="(480,130)"/>
+    <wire from="(460,170)" to="(480,170)"/>
+    <wire from="(460,210)" to="(480,210)"/>
+    <wire from="(460,290)" to="(480,290)"/>
+    <wire from="(460,330)" to="(480,330)"/>
+    <wire from="(460,370)" to="(480,370)"/>
+    <wire from="(460,410)" to="(480,410)"/>
+    <wire from="(950,130)" to="(980,130)"/>
+    <wire from="(950,210)" to="(980,210)"/>
+    <wire from="(900,440)" to="(930,440)"/>
+    <wire from="(430,670)" to="(440,670)"/>
+    <wire from="(250,250)" to="(260,250)"/>
+    <wire from="(250,290)" to="(260,290)"/>
+    <wire from="(250,330)" to="(260,330)"/>
+    <wire from="(230,710)" to="(240,710)"/>
+    <wire from="(710,430)" to="(720,430)"/>
+    <wire from="(710,470)" to="(720,470)"/>
+    <wire from="(600,50)" to="(600,550)"/>
+    <wire from="(930,300)" to="(930,310)"/>
+    <wire from="(800,350)" to="(920,350)"/>
+    <wire from="(1080,570)" to="(1080,850)"/>
+    <wire from="(730,140)" to="(920,140)"/>
+    <wire from="(600,570)" to="(600,850)"/>
+    <wire from="(750,220)" to="(920,220)"/>
+    <wire from="(860,460)" to="(880,460)"/>
+    <wire from="(900,460)" to="(920,460)"/>
+    <wire from="(270,750)" to="(290,750)"/>
+    <wire from="(660,450)" to="(690,450)"/>
+    <wire from="(270,710)" to="(290,710)"/>
+    <wire from="(270,670)" to="(290,670)"/>
+    <wire from="(270,790)" to="(290,790)"/>
+    <wire from="(270,630)" to="(290,630)"/>
+    <wire from="(600,50)" to="(1080,50)"/>
+    <wire from="(600,570)" to="(1080,570)"/>
+    <wire from="(600,850)" to="(1080,850)"/>
+    <wire from="(950,260)" to="(980,260)"/>
+    <wire from="(820,690)" to="(850,690)"/>
+    <wire from="(900,450)" to="(930,450)"/>
+    <wire from="(900,490)" to="(930,490)"/>
+    <wire from="(900,170)" to="(930,170)"/>
+    <wire from="(580,50)" to="(580,490)"/>
+    <wire from="(490,700)" to="(500,700)"/>
+    <wire from="(230,680)" to="(240,680)"/>
+    <wire from="(230,720)" to="(240,720)"/>
+    <wire from="(970,460)" to="(980,460)"/>
+    <wire from="(140,50)" to="(140,490)"/>
+    <wire from="(900,470)" to="(910,470)"/>
+    <wire from="(910,200)" to="(920,200)"/>
+    <wire from="(910,120)" to="(920,120)"/>
+    <wire from="(840,730)" to="(850,730)"/>
+    <wire from="(710,440)" to="(720,440)"/>
+    <wire from="(920,460)" to="(920,470)"/>
+    <wire from="(830,730)" to="(830,740)"/>
+    <wire from="(900,480)" to="(900,490)"/>
+    <wire from="(140,510)" to="(580,510)"/>
+    <wire from="(140,510)" to="(140,850)"/>
+    <wire from="(930,150)" to="(930,170)"/>
+    <wire from="(580,510)" to="(580,850)"/>
+    <wire from="(800,450)" to="(820,450)"/>
+    <wire from="(770,270)" to="(920,270)"/>
+    <wire from="(910,480)" to="(930,480)"/>
+    <wire from="(770,270)" to="(770,310)"/>
+    <wire from="(670,350)" to="(700,350)"/>
+    <wire from="(460,470)" to="(480,470)"/>
+    <wire from="(240,130)" to="(260,130)"/>
+    <wire from="(240,210)" to="(260,210)"/>
+    <wire from="(240,370)" to="(260,370)"/>
+    <wire from="(240,410)" to="(260,410)"/>
+    <wire from="(240,450)" to="(260,450)"/>
+    <wire from="(430,730)" to="(440,730)"/>
+    <wire from="(230,690)" to="(240,690)"/>
+    <wire from="(230,730)" to="(240,730)"/>
+    <wire from="(910,250)" to="(920,250)"/>
+    <wire from="(710,450)" to="(720,450)"/>
+    <wire from="(820,370)" to="(920,370)"/>
+    <wire from="(820,700)" to="(860,700)"/>
+    <wire from="(930,280)" to="(930,300)"/>
+    <wire from="(820,720)" to="(840,720)"/>
+    <wire from="(780,720)" to="(800,720)"/>
+    <wire from="(730,140)" to="(730,310)"/>
+    <wire from="(270,730)" to="(290,730)"/>
+    <wire from="(270,690)" to="(290,690)"/>
+    <wire from="(270,770)" to="(290,770)"/>
+    <wire from="(270,810)" to="(290,810)"/>
+    <wire from="(270,610)" to="(290,610)"/>
+    <wire from="(270,650)" to="(290,650)"/>
+    <wire from="(600,550)" to="(1080,550)"/>
+    <wire from="(460,440)" to="(480,440)"/>
+    <wire from="(950,360)" to="(980,360)"/>
+    <wire from="(820,710)" to="(850,710)"/>
+    <wire from="(820,750)" to="(850,750)"/>
+    <wire from="(900,430)" to="(930,430)"/>
+    <wire from="(490,680)" to="(500,680)"/>
+    <wire from="(230,700)" to="(240,700)"/>
+    <wire from="(200,710)" to="(210,710)"/>
+    <wire from="(920,470)" to="(930,470)"/>
+    <wire from="(820,730)" to="(830,730)"/>
+    <wire from="(890,720)" to="(900,720)"/>
+    <wire from="(710,420)" to="(720,420)"/>
+    <wire from="(710,460)" to="(720,460)"/>
+    <comp lib="0" loc="(480,330)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegDst"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(260,450)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ZeroExtend"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(210,710)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(290,610)" name="Tunnel">
+      <a name="label" val="MemRead"/>
+    </comp>
+    <comp lib="0" loc="(900,720)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(250,330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="BneOrBeq"/>
+    </comp>
+    <comp lib="0" loc="(910,300)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsSpecial"/>
+    </comp>
+    <comp lib="0" loc="(290,710)" name="Tunnel">
+      <a name="label" val="Branch"/>
+    </comp>
+    <comp lib="0" loc="(460,170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="MemRead"/>
+    </comp>
+    <comp lib="0" loc="(260,330)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeq"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(840,609)" name="Text">
+      <a name="text" val="Exception Handler"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(910,200)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(260,130)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(880,460)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(240,130)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(440,730)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(260,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJAL"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,730)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(200,710)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(290,810)" name="Tunnel">
+      <a name="label" val="ZeroExtend"/>
+    </comp>
+    <comp lib="6" loc="(353,93)" name="Text">
+      <a name="text" val="Input &amp; Output"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(800,450)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="3"/>
+      <a name="bit1" val="2"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="0"/>
+    </comp>
+    <comp lib="0" loc="(460,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(860,460)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(480,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Branch"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(480,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(950,210)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(670,350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(460,410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(910,120)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(240,410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="0" loc="(480,130)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(260,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscall"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(900,170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsSpecial"/>
+    </comp>
+    <comp lib="0" loc="(430,670)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(260,250)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoReg"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(690,450)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="2" loc="(950,130)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(930,340)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(290,650)" name="Tunnel">
+      <a name="label" val="ALUSrc"/>
+    </comp>
+    <comp loc="(720,320)" name="Funct_Decoder"/>
+    <comp lib="0" loc="(980,130)" name="Tunnel">
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="0" loc="(230,170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="0" loc="(460,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(290,790)" name="Tunnel">
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="0" loc="(980,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ALUop"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(460,250)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Jump"/>
+    </comp>
+    <comp lib="0" loc="(800,720)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(780,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(240,450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ZeroExtend"/>
+    </comp>
+    <comp lib="0" loc="(700,350)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(290,690)" name="Tunnel">
+      <a name="label" val="MemtoReg"/>
+    </comp>
+    <comp lib="0" loc="(290,730)" name="Tunnel">
+      <a name="label" val="RegDst"/>
+    </comp>
+    <comp lib="0" loc="(800,350)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="3"/>
+      <a name="bit1" val="2"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="0"/>
+    </comp>
+    <comp lib="0" loc="(460,210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="MemWrite"/>
+    </comp>
+    <comp lib="0" loc="(660,450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="op"/>
+    </comp>
+    <comp lib="0" loc="(910,250)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(260,210)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamt"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,370)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ALUSrc"/>
+    </comp>
+    <comp lib="0" loc="(290,630)" name="Tunnel">
+      <a name="label" val="MemWrite"/>
+    </comp>
+    <comp lib="0" loc="(480,210)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp loc="(490,690)" name="RegisterRead_Detector"/>
+    <comp lib="0" loc="(480,250)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Jump"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(950,360)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(460,370)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsJR"/>
+    </comp>
+    <comp lib="0" loc="(250,250)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="MemtoReg"/>
+    </comp>
+    <comp lib="6" loc="(371,553)" name="Text">
+      <a name="text" val="OP Decoding Area"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(980,460)" name="Tunnel">
+      <a name="label" val="IsSpecial"/>
+    </comp>
+    <comp lib="0" loc="(480,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsCOP0"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(290,770)" name="Tunnel">
+      <a name="label" val="BneOrBeq"/>
+    </comp>
+    <comp lib="1" loc="(890,720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+      <a name="negate0" val="true"/>
+      <a name="negate2" val="true"/>
+      <a name="negate3" val="true"/>
+      <a name="negate4" val="true"/>
+      <a name="negate5" val="true"/>
+    </comp>
+    <comp lib="0" loc="(980,260)" name="Tunnel">
+      <a name="label" val="IsShamt"/>
+    </comp>
+    <comp lib="0" loc="(460,330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="RegDst"/>
+    </comp>
+    <comp lib="0" loc="(480,370)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJR"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(970,460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+      <a name="negate0" val="true"/>
+      <a name="negate1" val="true"/>
+      <a name="negate2" val="true"/>
+      <a name="negate3" val="true"/>
+      <a name="negate4" val="true"/>
+      <a name="negate5" val="true"/>
+    </comp>
+    <comp lib="6" loc="(851,85)" name="Text">
+      <a name="text" val="ALU Decoding Area"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="2" loc="(950,260)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,750)" name="Tunnel">
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="0" loc="(480,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(980,210)" name="Tunnel">
+      <a name="label" val="IsJR"/>
+    </comp>
+    <comp lib="0" loc="(260,370)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrc"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(460,130)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(500,680)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(260,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp loc="(240,600)" name="Opcode_Decoder"/>
+    <comp lib="0" loc="(240,210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsShamt"/>
+    </comp>
+    <comp loc="(770,430)" name="ALU_Decoder"/>
+    <comp lib="0" loc="(460,290)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Branch"/>
+    </comp>
+    <comp lib="0" loc="(250,290)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="0" loc="(290,670)" name="Tunnel">
+      <a name="label" val="Jump"/>
+    </comp>
+    <comp lib="0" loc="(500,700)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(440,670)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(480,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemRead"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+  </circuit>
+  <circuit name="Funct_Decoder">
+    <a name="circuit" val="Funct_Decoder"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <rect fill="none" height="71" stroke="#000000" stroke-width="2" width="60" x="50" y="50"/>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="81" y="82">Funct</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="101">Decoder</text>
+      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
+      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
+      <circ-port height="8" pin="40,140" width="8" x="46" y="76"/>
+      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
+      <circ-port height="10" pin="390,240" width="10" x="105" y="65"/>
+      <circ-port height="8" pin="40,250" width="8" x="46" y="96"/>
+      <circ-port height="8" pin="40,310" width="8" x="46" y="106"/>
+      <circ-port height="10" pin="390,700" width="10" x="105" y="75"/>
+      <circ-port height="10" pin="390,1310" width="10" x="105" y="85"/>
+      <circ-port height="10" pin="390,1870" width="10" x="105" y="95"/>
+      <circ-port height="10" pin="390,2210" width="10" x="75" y="45"/>
+      <circ-port height="10" pin="390,2370" width="10" x="55" y="45"/>
+      <circ-port height="10" pin="390,2670" width="10" x="95" y="45"/>
+      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
+    </appear>
+    <wire from="(160,700)" to="(160,830)"/>
+    <wire from="(100,640)" to="(100,770)"/>
+    <wire from="(200,910)" to="(260,910)"/>
+    <wire from="(230,870)" to="(230,880)"/>
+    <wire from="(220,1020)" to="(220,1030)"/>
+    <wire from="(60,2600)" to="(180,2600)"/>
+    <wire from="(60,2760)" to="(180,2760)"/>
+    <wire from="(60,590)" to="(240,590)"/>
+    <wire from="(210,770)" to="(260,770)"/>
+    <wire from="(60,1390)" to="(240,1390)"/>
+    <wire from="(230,2630)" to="(230,2650)"/>
+    <wire from="(230,2790)" to="(230,2810)"/>
+    <wire from="(240,240)" to="(240,260)"/>
+    <wire from="(230,1030)" to="(230,1050)"/>
+    <wire from="(60,1240)" to="(60,1390)"/>
+    <wire from="(290,2210)" to="(390,2210)"/>
+    <wire from="(290,2370)" to="(390,2370)"/>
+    <wire from="(240,1040)" to="(240,1070)"/>
+    <wire from="(240,720)" to="(240,750)"/>
+    <wire from="(80,1520)" to="(180,1520)"/>
+    <wire from="(230,170)" to="(260,170)"/>
+    <wire from="(230,650)" to="(260,650)"/>
+    <wire from="(140,2710)" to="(230,2710)"/>
+    <wire from="(290,70)" to="(320,70)"/>
+    <wire from="(310,250)" to="(340,250)"/>
+    <wire from="(230,1130)" to="(260,1130)"/>
+    <wire from="(230,1290)" to="(260,1290)"/>
+    <wire from="(230,1930)" to="(260,1930)"/>
+    <wire from="(230,2090)" to="(260,2090)"/>
+    <wire from="(240,1790)" to="(260,1790)"/>
+    <wire from="(200,2550)" to="(220,2550)"/>
+    <wire from="(310,2660)" to="(330,2660)"/>
+    <wire from="(160,830)" to="(160,940)"/>
+    <wire from="(160,1070)" to="(180,1070)"/>
+    <wire from="(210,480)" to="(230,480)"/>
+    <wire from="(210,800)" to="(230,800)"/>
+    <wire from="(100,2520)" to="(180,2520)"/>
+    <wire from="(160,2580)" to="(240,2580)"/>
+    <wire from="(100,770)" to="(100,890)"/>
+    <wire from="(120,2080)" to="(180,2080)"/>
+    <wire from="(80,80)" to="(80,150)"/>
+    <wire from="(40,310)" to="(160,310)"/>
+    <wire from="(60,240)" to="(240,240)"/>
+    <wire from="(60,720)" to="(240,720)"/>
+    <wire from="(120,2550)" to="(120,2690)"/>
+    <wire from="(140,2570)" to="(140,2710)"/>
+    <wire from="(240,850)" to="(240,870)"/>
+    <wire from="(140,2250)" to="(140,2400)"/>
+    <wire from="(160,2430)" to="(160,2580)"/>
+    <wire from="(230,520)" to="(230,540)"/>
+    <wire from="(220,2680)" to="(260,2680)"/>
+    <wire from="(220,2840)" to="(260,2840)"/>
+    <wire from="(230,780)" to="(260,780)"/>
+    <wire from="(100,2060)" to="(260,2060)"/>
+    <wire from="(140,440)" to="(230,440)"/>
+    <wire from="(360,2670)" to="(390,2670)"/>
+    <wire from="(240,2240)" to="(260,2240)"/>
+    <wire from="(240,1280)" to="(260,1280)"/>
+    <wire from="(240,1120)" to="(260,1120)"/>
+    <wire from="(240,1920)" to="(260,1920)"/>
+    <wire from="(240,2400)" to="(260,2400)"/>
+    <wire from="(240,2560)" to="(260,2560)"/>
+    <wire from="(320,720)" to="(340,720)"/>
+    <wire from="(290,1810)" to="(310,1810)"/>
+    <wire from="(240,530)" to="(240,570)"/>
+    <wire from="(240,160)" to="(260,160)"/>
+    <wire from="(240,320)" to="(260,320)"/>
+    <wire from="(320,510)" to="(320,680)"/>
+    <wire from="(210,610)" to="(230,610)"/>
+    <wire from="(200,1720)" to="(220,1720)"/>
+    <wire from="(40,190)" to="(120,190)"/>
+    <wire from="(100,1690)" to="(180,1690)"/>
+    <wire from="(160,1750)" to="(240,1750)"/>
+    <wire from="(120,1460)" to="(260,1460)"/>
+    <wire from="(310,1880)" to="(310,1940)"/>
+    <wire from="(120,1720)" to="(120,1840)"/>
+    <wire from="(140,1740)" to="(140,1870)"/>
+    <wire from="(60,1500)" to="(60,1630)"/>
+    <wire from="(120,2690)" to="(180,2690)"/>
+    <wire from="(120,2850)" to="(180,2850)"/>
+    <wire from="(140,800)" to="(190,800)"/>
+    <wire from="(60,850)" to="(240,850)"/>
+    <wire from="(80,1520)" to="(80,1660)"/>
+    <wire from="(230,2090)" to="(230,2100)"/>
+    <wire from="(60,2460)" to="(60,2600)"/>
+    <wire from="(240,2100)" to="(240,2120)"/>
+    <wire from="(100,1540)" to="(100,1690)"/>
+    <wire from="(160,1600)" to="(160,1750)"/>
+    <wire from="(230,650)" to="(230,670)"/>
+    <wire from="(230,970)" to="(230,990)"/>
+    <wire from="(140,2250)" to="(180,2250)"/>
+    <wire from="(200,2150)" to="(240,2150)"/>
+    <wire from="(200,2310)" to="(240,2310)"/>
+    <wire from="(230,270)" to="(260,270)"/>
+    <wire from="(230,430)" to="(260,430)"/>
+    <wire from="(210,570)" to="(240,570)"/>
+    <wire from="(200,1520)" to="(230,1520)"/>
+    <wire from="(100,2660)" to="(100,2820)"/>
+    <wire from="(120,1560)" to="(120,1720)"/>
+    <wire from="(140,1580)" to="(140,1740)"/>
+    <wire from="(140,1050)" to="(230,1050)"/>
+    <wire from="(100,1810)" to="(190,1810)"/>
+    <wire from="(60,30)" to="(60,130)"/>
+    <wire from="(230,2190)" to="(260,2190)"/>
+    <wire from="(230,2350)" to="(260,2350)"/>
+    <wire from="(230,2510)" to="(260,2510)"/>
+    <wire from="(140,1870)" to="(140,1970)"/>
+    <wire from="(240,930)" to="(260,930)"/>
+    <wire from="(240,1730)" to="(260,1730)"/>
+    <wire from="(320,1330)" to="(340,1330)"/>
+    <wire from="(290,1940)" to="(310,1940)"/>
+    <wire from="(240,660)" to="(240,700)"/>
+    <wire from="(310,250)" to="(310,290)"/>
+    <wire from="(210,740)" to="(230,740)"/>
+    <wire from="(100,60)" to="(180,60)"/>
+    <wire from="(160,120)" to="(240,120)"/>
+    <wire from="(60,1630)" to="(60,1760)"/>
+    <wire from="(120,420)" to="(180,420)"/>
+    <wire from="(200,180)" to="(260,180)"/>
+    <wire from="(200,1140)" to="(260,1140)"/>
+    <wire from="(200,1300)" to="(260,1300)"/>
+    <wire from="(140,1470)" to="(260,1470)"/>
+    <wire from="(120,190)" to="(120,200)"/>
+    <wire from="(310,2680)" to="(310,2830)"/>
+    <wire from="(230,780)" to="(230,800)"/>
+    <wire from="(240,950)" to="(240,980)"/>
+    <wire from="(220,1020)" to="(260,1020)"/>
+    <wire from="(200,2120)" to="(240,2120)"/>
+    <wire from="(200,2280)" to="(240,2280)"/>
+    <wire from="(200,2600)" to="(240,2600)"/>
+    <wire from="(200,2760)" to="(240,2760)"/>
+    <wire from="(80,150)" to="(180,150)"/>
+    <wire from="(80,1110)" to="(180,1110)"/>
+    <wire from="(80,1270)" to="(180,1270)"/>
+    <wire from="(100,400)" to="(260,400)"/>
+    <wire from="(210,700)" to="(240,700)"/>
+    <wire from="(230,880)" to="(260,880)"/>
+    <wire from="(100,1940)" to="(190,1940)"/>
+    <wire from="(230,1680)" to="(260,1680)"/>
+    <wire from="(240,2180)" to="(260,2180)"/>
+    <wire from="(240,2340)" to="(260,2340)"/>
+    <wire from="(240,2500)" to="(260,2500)"/>
+    <wire from="(140,210)" to="(140,250)"/>
+    <wire from="(240,790)" to="(240,830)"/>
+    <wire from="(160,340)" to="(180,340)"/>
+    <wire from="(240,100)" to="(260,100)"/>
+    <wire from="(240,260)" to="(260,260)"/>
+    <wire from="(320,1890)" to="(320,2070)"/>
+    <wire from="(120,540)" to="(190,540)"/>
+    <wire from="(80,1780)" to="(80,1910)"/>
+    <wire from="(120,540)" to="(120,670)"/>
+    <wire from="(60,1760)" to="(60,1890)"/>
+    <wire from="(120,1030)" to="(180,1030)"/>
+    <wire from="(230,430)" to="(230,440)"/>
+    <wire from="(240,440)" to="(240,450)"/>
+    <wire from="(60,950)" to="(240,950)"/>
+    <wire from="(100,1000)" to="(100,1140)"/>
+    <wire from="(320,260)" to="(320,410)"/>
+    <wire from="(320,1700)" to="(320,1850)"/>
+    <wire from="(200,2730)" to="(240,2730)"/>
+    <wire from="(80,2040)" to="(180,2040)"/>
+    <wire from="(160,1480)" to="(260,1480)"/>
+    <wire from="(230,50)" to="(260,50)"/>
+    <wire from="(210,830)" to="(240,830)"/>
+    <wire from="(230,1170)" to="(260,1170)"/>
+    <wire from="(230,1330)" to="(260,1330)"/>
+    <wire from="(290,1550)" to="(320,1550)"/>
+    <wire from="(240,870)" to="(260,870)"/>
+    <wire from="(240,1670)" to="(260,1670)"/>
+    <wire from="(240,1830)" to="(260,1830)"/>
+    <wire from="(100,140)" to="(100,180)"/>
+    <wire from="(310,190)" to="(310,230)"/>
+    <wire from="(240,1240)" to="(240,1280)"/>
+    <wire from="(40,30)" to="(60,30)"/>
+    <wire from="(60,130)" to="(60,240)"/>
+    <wire from="(80,150)" to="(80,260)"/>
+    <wire from="(100,1440)" to="(180,1440)"/>
+    <wire from="(120,670)" to="(190,670)"/>
+    <wire from="(160,450)" to="(160,700)"/>
+    <wire from="(200,2520)" to="(260,2520)"/>
+    <wire from="(80,1910)" to="(80,2040)"/>
+    <wire from="(140,1970)" to="(140,2100)"/>
+    <wire from="(60,1890)" to="(60,2020)"/>
+    <wire from="(200,1560)" to="(260,1560)"/>
+    <wire from="(80,1270)" to="(80,1410)"/>
+    <wire from="(230,1520)" to="(230,1530)"/>
+    <wire from="(320,70)" to="(320,220)"/>
+    <wire from="(60,1090)" to="(60,1240)"/>
+    <wire from="(80,2490)" to="(180,2490)"/>
+    <wire from="(200,150)" to="(230,150)"/>
+    <wire from="(230,500)" to="(260,500)"/>
+    <wire from="(200,1110)" to="(230,1110)"/>
+    <wire from="(200,1270)" to="(230,1270)"/>
+    <wire from="(80,1110)" to="(80,1270)"/>
+    <wire from="(140,320)" to="(230,320)"/>
+    <wire from="(310,1860)" to="(340,1860)"/>
+    <wire from="(240,1960)" to="(260,1960)"/>
+    <wire from="(240,40)" to="(260,40)"/>
+    <wire from="(310,640)" to="(310,690)"/>
+    <wire from="(160,1480)" to="(160,1600)"/>
+    <wire from="(60,2020)" to="(60,2150)"/>
+    <wire from="(200,1690)" to="(260,1690)"/>
+    <wire from="(220,1320)" to="(220,1330)"/>
+    <wire from="(290,1310)" to="(340,1310)"/>
+    <wire from="(230,1170)" to="(230,1180)"/>
+    <wire from="(80,2040)" to="(80,2180)"/>
+    <wire from="(100,2060)" to="(100,2200)"/>
+    <wire from="(120,2080)" to="(120,2220)"/>
+    <wire from="(230,1330)" to="(230,1350)"/>
+    <wire from="(240,1500)" to="(240,1520)"/>
+    <wire from="(310,1150)" to="(310,1300)"/>
+    <wire from="(140,2100)" to="(140,2250)"/>
+    <wire from="(160,2280)" to="(160,2430)"/>
+    <wire from="(240,1180)" to="(240,1210)"/>
+    <wire from="(240,1340)" to="(240,1370)"/>
+    <wire from="(200,1070)" to="(240,1070)"/>
+    <wire from="(80,380)" to="(180,380)"/>
+    <wire from="(80,1660)" to="(180,1660)"/>
+    <wire from="(230,310)" to="(260,310)"/>
+    <wire from="(230,630)" to="(260,630)"/>
+    <wire from="(160,2000)" to="(190,2000)"/>
+    <wire from="(160,2120)" to="(160,2280)"/>
+    <wire from="(140,930)" to="(230,930)"/>
+    <wire from="(310,230)" to="(340,230)"/>
+    <wire from="(290,1010)" to="(320,1010)"/>
+    <wire from="(230,1430)" to="(260,1430)"/>
+    <wire from="(200,2040)" to="(230,2040)"/>
+    <wire from="(230,2230)" to="(260,2230)"/>
+    <wire from="(230,2390)" to="(260,2390)"/>
+    <wire from="(230,2550)" to="(260,2550)"/>
+    <wire from="(310,710)" to="(340,710)"/>
+    <wire from="(200,2690)" to="(220,2690)"/>
+    <wire from="(200,2850)" to="(220,2850)"/>
+    <wire from="(320,1850)" to="(340,1850)"/>
+    <wire from="(240,2460)" to="(240,2500)"/>
+    <wire from="(240,490)" to="(260,490)"/>
+    <wire from="(160,1210)" to="(180,1210)"/>
+    <wire from="(160,1370)" to="(180,1370)"/>
+    <wire from="(100,2660)" to="(180,2660)"/>
+    <wire from="(100,2820)" to="(180,2820)"/>
+    <wire from="(120,670)" to="(120,910)"/>
+    <wire from="(120,300)" to="(180,300)"/>
+    <wire from="(120,2220)" to="(180,2220)"/>
+    <wire from="(200,60)" to="(260,60)"/>
+    <wire from="(60,1500)" to="(240,1500)"/>
+    <wire from="(80,2490)" to="(80,2630)"/>
+    <wire from="(230,1780)" to="(230,1800)"/>
+    <wire from="(80,1780)" to="(190,1780)"/>
+    <wire from="(60,10)" to="(60,30)"/>
+    <wire from="(60,2310)" to="(60,2460)"/>
+    <wire from="(40,80)" to="(80,80)"/>
+    <wire from="(80,30)" to="(180,30)"/>
+    <wire from="(100,280)" to="(260,280)"/>
+    <wire from="(230,760)" to="(260,760)"/>
+    <wire from="(230,920)" to="(260,920)"/>
+    <wire from="(60,2150)" to="(60,2310)"/>
+    <wire from="(100,2200)" to="(260,2200)"/>
+    <wire from="(100,2360)" to="(260,2360)"/>
+    <wire from="(120,2690)" to="(120,2850)"/>
+    <wire from="(60,360)" to="(60,460)"/>
+    <wire from="(80,380)" to="(80,480)"/>
+    <wire from="(230,1720)" to="(260,1720)"/>
+    <wire from="(200,2490)" to="(230,2490)"/>
+    <wire from="(310,1320)" to="(340,1320)"/>
+    <wire from="(320,220)" to="(340,220)"/>
+    <wire from="(290,190)" to="(310,190)"/>
+    <wire from="(290,1150)" to="(310,1150)"/>
+    <wire from="(240,1420)" to="(260,1420)"/>
+    <wire from="(240,1580)" to="(260,1580)"/>
+    <wire from="(240,2700)" to="(260,2700)"/>
+    <wire from="(240,2860)" to="(260,2860)"/>
+    <wire from="(140,2710)" to="(140,2880)"/>
+    <wire from="(370,1870)" to="(390,1870)"/>
+    <wire from="(240,1630)" to="(240,1670)"/>
+    <wire from="(240,620)" to="(260,620)"/>
+    <wire from="(100,400)" to="(100,510)"/>
+    <wire from="(160,450)" to="(240,450)"/>
+    <wire from="(80,30)" to="(80,80)"/>
+    <wire from="(160,2730)" to="(160,2910)"/>
+    <wire from="(80,1660)" to="(80,1780)"/>
+    <wire from="(120,420)" to="(120,540)"/>
+    <wire from="(140,440)" to="(140,570)"/>
+    <wire from="(160,940)" to="(160,1070)"/>
+    <wire from="(140,250)" to="(140,320)"/>
+    <wire from="(120,910)" to="(180,910)"/>
+    <wire from="(310,2530)" to="(310,2660)"/>
+    <wire from="(230,310)" to="(230,320)"/>
+    <wire from="(60,1240)" to="(180,1240)"/>
+    <wire from="(210,1810)" to="(260,1810)"/>
+    <wire from="(230,2390)" to="(230,2400)"/>
+    <wire from="(220,2540)" to="(220,2550)"/>
+    <wire from="(230,1270)" to="(230,1290)"/>
+    <wire from="(230,1110)" to="(230,1130)"/>
+    <wire from="(230,1910)" to="(230,1930)"/>
+    <wire from="(80,1910)" to="(190,1910)"/>
+    <wire from="(230,2230)" to="(230,2250)"/>
+    <wire from="(230,2550)" to="(230,2570)"/>
+    <wire from="(240,2560)" to="(240,2580)"/>
+    <wire from="(230,150)" to="(230,170)"/>
+    <wire from="(240,320)" to="(240,340)"/>
+    <wire from="(240,1760)" to="(240,1790)"/>
+    <wire from="(240,2400)" to="(240,2430)"/>
+    <wire from="(230,90)" to="(260,90)"/>
+    <wire from="(200,380)" to="(230,380)"/>
+    <wire from="(200,1180)" to="(230,1180)"/>
+    <wire from="(200,1660)" to="(230,1660)"/>
+    <wire from="(100,890)" to="(260,890)"/>
+    <wire from="(60,2600)" to="(60,2760)"/>
+    <wire from="(140,1350)" to="(230,1350)"/>
+    <wire from="(230,1530)" to="(260,1530)"/>
+    <wire from="(230,2650)" to="(260,2650)"/>
+    <wire from="(230,2810)" to="(260,2810)"/>
+    <wire from="(100,510)" to="(190,510)"/>
+    <wire from="(290,2070)" to="(320,2070)"/>
+    <wire from="(290,640)" to="(310,640)"/>
+    <wire from="(240,750)" to="(260,750)"/>
+    <wire from="(210,1840)" to="(230,1840)"/>
+    <wire from="(370,240)" to="(390,240)"/>
+    <wire from="(240,2240)" to="(240,2280)"/>
+    <wire from="(200,1030)" to="(220,1030)"/>
+    <wire from="(160,2430)" to="(180,2430)"/>
+    <wire from="(160,2910)" to="(180,2910)"/>
+    <wire from="(100,1000)" to="(180,1000)"/>
+    <wire from="(310,710)" to="(310,770)"/>
+    <wire from="(200,2080)" to="(260,2080)"/>
+    <wire from="(100,1810)" to="(100,1940)"/>
+    <wire from="(120,1030)" to="(120,1160)"/>
+    <wire from="(140,1050)" to="(140,1180)"/>
+    <wire from="(200,1440)" to="(260,1440)"/>
+    <wire from="(230,920)" to="(230,930)"/>
+    <wire from="(210,1940)" to="(260,1940)"/>
+    <wire from="(60,1760)" to="(240,1760)"/>
+    <wire from="(140,1870)" to="(190,1870)"/>
+    <wire from="(240,930)" to="(240,940)"/>
+    <wire from="(220,1710)" to="(220,1720)"/>
+    <wire from="(230,2040)" to="(230,2050)"/>
+    <wire from="(160,1070)" to="(160,1210)"/>
+    <wire from="(230,1720)" to="(230,1740)"/>
+    <wire from="(240,1730)" to="(240,1750)"/>
+    <wire from="(240,1090)" to="(240,1120)"/>
+    <wire from="(240,1890)" to="(240,1920)"/>
+    <wire from="(200,340)" to="(240,340)"/>
+    <wire from="(220,1320)" to="(260,1320)"/>
+    <wire from="(40,250)" to="(140,250)"/>
+    <wire from="(240,130)" to="(240,160)"/>
+    <wire from="(80,1410)" to="(180,1410)"/>
+    <wire from="(290,2670)" to="(330,2670)"/>
+    <wire from="(200,30)" to="(230,30)"/>
+    <wire from="(100,180)" to="(100,280)"/>
+    <wire from="(120,200)" to="(120,300)"/>
+    <wire from="(230,1820)" to="(260,1820)"/>
+    <wire from="(100,640)" to="(190,640)"/>
+    <wire from="(240,1040)" to="(260,1040)"/>
+    <wire from="(210,1970)" to="(230,1970)"/>
+    <wire from="(290,770)" to="(310,770)"/>
+    <wire from="(290,290)" to="(310,290)"/>
+    <wire from="(240,1520)" to="(260,1520)"/>
+    <wire from="(240,2640)" to="(260,2640)"/>
+    <wire from="(290,2530)" to="(310,2530)"/>
+    <wire from="(240,2800)" to="(260,2800)"/>
+    <wire from="(160,1600)" to="(180,1600)"/>
+    <wire from="(100,1940)" to="(100,2060)"/>
+    <wire from="(160,2000)" to="(160,2120)"/>
+    <wire from="(60,460)" to="(60,590)"/>
+    <wire from="(80,480)" to="(80,610)"/>
+    <wire from="(120,1330)" to="(180,1330)"/>
+    <wire from="(230,90)" to="(230,100)"/>
+    <wire from="(60,2460)" to="(180,2460)"/>
+    <wire from="(60,130)" to="(240,130)"/>
+    <wire from="(60,1090)" to="(240,1090)"/>
+    <wire from="(60,1890)" to="(240,1890)"/>
+    <wire from="(100,1300)" to="(100,1440)"/>
+    <wire from="(240,2020)" to="(240,2040)"/>
+    <wire from="(230,2490)" to="(230,2510)"/>
+    <wire from="(240,100)" to="(240,120)"/>
+    <wire from="(80,260)" to="(180,260)"/>
+    <wire from="(80,2180)" to="(180,2180)"/>
+    <wire from="(80,2340)" to="(180,2340)"/>
+    <wire from="(230,990)" to="(260,990)"/>
+    <wire from="(100,1140)" to="(100,1300)"/>
+    <wire from="(140,570)" to="(140,800)"/>
+    <wire from="(140,2570)" to="(230,2570)"/>
+    <wire from="(290,410)" to="(320,410)"/>
+    <wire from="(230,1950)" to="(260,1950)"/>
+    <wire from="(200,2400)" to="(230,2400)"/>
+    <wire from="(200,2880)" to="(230,2880)"/>
+    <wire from="(100,770)" to="(190,770)"/>
+    <wire from="(210,1780)" to="(230,1780)"/>
+    <wire from="(120,1160)" to="(120,1330)"/>
+    <wire from="(140,1180)" to="(140,1350)"/>
+    <wire from="(320,1890)" to="(340,1890)"/>
+    <wire from="(310,2680)" to="(330,2680)"/>
+    <wire from="(140,1470)" to="(140,1580)"/>
+    <wire from="(240,530)" to="(260,530)"/>
+    <wire from="(60,1390)" to="(60,1500)"/>
+    <wire from="(80,1410)" to="(80,1520)"/>
+    <wire from="(320,720)" to="(320,900)"/>
+    <wire from="(200,2660)" to="(260,2660)"/>
+    <wire from="(200,2820)" to="(260,2820)"/>
+    <wire from="(60,590)" to="(60,720)"/>
+    <wire from="(80,610)" to="(80,740)"/>
+    <wire from="(200,420)" to="(260,420)"/>
+    <wire from="(310,1320)" to="(310,1450)"/>
+    <wire from="(230,380)" to="(230,390)"/>
+    <wire from="(60,1630)" to="(180,1630)"/>
+    <wire from="(140,1970)" to="(190,1970)"/>
+    <wire from="(60,2020)" to="(240,2020)"/>
+    <wire from="(230,1660)" to="(230,1680)"/>
+    <wire from="(230,1820)" to="(230,1840)"/>
+    <wire from="(140,1180)" to="(180,1180)"/>
+    <wire from="(240,2150)" to="(240,2180)"/>
+    <wire from="(240,2310)" to="(240,2340)"/>
+    <wire from="(200,1240)" to="(240,1240)"/>
+    <wire from="(220,2540)" to="(260,2540)"/>
+    <wire from="(160,310)" to="(160,340)"/>
+    <wire from="(80,870)" to="(180,870)"/>
+    <wire from="(80,2630)" to="(180,2630)"/>
+    <wire from="(80,2790)" to="(180,2790)"/>
+    <wire from="(200,1410)" to="(230,1410)"/>
+    <wire from="(140,1580)" to="(230,1580)"/>
+    <wire from="(140,1740)" to="(230,1740)"/>
+    <wire from="(320,260)" to="(340,260)"/>
+    <wire from="(240,980)" to="(260,980)"/>
+    <wire from="(210,1910)" to="(230,1910)"/>
+    <wire from="(240,2100)" to="(260,2100)"/>
+    <wire from="(240,1830)" to="(240,1870)"/>
+    <wire from="(160,340)" to="(160,450)"/>
+    <wire from="(240,660)" to="(260,660)"/>
+    <wire from="(120,200)" to="(260,200)"/>
+    <wire from="(120,1160)" to="(260,1160)"/>
+    <wire from="(60,240)" to="(60,360)"/>
+    <wire from="(80,260)" to="(80,380)"/>
+    <wire from="(100,280)" to="(100,400)"/>
+    <wire from="(120,300)" to="(120,420)"/>
+    <wire from="(140,320)" to="(140,440)"/>
+    <wire from="(140,800)" to="(140,930)"/>
+    <wire from="(60,720)" to="(60,850)"/>
+    <wire from="(80,740)" to="(80,870)"/>
+    <wire from="(120,2550)" to="(180,2550)"/>
+    <wire from="(100,2520)" to="(100,2660)"/>
+    <wire from="(230,1950)" to="(230,1970)"/>
+    <wire from="(80,2340)" to="(80,2490)"/>
+    <wire from="(160,2580)" to="(160,2730)"/>
+    <wire from="(230,30)" to="(230,50)"/>
+    <wire from="(240,360)" to="(240,380)"/>
+    <wire from="(320,1330)" to="(320,1550)"/>
+    <wire from="(200,1210)" to="(240,1210)"/>
+    <wire from="(200,1370)" to="(240,1370)"/>
+    <wire from="(220,1710)" to="(260,1710)"/>
+    <wire from="(160,700)" to="(190,700)"/>
+    <wire from="(200,100)" to="(230,100)"/>
+    <wire from="(200,260)" to="(230,260)"/>
+    <wire from="(80,2180)" to="(80,2340)"/>
+    <wire from="(100,2200)" to="(100,2360)"/>
+    <wire from="(100,2360)" to="(100,2520)"/>
+    <wire from="(120,2220)" to="(120,2380)"/>
+    <wire from="(60,850)" to="(60,950)"/>
+    <wire from="(80,870)" to="(80,970)"/>
+    <wire from="(230,1570)" to="(260,1570)"/>
+    <wire from="(290,510)" to="(320,510)"/>
+    <wire from="(210,1870)" to="(240,1870)"/>
+    <wire from="(230,2050)" to="(260,2050)"/>
+    <wire from="(200,2180)" to="(230,2180)"/>
+    <wire from="(200,2340)" to="(230,2340)"/>
+    <wire from="(230,2690)" to="(260,2690)"/>
+    <wire from="(230,2850)" to="(260,2850)"/>
+    <wire from="(310,690)" to="(340,690)"/>
+    <wire from="(240,790)" to="(260,790)"/>
+    <wire from="(120,2380)" to="(120,2550)"/>
+    <wire from="(140,2400)" to="(140,2570)"/>
+    <wire from="(240,1960)" to="(240,2000)"/>
+    <wire from="(240,2600)" to="(240,2640)"/>
+    <wire from="(240,2760)" to="(240,2800)"/>
+    <wire from="(100,890)" to="(100,1000)"/>
+    <wire from="(160,940)" to="(240,940)"/>
+    <wire from="(100,1690)" to="(100,1810)"/>
+    <wire from="(120,910)" to="(120,1030)"/>
+    <wire from="(140,930)" to="(140,1050)"/>
+    <wire from="(120,1560)" to="(180,1560)"/>
+    <wire from="(120,1720)" to="(180,1720)"/>
+    <wire from="(200,1000)" to="(260,1000)"/>
+    <wire from="(140,210)" to="(260,210)"/>
+    <wire from="(60,360)" to="(240,360)"/>
+    <wire from="(100,60)" to="(100,140)"/>
+    <wire from="(80,480)" to="(190,480)"/>
+    <wire from="(230,480)" to="(230,500)"/>
+    <wire from="(140,2400)" to="(180,2400)"/>
+    <wire from="(140,2880)" to="(180,2880)"/>
+    <wire from="(200,2460)" to="(240,2460)"/>
+    <wire from="(240,10)" to="(240,40)"/>
+    <wire from="(320,1010)" to="(320,1290)"/>
+    <wire from="(80,970)" to="(180,970)"/>
+    <wire from="(160,830)" to="(190,830)"/>
+    <wire from="(200,870)" to="(230,870)"/>
+    <wire from="(100,1540)" to="(260,1540)"/>
+    <wire from="(80,2630)" to="(80,2790)"/>
+    <wire from="(210,2000)" to="(240,2000)"/>
+    <wire from="(200,2630)" to="(230,2630)"/>
+    <wire from="(200,2790)" to="(230,2790)"/>
+    <wire from="(160,120)" to="(160,220)"/>
+    <wire from="(310,1300)" to="(340,1300)"/>
+    <wire from="(240,2040)" to="(260,2040)"/>
+    <wire from="(320,680)" to="(340,680)"/>
+    <wire from="(290,1450)" to="(310,1450)"/>
+    <wire from="(140,100)" to="(140,210)"/>
+    <wire from="(240,440)" to="(260,440)"/>
+    <wire from="(160,2120)" to="(180,2120)"/>
+    <wire from="(160,2280)" to="(180,2280)"/>
+    <wire from="(120,80)" to="(120,190)"/>
+    <wire from="(120,2380)" to="(260,2380)"/>
+    <wire from="(120,1840)" to="(190,1840)"/>
+    <wire from="(60,10)" to="(240,10)"/>
+    <wire from="(210,510)" to="(260,510)"/>
+    <wire from="(230,1570)" to="(230,1580)"/>
+    <wire from="(220,2680)" to="(220,2690)"/>
+    <wire from="(220,2840)" to="(220,2850)"/>
+    <wire from="(230,1410)" to="(230,1430)"/>
+    <wire from="(240,1580)" to="(240,1600)"/>
+    <wire from="(230,2690)" to="(230,2710)"/>
+    <wire from="(80,610)" to="(190,610)"/>
+    <wire from="(230,610)" to="(230,630)"/>
+    <wire from="(240,2700)" to="(240,2730)"/>
+    <wire from="(230,2850)" to="(230,2880)"/>
+    <wire from="(200,1630)" to="(240,1630)"/>
+    <wire from="(200,2430)" to="(240,2430)"/>
+    <wire from="(200,2910)" to="(240,2910)"/>
+    <wire from="(240,460)" to="(240,490)"/>
+    <wire from="(160,220)" to="(260,220)"/>
+    <wire from="(230,390)" to="(260,390)"/>
+    <wire from="(230,1030)" to="(260,1030)"/>
+    <wire from="(370,700)" to="(390,700)"/>
+    <wire from="(320,1290)" to="(340,1290)"/>
+    <wire from="(160,1370)" to="(160,1480)"/>
+    <wire from="(210,540)" to="(230,540)"/>
+    <wire from="(200,1330)" to="(220,1330)"/>
+    <wire from="(160,2730)" to="(180,2730)"/>
+    <wire from="(100,180)" to="(180,180)"/>
+    <wire from="(100,1140)" to="(180,1140)"/>
+    <wire from="(100,1300)" to="(180,1300)"/>
+    <wire from="(310,1810)" to="(310,1860)"/>
+    <wire from="(240,2860)" to="(240,2910)"/>
+    <wire from="(160,1750)" to="(160,2000)"/>
+    <wire from="(140,1350)" to="(140,1470)"/>
+    <wire from="(200,2220)" to="(260,2220)"/>
+    <wire from="(120,1330)" to="(120,1460)"/>
+    <wire from="(100,510)" to="(100,640)"/>
+    <wire from="(40,140)" to="(100,140)"/>
+    <wire from="(200,300)" to="(260,300)"/>
+    <wire from="(230,260)" to="(230,270)"/>
+    <wire from="(60,2150)" to="(180,2150)"/>
+    <wire from="(60,2310)" to="(180,2310)"/>
+    <wire from="(140,570)" to="(190,570)"/>
+    <wire from="(60,460)" to="(240,460)"/>
+    <wire from="(210,640)" to="(260,640)"/>
+    <wire from="(60,950)" to="(60,1090)"/>
+    <wire from="(80,970)" to="(80,1110)"/>
+    <wire from="(230,2180)" to="(230,2190)"/>
+    <wire from="(230,2340)" to="(230,2350)"/>
+    <wire from="(80,740)" to="(190,740)"/>
+    <wire from="(230,740)" to="(230,760)"/>
+    <wire from="(160,220)" to="(160,310)"/>
+    <wire from="(140,100)" to="(180,100)"/>
+    <wire from="(240,1390)" to="(240,1420)"/>
+    <wire from="(200,1600)" to="(240,1600)"/>
+    <wire from="(240,590)" to="(240,620)"/>
+    <wire from="(230,520)" to="(260,520)"/>
+    <wire from="(200,970)" to="(230,970)"/>
+    <wire from="(160,1210)" to="(160,1370)"/>
+    <wire from="(140,2100)" to="(230,2100)"/>
+    <wire from="(290,900)" to="(320,900)"/>
+    <wire from="(230,1800)" to="(260,1800)"/>
+    <wire from="(200,2250)" to="(230,2250)"/>
+    <wire from="(100,1440)" to="(100,1540)"/>
+    <wire from="(120,1460)" to="(120,1560)"/>
+    <wire from="(290,1700)" to="(320,1700)"/>
+    <wire from="(310,1880)" to="(340,1880)"/>
+    <wire from="(240,1180)" to="(260,1180)"/>
+    <wire from="(240,1340)" to="(260,1340)"/>
+    <wire from="(290,2830)" to="(310,2830)"/>
+    <wire from="(370,1310)" to="(390,1310)"/>
+    <wire from="(240,380)" to="(260,380)"/>
+    <wire from="(210,670)" to="(230,670)"/>
+    <wire from="(120,1840)" to="(120,2080)"/>
+    <wire from="(120,80)" to="(260,80)"/>
+    <comp lib="1" loc="(290,1150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(390,700)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALU1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(210,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,2670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(370,1310)" name="OR Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(200,1600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,640)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(390,2210)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJR"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(210,610)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,250)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1070)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,1940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1700)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(390,1870)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALU3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,2430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2730)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,30)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,60)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,190)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(370,700)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="1" loc="(210,2000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,970)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,1910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2080)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,2370)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,2070)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(210,1970)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,70)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1940)" name="AND Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(200,1560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(370,240)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="1" loc="(210,670)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(210,830)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(210,480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,2210)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(390,1310)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALU2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(210,700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(370,1870)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="1" loc="(200,1030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,190)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(360,2670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="1" loc="(200,2460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1010)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,510)" name="AND Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="0" loc="(390,2670)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(390,2370)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscall"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,1810)" name="AND Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(200,420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,770)" name="AND Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(290,640)" name="AND Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(290,2530)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(390,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALU0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+  </circuit>
+  <circuit name="ALU_Decoder">
+    <a name="circuit" val="ALU_Decoder"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <rect fill="none" height="66" stroke="#000000" stroke-width="2" width="60" x="50" y="55"/>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="88">ALU</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="104">Decoder</text>
+      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
+      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
+      <circ-port height="8" pin="40,130" width="8" x="46" y="76"/>
+      <circ-port height="10" pin="430,140" width="10" x="105" y="65"/>
+      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
+      <circ-port height="8" pin="40,240" width="8" x="46" y="96"/>
+      <circ-port height="8" pin="40,300" width="8" x="46" y="106"/>
+      <circ-port height="10" pin="430,1130" width="10" x="105" y="75"/>
+      <circ-port height="10" pin="430,2190" width="10" x="105" y="85"/>
+      <circ-port height="10" pin="430,3270" width="10" x="105" y="95"/>
+      <circ-anchor facing="east" height="6" width="6" x="97" y="67"/>
+    </appear>
+    <wire from="(310,1140)" to="(310,1210)"/>
+    <wire from="(200,910)" to="(260,910)"/>
+    <wire from="(120,3710)" to="(180,3710)"/>
+    <wire from="(230,230)" to="(230,240)"/>
+    <wire from="(60,3960)" to="(60,4100)"/>
+    <wire from="(240,2800)" to="(240,2820)"/>
+    <wire from="(240,240)" to="(240,260)"/>
+    <wire from="(230,550)" to="(230,570)"/>
+    <wire from="(200,290)" to="(240,290)"/>
+    <wire from="(200,1570)" to="(240,1570)"/>
+    <wire from="(140,2150)" to="(180,2150)"/>
+    <wire from="(140,2470)" to="(180,2470)"/>
+    <wire from="(200,2210)" to="(240,2210)"/>
+    <wire from="(200,2530)" to="(240,2530)"/>
+    <wire from="(80,880)" to="(180,880)"/>
+    <wire from="(340,3310)" to="(380,3310)"/>
+    <wire from="(60,3640)" to="(60,3800)"/>
+    <wire from="(230,1930)" to="(260,1930)"/>
+    <wire from="(230,2250)" to="(260,2250)"/>
+    <wire from="(230,2570)" to="(260,2570)"/>
+    <wire from="(230,3850)" to="(260,3850)"/>
+    <wire from="(230,4170)" to="(260,4170)"/>
+    <wire from="(290,80)" to="(310,80)"/>
+    <wire from="(80,1920)" to="(230,1920)"/>
+    <wire from="(160,3470)" to="(180,3470)"/>
+    <wire from="(240,560)" to="(240,600)"/>
+    <wire from="(80,2380)" to="(80,2560)"/>
+    <wire from="(310,1140)" to="(380,1140)"/>
+    <wire from="(60,3210)" to="(180,3210)"/>
+    <wire from="(290,2740)" to="(340,2740)"/>
+    <wire from="(230,3240)" to="(230,3250)"/>
+    <wire from="(200,2660)" to="(240,2660)"/>
+    <wire from="(140,4200)" to="(180,4200)"/>
+    <wire from="(80,50)" to="(180,50)"/>
+    <wire from="(80,1330)" to="(180,1330)"/>
+    <wire from="(200,110)" to="(230,110)"/>
+    <wire from="(100,780)" to="(260,780)"/>
+    <wire from="(80,80)" to="(80,180)"/>
+    <wire from="(290,210)" to="(310,210)"/>
+    <wire from="(240,4000)" to="(260,4000)"/>
+    <wire from="(160,2320)" to="(180,2320)"/>
+    <wire from="(100,1050)" to="(180,1050)"/>
+    <wire from="(100,2970)" to="(180,2970)"/>
+    <wire from="(160,3030)" to="(240,3030)"/>
+    <wire from="(230,810)" to="(230,820)"/>
+    <wire from="(60,2060)" to="(180,2060)"/>
+    <wire from="(240,820)" to="(240,830)"/>
+    <wire from="(230,2090)" to="(230,2100)"/>
+    <wire from="(160,1120)" to="(160,1270)"/>
+    <wire from="(320,1150)" to="(320,1360)"/>
+    <wire from="(80,180)" to="(180,180)"/>
+    <wire from="(80,500)" to="(180,500)"/>
+    <wire from="(200,880)" to="(230,880)"/>
+    <wire from="(350,530)" to="(350,1080)"/>
+    <wire from="(140,3450)" to="(230,3450)"/>
+    <wire from="(230,1230)" to="(260,1230)"/>
+    <wire from="(230,2830)" to="(260,2830)"/>
+    <wire from="(200,1850)" to="(220,1850)"/>
+    <wire from="(100,1820)" to="(180,1820)"/>
+    <wire from="(160,1880)" to="(240,1880)"/>
+    <wire from="(120,1850)" to="(120,1970)"/>
+    <wire from="(200,1940)" to="(260,1940)"/>
+    <wire from="(200,3860)" to="(260,3860)"/>
+    <wire from="(140,1870)" to="(140,2000)"/>
+    <wire from="(230,940)" to="(230,950)"/>
+    <wire from="(240,950)" to="(240,970)"/>
+    <wire from="(100,3110)" to="(100,3260)"/>
+    <wire from="(120,3130)" to="(120,3280)"/>
+    <wire from="(140,3150)" to="(140,3300)"/>
+    <wire from="(60,1150)" to="(60,1300)"/>
+    <wire from="(80,3830)" to="(180,3830)"/>
+    <wire from="(120,190)" to="(120,220)"/>
+    <wire from="(200,50)" to="(230,50)"/>
+    <wire from="(200,1330)" to="(230,1330)"/>
+    <wire from="(160,1570)" to="(160,1730)"/>
+    <wire from="(140,2300)" to="(230,2300)"/>
+    <wire from="(230,1040)" to="(260,1040)"/>
+    <wire from="(230,2960)" to="(260,2960)"/>
+    <wire from="(120,700)" to="(120,800)"/>
+    <wire from="(140,720)" to="(140,820)"/>
+    <wire from="(240,1700)" to="(260,1700)"/>
+    <wire from="(240,3300)" to="(260,3300)"/>
+    <wire from="(200,380)" to="(220,380)"/>
+    <wire from="(200,700)" to="(220,700)"/>
+    <wire from="(100,350)" to="(180,350)"/>
+    <wire from="(100,670)" to="(180,670)"/>
+    <wire from="(160,730)" to="(240,730)"/>
+    <wire from="(160,2660)" to="(160,2790)"/>
+    <wire from="(140,3600)" to="(140,3740)"/>
+    <wire from="(330,1160)" to="(330,1500)"/>
+    <wire from="(160,3620)" to="(160,3770)"/>
+    <wire from="(140,2000)" to="(140,2150)"/>
+    <wire from="(140,110)" to="(180,110)"/>
+    <wire from="(240,2680)" to="(240,2710)"/>
+    <wire from="(240,3640)" to="(240,3670)"/>
+    <wire from="(220,2430)" to="(260,2430)"/>
+    <wire from="(220,2750)" to="(260,2750)"/>
+    <wire from="(200,3050)" to="(240,3050)"/>
+    <wire from="(80,760)" to="(180,760)"/>
+    <wire from="(200,180)" to="(230,180)"/>
+    <wire from="(200,500)" to="(230,500)"/>
+    <wire from="(60,1600)" to="(60,1760)"/>
+    <wire from="(100,1490)" to="(260,1490)"/>
+    <wire from="(120,380)" to="(120,540)"/>
+    <wire from="(100,3410)" to="(260,3410)"/>
+    <wire from="(230,1810)" to="(260,1810)"/>
+    <wire from="(230,4050)" to="(260,4050)"/>
+    <wire from="(160,2790)" to="(160,2890)"/>
+    <wire from="(240,2150)" to="(260,2150)"/>
+    <wire from="(40,30)" to="(60,30)"/>
+    <wire from="(100,2730)" to="(100,2840)"/>
+    <wire from="(240,3960)" to="(240,4000)"/>
+    <wire from="(120,3130)" to="(260,3130)"/>
+    <wire from="(310,3260)" to="(380,3260)"/>
+    <wire from="(290,360)" to="(360,360)"/>
+    <wire from="(80,3990)" to="(80,4120)"/>
+    <wire from="(120,2440)" to="(180,2440)"/>
+    <wire from="(120,2760)" to="(180,2760)"/>
+    <wire from="(330,3300)" to="(380,3300)"/>
+    <wire from="(60,850)" to="(180,850)"/>
+    <wire from="(230,3440)" to="(230,3450)"/>
+    <wire from="(230,1520)" to="(230,1540)"/>
+    <wire from="(240,3450)" to="(240,3470)"/>
+    <wire from="(230,880)" to="(230,900)"/>
+    <wire from="(200,1900)" to="(240,1900)"/>
+    <wire from="(200,3180)" to="(240,3180)"/>
+    <wire from="(200,3500)" to="(240,3500)"/>
+    <wire from="(220,4160)" to="(260,4160)"/>
+    <wire from="(230,340)" to="(260,340)"/>
+    <wire from="(200,950)" to="(230,950)"/>
+    <wire from="(230,660)" to="(260,660)"/>
+    <wire from="(100,2260)" to="(260,2260)"/>
+    <wire from="(100,2580)" to="(260,2580)"/>
+    <wire from="(80,3670)" to="(80,3830)"/>
+    <wire from="(140,2880)" to="(230,2880)"/>
+    <wire from="(200,3830)" to="(230,3830)"/>
+    <wire from="(290,1360)" to="(320,1360)"/>
+    <wire from="(230,3540)" to="(260,3540)"/>
+    <wire from="(240,1640)" to="(260,1640)"/>
+    <wire from="(100,2410)" to="(100,2580)"/>
+    <wire from="(240,3240)" to="(260,3240)"/>
+    <wire from="(100,3690)" to="(100,3860)"/>
+    <wire from="(240,1530)" to="(240,1570)"/>
+    <wire from="(160,600)" to="(180,600)"/>
+    <wire from="(120,3710)" to="(120,3890)"/>
+    <wire from="(200,2970)" to="(260,2970)"/>
+    <wire from="(200,1050)" to="(260,1050)"/>
+    <wire from="(200,1370)" to="(260,1370)"/>
+    <wire from="(120,4170)" to="(180,4170)"/>
+    <wire from="(60,20)" to="(180,20)"/>
+    <wire from="(230,50)" to="(230,60)"/>
+    <wire from="(60,1300)" to="(180,1300)"/>
+    <wire from="(230,1330)" to="(230,1340)"/>
+    <wire from="(220,1960)" to="(220,1970)"/>
+    <wire from="(230,2290)" to="(230,2300)"/>
+    <wire from="(220,3880)" to="(220,3890)"/>
+    <wire from="(240,2300)" to="(240,2320)"/>
+    <wire from="(230,2610)" to="(230,2630)"/>
+    <wire from="(230,3890)" to="(230,3910)"/>
+    <wire from="(230,1970)" to="(230,2000)"/>
+    <wire from="(240,3900)" to="(240,3930)"/>
+    <wire from="(200,2030)" to="(240,2030)"/>
+    <wire from="(200,2350)" to="(240,2350)"/>
+    <wire from="(80,1020)" to="(180,1020)"/>
+    <wire from="(80,2940)" to="(180,2940)"/>
+    <wire from="(200,760)" to="(230,760)"/>
+    <wire from="(200,1400)" to="(230,1400)"/>
+    <wire from="(240,2090)" to="(260,2090)"/>
+    <wire from="(160,3930)" to="(180,3930)"/>
+    <wire from="(290,3420)" to="(310,3420)"/>
+    <wire from="(240,2620)" to="(240,2660)"/>
+    <wire from="(340,1170)" to="(340,1670)"/>
+    <wire from="(240,1980)" to="(240,2030)"/>
+    <wire from="(200,220)" to="(260,220)"/>
+    <wire from="(200,540)" to="(260,540)"/>
+    <wire from="(200,1820)" to="(260,1820)"/>
+    <wire from="(330,3240)" to="(380,3240)"/>
+    <wire from="(60,150)" to="(180,150)"/>
+    <wire from="(230,180)" to="(230,190)"/>
+    <wire from="(60,470)" to="(180,470)"/>
+    <wire from="(230,500)" to="(230,510)"/>
+    <wire from="(40,80)" to="(80,80)"/>
+    <wire from="(240,1150)" to="(240,1180)"/>
+    <wire from="(80,1470)" to="(180,1470)"/>
+    <wire from="(80,1790)" to="(180,1790)"/>
+    <wire from="(80,3390)" to="(180,3390)"/>
+    <wire from="(200,570)" to="(230,570)"/>
+    <wire from="(100,2840)" to="(260,2840)"/>
+    <wire from="(290,2270)" to="(310,2270)"/>
+    <wire from="(100,3110)" to="(180,3110)"/>
+    <wire from="(320,1110)" to="(380,1110)"/>
+    <wire from="(200,350)" to="(260,350)"/>
+    <wire from="(200,670)" to="(260,670)"/>
+    <wire from="(60,3800)" to="(180,3800)"/>
+    <wire from="(230,2870)" to="(230,2880)"/>
+    <wire from="(160,300)" to="(160,440)"/>
+    <wire from="(240,2880)" to="(240,2890)"/>
+    <wire from="(230,3830)" to="(230,3850)"/>
+    <wire from="(100,1200)" to="(100,1350)"/>
+    <wire from="(120,1220)" to="(120,1370)"/>
+    <wire from="(160,3180)" to="(160,3330)"/>
+    <wire from="(80,1180)" to="(80,1330)"/>
+    <wire from="(140,950)" to="(180,950)"/>
+    <wire from="(80,320)" to="(180,320)"/>
+    <wire from="(80,640)" to="(180,640)"/>
+    <wire from="(80,2240)" to="(180,2240)"/>
+    <wire from="(80,2560)" to="(180,2560)"/>
+    <wire from="(200,1020)" to="(230,1020)"/>
+    <wire from="(140,3910)" to="(230,3910)"/>
+    <wire from="(140,1240)" to="(140,1400)"/>
+    <wire from="(230,1690)" to="(260,1690)"/>
+    <wire from="(200,2940)" to="(230,2940)"/>
+    <wire from="(230,3290)" to="(260,3290)"/>
+    <wire from="(240,1390)" to="(260,1390)"/>
+    <wire from="(360,1190)" to="(380,1190)"/>
+    <wire from="(240,1600)" to="(240,1640)"/>
+    <wire from="(240,110)" to="(260,110)"/>
+    <wire from="(160,3620)" to="(240,3620)"/>
+    <wire from="(200,800)" to="(260,800)"/>
+    <wire from="(230,760)" to="(230,770)"/>
+    <wire from="(230,1080)" to="(230,1090)"/>
+    <wire from="(230,3000)" to="(230,3010)"/>
+    <wire from="(350,1180)" to="(350,1830)"/>
+    <wire from="(240,3010)" to="(240,3030)"/>
+    <wire from="(60,3210)" to="(60,3360)"/>
+    <wire from="(160,2030)" to="(160,2180)"/>
+    <wire from="(240,1090)" to="(240,1120)"/>
+    <wire from="(140,1400)" to="(180,1400)"/>
+    <wire from="(220,4040)" to="(260,4040)"/>
+    <wire from="(200,1470)" to="(230,1470)"/>
+    <wire from="(200,1790)" to="(230,1790)"/>
+    <wire from="(80,1630)" to="(80,1790)"/>
+    <wire from="(140,410)" to="(140,570)"/>
+    <wire from="(350,3220)" to="(380,3220)"/>
+    <wire from="(290,920)" to="(320,920)"/>
+    <wire from="(230,2140)" to="(260,2140)"/>
+    <wire from="(200,3390)" to="(230,3390)"/>
+    <wire from="(230,3100)" to="(260,3100)"/>
+    <wire from="(120,2760)" to="(120,2860)"/>
+    <wire from="(140,2780)" to="(140,2880)"/>
+    <wire from="(200,2440)" to="(220,2440)"/>
+    <wire from="(200,2760)" to="(220,2760)"/>
+    <wire from="(160,1120)" to="(180,1120)"/>
+    <wire from="(240,240)" to="(260,240)"/>
+    <wire from="(240,560)" to="(260,560)"/>
+    <wire from="(350,2590)" to="(350,3220)"/>
+    <wire from="(100,2410)" to="(180,2410)"/>
+    <wire from="(100,2730)" to="(180,2730)"/>
+    <wire from="(160,2790)" to="(240,2790)"/>
+    <wire from="(120,1220)" to="(260,1220)"/>
+    <wire from="(310,2120)" to="(310,2180)"/>
+    <wire from="(100,4020)" to="(100,4140)"/>
+    <wire from="(320,3290)" to="(380,3290)"/>
+    <wire from="(40,130)" to="(100,130)"/>
+    <wire from="(120,4050)" to="(180,4050)"/>
+    <wire from="(290,1670)" to="(340,1670)"/>
+    <wire from="(220,1840)" to="(220,1850)"/>
+    <wire from="(230,1850)" to="(230,1870)"/>
+    <wire from="(240,1860)" to="(240,1880)"/>
+    <wire from="(240,4100)" to="(240,4120)"/>
+    <wire from="(160,4080)" to="(160,4230)"/>
+    <wire from="(60,2060)" to="(60,2210)"/>
+    <wire from="(140,570)" to="(180,570)"/>
+    <wire from="(200,1270)" to="(240,1270)"/>
+    <wire from="(340,1090)" to="(380,1090)"/>
+    <wire from="(80,2820)" to="(180,2820)"/>
+    <wire from="(200,320)" to="(230,320)"/>
+    <wire from="(200,640)" to="(230,640)"/>
+    <wire from="(100,3550)" to="(260,3550)"/>
+    <wire from="(120,2440)" to="(120,2600)"/>
+    <wire from="(200,2240)" to="(230,2240)"/>
+    <wire from="(200,2560)" to="(230,2560)"/>
+    <wire from="(290,1060)" to="(310,1060)"/>
+    <wire from="(240,1330)" to="(260,1330)"/>
+    <wire from="(200,4170)" to="(220,4170)"/>
+    <wire from="(140,3740)" to="(140,3910)"/>
+    <wire from="(240,50)" to="(260,50)"/>
+    <wire from="(160,1570)" to="(180,1570)"/>
+    <wire from="(330,790)" to="(330,1100)"/>
+    <wire from="(100,4140)" to="(180,4140)"/>
+    <wire from="(360,1190)" to="(360,1950)"/>
+    <wire from="(290,2420)" to="(360,2420)"/>
+    <wire from="(290,4030)" to="(350,4030)"/>
+    <wire from="(360,360)" to="(360,1070)"/>
+    <wire from="(220,370)" to="(220,380)"/>
+    <wire from="(220,690)" to="(220,700)"/>
+    <wire from="(60,990)" to="(180,990)"/>
+    <wire from="(60,2910)" to="(180,2910)"/>
+    <wire from="(60,740)" to="(240,740)"/>
+    <wire from="(230,2940)" to="(230,2960)"/>
+    <wire from="(230,3580)" to="(230,3600)"/>
+    <wire from="(230,700)" to="(230,720)"/>
+    <wire from="(240,710)" to="(240,730)"/>
+    <wire from="(230,1020)" to="(230,1040)"/>
+    <wire from="(200,440)" to="(240,440)"/>
+    <wire from="(240,3590)" to="(240,3620)"/>
+    <wire from="(200,3640)" to="(240,3640)"/>
+    <wire from="(200,3960)" to="(240,3960)"/>
+    <wire from="(230,380)" to="(230,410)"/>
+    <wire from="(200,1090)" to="(230,1090)"/>
+    <wire from="(230,2400)" to="(260,2400)"/>
+    <wire from="(230,2720)" to="(260,2720)"/>
+    <wire from="(200,3010)" to="(230,3010)"/>
+    <wire from="(230,3680)" to="(260,3680)"/>
+    <wire from="(240,820)" to="(260,820)"/>
+    <wire from="(240,180)" to="(260,180)"/>
+    <wire from="(240,500)" to="(260,500)"/>
+    <wire from="(160,2660)" to="(180,2660)"/>
+    <wire from="(240,390)" to="(240,440)"/>
+    <wire from="(290,4150)" to="(360,4150)"/>
+    <wire from="(200,3110)" to="(260,3110)"/>
+    <wire from="(200,3430)" to="(260,3430)"/>
+    <wire from="(200,1510)" to="(260,1510)"/>
+    <wire from="(60,1440)" to="(180,1440)"/>
+    <wire from="(60,1760)" to="(180,1760)"/>
+    <wire from="(60,3360)" to="(180,3360)"/>
+    <wire from="(60,20)" to="(60,30)"/>
+    <wire from="(230,1470)" to="(230,1480)"/>
+    <wire from="(230,3390)" to="(230,3400)"/>
+    <wire from="(230,1790)" to="(230,1810)"/>
+    <wire from="(200,3770)" to="(240,3770)"/>
+    <wire from="(80,3080)" to="(180,3080)"/>
+    <wire from="(200,1540)" to="(230,1540)"/>
+    <wire from="(140,1870)" to="(230,1870)"/>
+    <wire from="(200,2820)" to="(230,2820)"/>
+    <wire from="(230,4130)" to="(260,4130)"/>
+    <wire from="(240,950)" to="(260,950)"/>
+    <wire from="(360,1070)" to="(380,1070)"/>
+    <wire from="(80,4120)" to="(230,4120)"/>
+    <wire from="(200,2280)" to="(260,2280)"/>
+    <wire from="(200,2600)" to="(260,2600)"/>
+    <wire from="(60,290)" to="(180,290)"/>
+    <wire from="(60,2210)" to="(180,2210)"/>
+    <wire from="(60,2530)" to="(180,2530)"/>
+    <wire from="(60,850)" to="(60,990)"/>
+    <wire from="(230,1920)" to="(230,1930)"/>
+    <wire from="(230,2240)" to="(230,2250)"/>
+    <wire from="(230,2560)" to="(230,2570)"/>
+    <wire from="(160,1270)" to="(160,1420)"/>
+    <wire from="(230,320)" to="(230,340)"/>
+    <wire from="(230,640)" to="(230,660)"/>
+    <wire from="(240,3210)" to="(240,3240)"/>
+    <wire from="(290,790)" to="(330,790)"/>
+    <wire from="(220,1680)" to="(260,1680)"/>
+    <wire from="(80,3530)" to="(180,3530)"/>
+    <wire from="(230,100)" to="(260,100)"/>
+    <wire from="(140,720)" to="(230,720)"/>
+    <wire from="(230,1380)" to="(260,1380)"/>
+    <wire from="(200,2630)" to="(230,2630)"/>
+    <wire from="(350,1180)" to="(380,1180)"/>
+    <wire from="(240,760)" to="(260,760)"/>
+    <wire from="(310,80)" to="(310,130)"/>
+    <wire from="(200,2410)" to="(260,2410)"/>
+    <wire from="(200,2730)" to="(260,2730)"/>
+    <wire from="(120,1370)" to="(180,1370)"/>
+    <wire from="(120,1690)" to="(180,1690)"/>
+    <wire from="(60,1300)" to="(60,1440)"/>
+    <wire from="(80,3240)" to="(80,3390)"/>
+    <wire from="(100,3260)" to="(100,3410)"/>
+    <wire from="(120,3280)" to="(120,3430)"/>
+    <wire from="(140,3300)" to="(140,3450)"/>
+    <wire from="(140,1090)" to="(180,1090)"/>
+    <wire from="(240,2060)" to="(240,2090)"/>
+    <wire from="(200,1150)" to="(240,1150)"/>
+    <wire from="(140,3010)" to="(180,3010)"/>
+    <wire from="(80,2380)" to="(180,2380)"/>
+    <wire from="(80,2700)" to="(180,2700)"/>
+    <wire from="(230,230)" to="(260,230)"/>
+    <wire from="(230,550)" to="(260,550)"/>
+    <wire from="(100,1660)" to="(100,1820)"/>
+    <wire from="(160,440)" to="(160,600)"/>
+    <wire from="(230,1190)" to="(260,1190)"/>
+    <wire from="(200,3080)" to="(230,3080)"/>
+    <wire from="(240,890)" to="(260,890)"/>
+    <wire from="(240,1530)" to="(260,1530)"/>
+    <wire from="(240,3450)" to="(260,3450)"/>
+    <wire from="(200,4050)" to="(220,4050)"/>
+    <wire from="(100,4020)" to="(180,4020)"/>
+    <wire from="(160,4080)" to="(240,4080)"/>
+    <wire from="(320,920)" to="(320,1110)"/>
+    <wire from="(120,4050)" to="(120,4170)"/>
+    <wire from="(310,3280)" to="(380,3280)"/>
+    <wire from="(200,2860)" to="(260,2860)"/>
+    <wire from="(200,4140)" to="(260,4140)"/>
+    <wire from="(120,220)" to="(180,220)"/>
+    <wire from="(120,540)" to="(180,540)"/>
+    <wire from="(140,4070)" to="(140,4200)"/>
+    <wire from="(310,3280)" to="(310,3420)"/>
+    <wire from="(60,150)" to="(60,290)"/>
+    <wire from="(60,620)" to="(240,620)"/>
+    <wire from="(230,2820)" to="(230,2830)"/>
+    <wire from="(230,3140)" to="(230,3150)"/>
+    <wire from="(80,2090)" to="(80,2240)"/>
+    <wire from="(100,2110)" to="(100,2260)"/>
+    <wire from="(120,2130)" to="(120,2280)"/>
+    <wire from="(140,2150)" to="(140,2300)"/>
+    <wire from="(60,470)" to="(60,620)"/>
+    <wire from="(140,1540)" to="(180,1540)"/>
+    <wire from="(200,1600)" to="(240,1600)"/>
+    <wire from="(240,3150)" to="(240,3180)"/>
+    <wire from="(140,2470)" to="(140,2630)"/>
+    <wire from="(160,3770)" to="(160,3930)"/>
+    <wire from="(200,3530)" to="(230,3530)"/>
+    <wire from="(290,2980)" to="(320,2980)"/>
+    <wire from="(310,130)" to="(330,130)"/>
+    <wire from="(240,1980)" to="(260,1980)"/>
+    <wire from="(240,2300)" to="(260,2300)"/>
+    <wire from="(240,2620)" to="(260,2620)"/>
+    <wire from="(240,3900)" to="(260,3900)"/>
+    <wire from="(160,3180)" to="(180,3180)"/>
+    <wire from="(120,3280)" to="(260,3280)"/>
+    <wire from="(100,130)" to="(100,200)"/>
+    <wire from="(200,1730)" to="(240,1730)"/>
+    <wire from="(140,2630)" to="(180,2630)"/>
+    <wire from="(200,3330)" to="(240,3330)"/>
+    <wire from="(290,1500)" to="(330,1500)"/>
+    <wire from="(340,680)" to="(340,1090)"/>
+    <wire from="(230,810)" to="(260,810)"/>
+    <wire from="(60,3800)" to="(60,3960)"/>
+    <wire from="(100,3690)" to="(260,3690)"/>
+    <wire from="(200,2380)" to="(230,2380)"/>
+    <wire from="(200,2700)" to="(230,2700)"/>
+    <wire from="(230,4010)" to="(260,4010)"/>
+    <wire from="(240,1470)" to="(260,1470)"/>
+    <wire from="(310,2180)" to="(330,2180)"/>
+    <wire from="(290,3120)" to="(310,3120)"/>
+    <wire from="(240,3390)" to="(260,3390)"/>
+    <wire from="(160,2030)" to="(180,2030)"/>
+    <wire from="(120,2130)" to="(260,2130)"/>
+    <wire from="(310,150)" to="(310,210)"/>
+    <wire from="(120,800)" to="(180,800)"/>
+    <wire from="(320,3290)" to="(320,3560)"/>
+    <wire from="(60,3050)" to="(180,3050)"/>
+    <wire from="(220,2430)" to="(220,2440)"/>
+    <wire from="(220,2750)" to="(220,2760)"/>
+    <wire from="(60,2800)" to="(240,2800)"/>
+    <wire from="(160,830)" to="(160,970)"/>
+    <wire from="(230,2760)" to="(230,2780)"/>
+    <wire from="(240,2770)" to="(240,2790)"/>
+    <wire from="(230,3080)" to="(230,3100)"/>
+    <wire from="(230,3720)" to="(230,3740)"/>
+    <wire from="(230,2440)" to="(230,2470)"/>
+    <wire from="(200,260)" to="(240,260)"/>
+    <wire from="(200,2180)" to="(240,2180)"/>
+    <wire from="(200,2500)" to="(240,2500)"/>
+    <wire from="(200,4100)" to="(240,4100)"/>
+    <wire from="(80,50)" to="(80,80)"/>
+    <wire from="(230,940)" to="(260,940)"/>
+    <wire from="(290,3560)" to="(320,3560)"/>
+    <wire from="(200,3150)" to="(230,3150)"/>
+    <wire from="(240,1920)" to="(260,1920)"/>
+    <wire from="(240,2240)" to="(260,2240)"/>
+    <wire from="(240,2560)" to="(260,2560)"/>
+    <wire from="(240,2880)" to="(260,2880)"/>
+    <wire from="(240,3840)" to="(260,3840)"/>
+    <wire from="(410,1130)" to="(430,1130)"/>
+    <wire from="(240,850)" to="(240,890)"/>
+    <wire from="(240,3730)" to="(240,3770)"/>
+    <wire from="(40,190)" to="(120,190)"/>
+    <wire from="(240,2450)" to="(240,2500)"/>
+    <wire from="(100,70)" to="(100,130)"/>
+    <wire from="(330,2850)" to="(330,3240)"/>
+    <wire from="(200,3570)" to="(260,3570)"/>
+    <wire from="(310,2200)" to="(310,2270)"/>
+    <wire from="(60,1900)" to="(180,1900)"/>
+    <wire from="(60,3500)" to="(180,3500)"/>
+    <wire from="(80,880)" to="(80,1020)"/>
+    <wire from="(230,3530)" to="(230,3540)"/>
+    <wire from="(220,4160)" to="(220,4170)"/>
+    <wire from="(360,2420)" to="(360,3210)"/>
+    <wire from="(240,1300)" to="(240,1330)"/>
+    <wire from="(230,4170)" to="(230,4200)"/>
+    <wire from="(240,20)" to="(240,50)"/>
+    <wire from="(340,1170)" to="(380,1170)"/>
+    <wire from="(200,4230)" to="(240,4230)"/>
+    <wire from="(120,90)" to="(120,190)"/>
+    <wire from="(200,2000)" to="(230,2000)"/>
+    <wire from="(200,3600)" to="(230,3600)"/>
+    <wire from="(240,1090)" to="(260,1090)"/>
+    <wire from="(240,3010)" to="(260,3010)"/>
+    <wire from="(160,260)" to="(160,300)"/>
+    <wire from="(200,1690)" to="(220,1690)"/>
+    <wire from="(100,1660)" to="(180,1660)"/>
+    <wire from="(240,4180)" to="(240,4230)"/>
+    <wire from="(60,30)" to="(60,150)"/>
+    <wire from="(140,110)" to="(140,240)"/>
+    <wire from="(160,130)" to="(160,260)"/>
+    <wire from="(200,4020)" to="(260,4020)"/>
+    <wire from="(160,3330)" to="(160,3470)"/>
+    <wire from="(60,2350)" to="(180,2350)"/>
+    <wire from="(80,1330)" to="(80,1470)"/>
+    <wire from="(60,2910)" to="(60,3050)"/>
+    <wire from="(100,1350)" to="(100,1490)"/>
+    <wire from="(120,1370)" to="(120,1510)"/>
+    <wire from="(230,2380)" to="(230,2400)"/>
+    <wire from="(230,2700)" to="(230,2720)"/>
+    <wire from="(160,1730)" to="(160,1880)"/>
+    <wire from="(330,3300)" to="(330,3700)"/>
+    <wire from="(240,150)" to="(240,180)"/>
+    <wire from="(240,470)" to="(240,500)"/>
+    <wire from="(290,2850)" to="(330,2850)"/>
+    <wire from="(80,3670)" to="(180,3670)"/>
+    <wire from="(80,3990)" to="(180,3990)"/>
+    <wire from="(60,990)" to="(60,1150)"/>
+    <wire from="(100,1200)" to="(260,1200)"/>
+    <wire from="(120,1690)" to="(120,1850)"/>
+    <wire from="(140,1710)" to="(140,1870)"/>
+    <wire from="(140,2780)" to="(230,2780)"/>
+    <wire from="(230,1520)" to="(260,1520)"/>
+    <wire from="(230,3440)" to="(260,3440)"/>
+    <wire from="(240,1860)" to="(260,1860)"/>
+    <wire from="(240,2820)" to="(260,2820)"/>
+    <wire from="(360,140)" to="(430,140)"/>
+    <wire from="(120,1510)" to="(180,1510)"/>
+    <wire from="(120,3430)" to="(180,3430)"/>
+    <wire from="(60,1760)" to="(60,1900)"/>
+    <wire from="(80,180)" to="(80,320)"/>
+    <wire from="(80,500)" to="(80,640)"/>
+    <wire from="(230,1230)" to="(230,1240)"/>
+    <wire from="(60,3360)" to="(60,3500)"/>
+    <wire from="(160,2180)" to="(160,2320)"/>
+    <wire from="(100,200)" to="(100,350)"/>
+    <wire from="(100,520)" to="(100,670)"/>
+    <wire from="(240,1240)" to="(240,1270)"/>
+    <wire from="(140,3150)" to="(180,3150)"/>
+    <wire from="(200,3210)" to="(240,3210)"/>
+    <wire from="(40,240)" to="(140,240)"/>
+    <wire from="(60,1440)" to="(60,1600)"/>
+    <wire from="(120,220)" to="(120,380)"/>
+    <wire from="(120,540)" to="(120,700)"/>
+    <wire from="(160,2500)" to="(160,2660)"/>
+    <wire from="(230,1650)" to="(260,1650)"/>
+    <wire from="(230,1970)" to="(260,1970)"/>
+    <wire from="(230,2290)" to="(260,2290)"/>
+    <wire from="(230,2610)" to="(260,2610)"/>
+    <wire from="(230,3250)" to="(260,3250)"/>
+    <wire from="(230,3890)" to="(260,3890)"/>
+    <wire from="(240,1030)" to="(260,1030)"/>
+    <wire from="(140,240)" to="(140,410)"/>
+    <wire from="(240,2950)" to="(260,2950)"/>
+    <wire from="(240,3590)" to="(260,3590)"/>
+    <wire from="(240,3800)" to="(240,3840)"/>
+    <wire from="(240,390)" to="(260,390)"/>
+    <wire from="(240,710)" to="(260,710)"/>
+    <wire from="(160,1270)" to="(180,1270)"/>
+    <wire from="(120,90)" to="(260,90)"/>
+    <wire from="(360,2190)" to="(430,2190)"/>
+    <wire from="(290,530)" to="(350,530)"/>
+    <wire from="(120,2280)" to="(180,2280)"/>
+    <wire from="(120,2600)" to="(180,2600)"/>
+    <wire from="(60,2210)" to="(60,2350)"/>
+    <wire from="(60,2680)" to="(240,2680)"/>
+    <wire from="(60,2530)" to="(60,2680)"/>
+    <wire from="(140,2000)" to="(180,2000)"/>
+    <wire from="(140,3600)" to="(180,3600)"/>
+    <wire from="(200,2060)" to="(240,2060)"/>
+    <wire from="(80,3830)" to="(80,3990)"/>
+    <wire from="(230,2100)" to="(260,2100)"/>
+    <wire from="(200,3670)" to="(230,3670)"/>
+    <wire from="(200,3990)" to="(230,3990)"/>
+    <wire from="(290,1210)" to="(310,1210)"/>
+    <wire from="(240,1800)" to="(260,1800)"/>
+    <wire from="(160,440)" to="(180,440)"/>
+    <wire from="(60,740)" to="(60,850)"/>
+    <wire from="(160,830)" to="(240,830)"/>
+    <wire from="(60,290)" to="(60,470)"/>
+    <wire from="(340,3310)" to="(340,3870)"/>
+    <wire from="(80,760)" to="(80,880)"/>
+    <wire from="(120,800)" to="(120,930)"/>
+    <wire from="(140,820)" to="(140,950)"/>
+    <wire from="(320,3250)" to="(380,3250)"/>
+    <wire from="(100,780)" to="(100,910)"/>
+    <wire from="(320,2980)" to="(320,3250)"/>
+    <wire from="(290,3870)" to="(340,3870)"/>
+    <wire from="(220,4040)" to="(220,4050)"/>
+    <wire from="(230,4050)" to="(230,4070)"/>
+    <wire from="(240,4060)" to="(240,4080)"/>
+    <wire from="(200,3470)" to="(240,3470)"/>
+    <wire from="(80,1180)" to="(180,1180)"/>
+    <wire from="(200,1240)" to="(230,1240)"/>
+    <wire from="(230,2870)" to="(260,2870)"/>
+    <wire from="(160,3770)" to="(180,3770)"/>
+    <wire from="(240,3530)" to="(260,3530)"/>
+    <wire from="(360,3330)" to="(380,3330)"/>
+    <wire from="(240,330)" to="(260,330)"/>
+    <wire from="(240,650)" to="(260,650)"/>
+    <wire from="(310,1120)" to="(380,1120)"/>
+    <wire from="(200,1660)" to="(260,1660)"/>
+    <wire from="(120,2860)" to="(180,2860)"/>
+    <wire from="(330,1160)" to="(380,1160)"/>
+    <wire from="(100,910)" to="(100,1050)"/>
+    <wire from="(120,930)" to="(120,1070)"/>
+    <wire from="(140,950)" to="(140,1090)"/>
+    <wire from="(160,2890)" to="(160,3030)"/>
+    <wire from="(160,970)" to="(160,1120)"/>
+    <wire from="(200,2320)" to="(240,2320)"/>
+    <wire from="(80,1630)" to="(180,1630)"/>
+    <wire from="(200,410)" to="(230,410)"/>
+    <wire from="(230,1080)" to="(260,1080)"/>
+    <wire from="(230,3000)" to="(260,3000)"/>
+    <wire from="(240,990)" to="(240,1030)"/>
+    <wire from="(340,2740)" to="(340,3230)"/>
+    <wire from="(240,2910)" to="(240,2950)"/>
+    <wire from="(160,130)" to="(240,130)"/>
+    <wire from="(310,1060)" to="(310,1120)"/>
+    <wire from="(200,3710)" to="(260,3710)"/>
+    <wire from="(350,3320)" to="(350,4030)"/>
+    <wire from="(60,3640)" to="(180,3640)"/>
+    <wire from="(60,3960)" to="(180,3960)"/>
+    <wire from="(80,2940)" to="(80,3080)"/>
+    <wire from="(140,1400)" to="(140,1540)"/>
+    <wire from="(230,3670)" to="(230,3680)"/>
+    <wire from="(230,3990)" to="(230,4010)"/>
+    <wire from="(160,1420)" to="(160,1570)"/>
+    <wire from="(240,1440)" to="(240,1470)"/>
+    <wire from="(200,850)" to="(240,850)"/>
+    <wire from="(240,3360)" to="(240,3390)"/>
+    <wire from="(340,3230)" to="(380,3230)"/>
+    <wire from="(200,1180)" to="(230,1180)"/>
+    <wire from="(80,1020)" to="(80,1180)"/>
+    <wire from="(140,4070)" to="(230,4070)"/>
+    <wire from="(230,1850)" to="(260,1850)"/>
+    <wire from="(200,3740)" to="(230,3740)"/>
+    <wire from="(240,3150)" to="(260,3150)"/>
+    <wire from="(240,1760)" to="(240,1800)"/>
+    <wire from="(120,930)" to="(260,930)"/>
+    <wire from="(80,1790)" to="(80,1920)"/>
+    <wire from="(330,1100)" to="(380,1100)"/>
+    <wire from="(80,3390)" to="(80,3530)"/>
+    <wire from="(230,4120)" to="(230,4130)"/>
+    <wire from="(100,3410)" to="(100,3550)"/>
+    <wire from="(120,3430)" to="(120,3570)"/>
+    <wire from="(160,3470)" to="(160,3620)"/>
+    <wire from="(140,570)" to="(140,720)"/>
+    <wire from="(140,3450)" to="(140,3600)"/>
+    <wire from="(140,1240)" to="(180,1240)"/>
+    <wire from="(240,2210)" to="(240,2240)"/>
+    <wire from="(240,2530)" to="(240,2560)"/>
+    <wire from="(200,20)" to="(240,20)"/>
+    <wire from="(200,1300)" to="(240,1300)"/>
+    <wire from="(220,1960)" to="(260,1960)"/>
+    <wire from="(220,3880)" to="(260,3880)"/>
+    <wire from="(230,60)" to="(260,60)"/>
+    <wire from="(230,380)" to="(260,380)"/>
+    <wire from="(230,700)" to="(260,700)"/>
+    <wire from="(200,1630)" to="(230,1630)"/>
+    <wire from="(80,1470)" to="(80,1630)"/>
+    <wire from="(60,3050)" to="(60,3210)"/>
+    <wire from="(100,3260)" to="(260,3260)"/>
+    <wire from="(230,1340)" to="(260,1340)"/>
+    <wire from="(230,3580)" to="(260,3580)"/>
+    <wire from="(310,150)" to="(330,150)"/>
+    <wire from="(100,1490)" to="(100,1660)"/>
+    <wire from="(240,290)" to="(240,330)"/>
+    <wire from="(360,3330)" to="(360,4150)"/>
+    <wire from="(120,1510)" to="(120,1690)"/>
+    <wire from="(60,620)" to="(60,740)"/>
+    <wire from="(80,640)" to="(80,760)"/>
+    <wire from="(120,1970)" to="(180,1970)"/>
+    <wire from="(120,3570)" to="(180,3570)"/>
+    <wire from="(120,3890)" to="(180,3890)"/>
+    <wire from="(220,1680)" to="(220,1690)"/>
+    <wire from="(60,3500)" to="(60,3640)"/>
+    <wire from="(80,2240)" to="(80,2380)"/>
+    <wire from="(80,2560)" to="(80,2700)"/>
+    <wire from="(230,3290)" to="(230,3300)"/>
+    <wire from="(230,1690)" to="(230,1710)"/>
+    <wire from="(100,2260)" to="(100,2410)"/>
+    <wire from="(100,2580)" to="(100,2730)"/>
+    <wire from="(240,740)" to="(240,760)"/>
+    <wire from="(140,410)" to="(180,410)"/>
+    <wire from="(240,1700)" to="(240,1730)"/>
+    <wire from="(200,150)" to="(240,150)"/>
+    <wire from="(200,470)" to="(240,470)"/>
+    <wire from="(240,3300)" to="(240,3330)"/>
+    <wire from="(230,190)" to="(260,190)"/>
+    <wire from="(230,510)" to="(260,510)"/>
+    <wire from="(60,1900)" to="(60,2060)"/>
+    <wire from="(100,2110)" to="(260,2110)"/>
+    <wire from="(120,2280)" to="(120,2440)"/>
+    <wire from="(100,3860)" to="(100,4020)"/>
+    <wire from="(120,2600)" to="(120,2760)"/>
+    <wire from="(240,2450)" to="(260,2450)"/>
+    <wire from="(240,2770)" to="(260,2770)"/>
+    <wire from="(160,3330)" to="(180,3330)"/>
+    <wire from="(80,1920)" to="(80,2090)"/>
+    <wire from="(100,1940)" to="(100,2110)"/>
+    <wire from="(310,2200)" to="(330,2200)"/>
+    <wire from="(240,3090)" to="(260,3090)"/>
+    <wire from="(240,3730)" to="(260,3730)"/>
+    <wire from="(140,2300)" to="(140,2470)"/>
+    <wire from="(360,3210)" to="(380,3210)"/>
+    <wire from="(160,1730)" to="(180,1730)"/>
+    <wire from="(80,320)" to="(80,500)"/>
+    <wire from="(160,2320)" to="(160,2500)"/>
+    <wire from="(290,2590)" to="(350,2590)"/>
+    <wire from="(60,1150)" to="(180,1150)"/>
+    <wire from="(290,680)" to="(340,680)"/>
+    <wire from="(230,1180)" to="(230,1190)"/>
+    <wire from="(230,2140)" to="(230,2150)"/>
+    <wire from="(240,2150)" to="(240,2180)"/>
+    <wire from="(200,600)" to="(240,600)"/>
+    <wire from="(140,3740)" to="(180,3740)"/>
+    <wire from="(200,3800)" to="(240,3800)"/>
+    <wire from="(350,3320)" to="(380,3320)"/>
+    <wire from="(350,1080)" to="(380,1080)"/>
+    <wire from="(240,4180)" to="(260,4180)"/>
+    <wire from="(60,2800)" to="(60,2910)"/>
+    <wire from="(160,260)" to="(180,260)"/>
+    <wire from="(160,2180)" to="(180,2180)"/>
+    <wire from="(160,2500)" to="(180,2500)"/>
+    <wire from="(100,910)" to="(180,910)"/>
+    <wire from="(160,970)" to="(240,970)"/>
+    <wire from="(160,2890)" to="(240,2890)"/>
+    <wire from="(60,2350)" to="(60,2530)"/>
+    <wire from="(80,2820)" to="(80,2940)"/>
+    <wire from="(100,2840)" to="(100,2970)"/>
+    <wire from="(320,1150)" to="(380,1150)"/>
+    <wire from="(120,2860)" to="(120,2990)"/>
+    <wire from="(140,2880)" to="(140,3010)"/>
+    <wire from="(40,300)" to="(160,300)"/>
+    <wire from="(60,1600)" to="(180,1600)"/>
+    <wire from="(230,1630)" to="(230,1650)"/>
+    <wire from="(200,3930)" to="(240,3930)"/>
+    <wire from="(80,3240)" to="(180,3240)"/>
+    <wire from="(290,3700)" to="(330,3700)"/>
+    <wire from="(230,770)" to="(260,770)"/>
+    <wire from="(140,1710)" to="(230,1710)"/>
+    <wire from="(200,3300)" to="(230,3300)"/>
+    <wire from="(240,2390)" to="(260,2390)"/>
+    <wire from="(240,2710)" to="(260,2710)"/>
+    <wire from="(160,4230)" to="(180,4230)"/>
+    <wire from="(290,2120)" to="(310,2120)"/>
+    <wire from="(240,3670)" to="(260,3670)"/>
+    <wire from="(160,1420)" to="(240,1420)"/>
+    <wire from="(100,2970)" to="(100,3110)"/>
+    <wire from="(120,2990)" to="(120,3130)"/>
+    <wire from="(140,3010)" to="(140,3150)"/>
+    <wire from="(100,1050)" to="(100,1200)"/>
+    <wire from="(120,1070)" to="(120,1220)"/>
+    <wire from="(140,1090)" to="(140,1240)"/>
+    <wire from="(160,3030)" to="(160,3180)"/>
+    <wire from="(220,1840)" to="(260,1840)"/>
+    <wire from="(80,2090)" to="(180,2090)"/>
+    <wire from="(290,3270)" to="(380,3270)"/>
+    <wire from="(230,900)" to="(260,900)"/>
+    <wire from="(140,240)" to="(230,240)"/>
+    <wire from="(200,2150)" to="(230,2150)"/>
+    <wire from="(200,2470)" to="(230,2470)"/>
+    <wire from="(230,3140)" to="(260,3140)"/>
+    <wire from="(240,1240)" to="(260,1240)"/>
+    <wire from="(240,4120)" to="(260,4120)"/>
+    <wire from="(240,3050)" to="(240,3090)"/>
+    <wire from="(100,1820)" to="(100,1940)"/>
+    <wire from="(160,600)" to="(160,730)"/>
+    <wire from="(120,1850)" to="(180,1850)"/>
+    <wire from="(60,4100)" to="(180,4100)"/>
+    <wire from="(240,1900)" to="(240,1920)"/>
+    <wire from="(160,1880)" to="(160,2030)"/>
+    <wire from="(220,370)" to="(260,370)"/>
+    <wire from="(220,690)" to="(260,690)"/>
+    <wire from="(200,990)" to="(240,990)"/>
+    <wire from="(240,3500)" to="(240,3530)"/>
+    <wire from="(200,2910)" to="(240,2910)"/>
+    <wire from="(240,620)" to="(240,650)"/>
+    <wire from="(100,70)" to="(260,70)"/>
+    <wire from="(100,1350)" to="(260,1350)"/>
+    <wire from="(80,3080)" to="(80,3240)"/>
+    <wire from="(200,3240)" to="(230,3240)"/>
+    <wire from="(160,730)" to="(160,830)"/>
+    <wire from="(200,4200)" to="(230,4200)"/>
+    <wire from="(200,3890)" to="(220,3890)"/>
+    <wire from="(140,1540)" to="(140,1710)"/>
+    <wire from="(200,1970)" to="(220,1970)"/>
+    <wire from="(100,670)" to="(100,780)"/>
+    <wire from="(100,1940)" to="(180,1940)"/>
+    <wire from="(100,3860)" to="(180,3860)"/>
+    <wire from="(120,1070)" to="(260,1070)"/>
+    <wire from="(120,2990)" to="(260,2990)"/>
+    <wire from="(290,1830)" to="(350,1830)"/>
+    <wire from="(120,380)" to="(180,380)"/>
+    <wire from="(120,700)" to="(180,700)"/>
+    <wire from="(230,100)" to="(230,110)"/>
+    <wire from="(310,3120)" to="(310,3260)"/>
+    <wire from="(80,3530)" to="(80,3670)"/>
+    <wire from="(100,3550)" to="(100,3690)"/>
+    <wire from="(120,3570)" to="(120,3710)"/>
+    <wire from="(230,1380)" to="(230,1400)"/>
+    <wire from="(160,3930)" to="(160,4080)"/>
+    <wire from="(140,2630)" to="(140,2780)"/>
+    <wire from="(240,110)" to="(240,130)"/>
+    <wire from="(240,1390)" to="(240,1420)"/>
+    <wire from="(200,1120)" to="(240,1120)"/>
+    <wire from="(200,1440)" to="(240,1440)"/>
+    <wire from="(200,1760)" to="(240,1760)"/>
+    <wire from="(140,3300)" to="(180,3300)"/>
+    <wire from="(200,3360)" to="(240,3360)"/>
+    <wire from="(100,200)" to="(260,200)"/>
+    <wire from="(100,520)" to="(260,520)"/>
+    <wire from="(120,1970)" to="(120,2130)"/>
+    <wire from="(120,3890)" to="(120,4050)"/>
+    <wire from="(140,820)" to="(230,820)"/>
+    <wire from="(140,3910)" to="(140,4070)"/>
+    <wire from="(230,1480)" to="(260,1480)"/>
+    <wire from="(200,2090)" to="(230,2090)"/>
+    <wire from="(230,2440)" to="(260,2440)"/>
+    <wire from="(230,2760)" to="(260,2760)"/>
+    <wire from="(230,3400)" to="(260,3400)"/>
+    <wire from="(230,3720)" to="(260,3720)"/>
+    <wire from="(240,1180)" to="(260,1180)"/>
+    <wire from="(240,4060)" to="(260,4060)"/>
+    <wire from="(410,3270)" to="(430,3270)"/>
+    <wire from="(100,350)" to="(100,520)"/>
+    <wire from="(240,2350)" to="(240,2390)"/>
+    <wire from="(60,2680)" to="(60,2800)"/>
+    <wire from="(80,2700)" to="(80,2820)"/>
+    <wire from="(290,1950)" to="(360,1950)"/>
+    <comp lib="1" loc="(200,1900)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,360)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,190)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3670)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,210)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,1670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2980)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,1830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,2850)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,80)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,3870)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,640)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3120)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3890)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2120)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1060)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,990)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(430,2190)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUop2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,2180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2740)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3420)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1730)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1970)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,920)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,4200)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2730)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2530)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3640)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,240)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,300)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1130)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="12"/>
+    </comp>
+    <comp lib="1" loc="(200,3240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3700)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3050)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,790)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(430,3270)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUop3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,2280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3830)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1360)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(360,2190)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(430,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUop0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(360,140)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,530)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3990)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3560)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,2420)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,50)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3530)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,670)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1050)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2590)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,2270)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,1210)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4050)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(430,1130)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUop1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3080)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3270)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="13"/>
+    </comp>
+    <comp lib="1" loc="(290,1950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,4140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,680)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,4150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2970)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3270)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,4030)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+  </circuit>
+  <circuit name="Opcode_Decoder">
+    <a name="circuit" val="Opcode_Decoder"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <rect fill="none" height="235" stroke="#000000" stroke-width="2" width="31" x="50" y="55"/>
+      <circ-port height="8" pin="40,30" width="8" x="46" y="136"/>
+      <circ-port height="10" pin="420,70" width="10" x="75" y="65"/>
+      <circ-port height="8" pin="40,80" width="8" x="46" y="146"/>
+      <circ-port height="8" pin="40,140" width="8" x="46" y="156"/>
+      <circ-port height="10" pin="420,180" width="10" x="75" y="85"/>
+      <circ-port height="8" pin="40,190" width="8" x="46" y="166"/>
+      <circ-port height="8" pin="40,250" width="8" x="46" y="176"/>
+      <circ-port height="8" pin="40,300" width="8" x="46" y="186"/>
+      <circ-port height="10" pin="420,750" width="10" x="75" y="105"/>
+      <circ-port height="10" pin="420,1490" width="10" x="75" y="125"/>
+      <circ-port height="10" pin="420,1690" width="10" x="75" y="145"/>
+      <circ-port height="10" pin="420,1900" width="10" x="75" y="165"/>
+      <circ-port height="10" pin="420,2130" width="10" x="75" y="185"/>
+      <circ-port height="10" pin="420,2970" width="10" x="75" y="205"/>
+      <circ-port height="10" pin="420,3790" width="10" x="75" y="225"/>
+      <circ-port height="10" pin="420,3930" width="10" x="75" y="245"/>
+      <circ-port height="10" pin="420,4130" width="10" x="75" y="265"/>
+      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
+    </appear>
+    <wire from="(120,190)" to="(180,190)"/>
+    <wire from="(350,3020)" to="(350,3610)"/>
+    <wire from="(60,3720)" to="(180,3720)"/>
+    <wire from="(330,450)" to="(330,720)"/>
+    <wire from="(220,2140)" to="(220,2150)"/>
+    <wire from="(230,3750)" to="(230,3770)"/>
+    <wire from="(230,2150)" to="(230,2180)"/>
+    <wire from="(140,2790)" to="(180,2790)"/>
+    <wire from="(240,3120)" to="(240,3150)"/>
+    <wire from="(200,2210)" to="(240,2210)"/>
+    <wire from="(200,2850)" to="(240,2850)"/>
+    <wire from="(240,240)" to="(240,270)"/>
+    <wire from="(320,730)" to="(360,730)"/>
+    <wire from="(230,2890)" to="(260,2890)"/>
+    <wire from="(200,3820)" to="(230,3820)"/>
+    <wire from="(240,990)" to="(260,990)"/>
+    <wire from="(200,3510)" to="(220,3510)"/>
+    <wire from="(350,3020)" to="(370,3020)"/>
+    <wire from="(200,1590)" to="(220,1590)"/>
+    <wire from="(100,1560)" to="(180,1560)"/>
+    <wire from="(160,1620)" to="(240,1620)"/>
+    <wire from="(100,3480)" to="(180,3480)"/>
+    <wire from="(160,3540)" to="(240,3540)"/>
+    <wire from="(120,690)" to="(260,690)"/>
+    <wire from="(240,2160)" to="(240,2210)"/>
+    <wire from="(120,4210)" to="(260,4210)"/>
+    <wire from="(310,1910)" to="(310,1970)"/>
+    <wire from="(120,1590)" to="(120,1710)"/>
+    <wire from="(140,1610)" to="(140,1730)"/>
+    <wire from="(120,3510)" to="(120,3630)"/>
+    <wire from="(200,3600)" to="(260,3600)"/>
+    <wire from="(200,3920)" to="(260,3920)"/>
+    <wire from="(140,3530)" to="(140,3660)"/>
+    <wire from="(200,1680)" to="(260,1680)"/>
+    <wire from="(80,80)" to="(80,150)"/>
+    <wire from="(80,270)" to="(80,410)"/>
+    <wire from="(80,3150)" to="(80,3290)"/>
+    <wire from="(100,3170)" to="(100,3310)"/>
+    <wire from="(120,3190)" to="(120,3330)"/>
+    <wire from="(100,290)" to="(100,440)"/>
+    <wire from="(200,740)" to="(240,740)"/>
+    <wire from="(200,2980)" to="(240,2980)"/>
+    <wire from="(80,1650)" to="(180,1650)"/>
+    <wire from="(80,3890)" to="(180,3890)"/>
+    <wire from="(200,1070)" to="(230,1070)"/>
+    <wire from="(120,310)" to="(120,470)"/>
+    <wire from="(160,1310)" to="(160,1470)"/>
+    <wire from="(230,3020)" to="(260,3020)"/>
+    <wire from="(290,2760)" to="(320,2760)"/>
+    <wire from="(230,3340)" to="(260,3340)"/>
+    <wire from="(240,800)" to="(260,800)"/>
+    <wire from="(240,1440)" to="(260,1440)"/>
+    <wire from="(240,480)" to="(260,480)"/>
+    <wire from="(310,760)" to="(310,830)"/>
+    <wire from="(120,3330)" to="(180,3330)"/>
+    <wire from="(60,2060)" to="(180,2060)"/>
+    <wire from="(60,2700)" to="(180,2700)"/>
+    <wire from="(230,2730)" to="(230,2740)"/>
+    <wire from="(230,2090)" to="(230,2110)"/>
+    <wire from="(240,2420)" to="(240,2450)"/>
+    <wire from="(60,1340)" to="(60,1500)"/>
+    <wire from="(100,1230)" to="(260,1230)"/>
+    <wire from="(60,3260)" to="(60,3420)"/>
+    <wire from="(140,3660)" to="(140,3820)"/>
+    <wire from="(390,750)" to="(420,750)"/>
+    <wire from="(230,1550)" to="(260,1550)"/>
+    <wire from="(230,3470)" to="(260,3470)"/>
+    <wire from="(240,930)" to="(260,930)"/>
+    <wire from="(340,710)" to="(360,710)"/>
+    <wire from="(160,3090)" to="(180,3090)"/>
+    <wire from="(60,510)" to="(60,620)"/>
+    <wire from="(330,2630)" to="(330,2940)"/>
+    <wire from="(160,600)" to="(240,600)"/>
+    <wire from="(100,1820)" to="(180,1820)"/>
+    <wire from="(160,1880)" to="(240,1880)"/>
+    <wire from="(80,530)" to="(80,650)"/>
+    <wire from="(100,550)" to="(100,670)"/>
+    <wire from="(120,570)" to="(120,690)"/>
+    <wire from="(140,590)" to="(140,710)"/>
+    <wire from="(80,2450)" to="(80,2590)"/>
+    <wire from="(230,1260)" to="(230,1280)"/>
+    <wire from="(100,2470)" to="(100,2620)"/>
+    <wire from="(290,450)" to="(330,450)"/>
+    <wire from="(200,3560)" to="(240,3560)"/>
+    <wire from="(140,3820)" to="(180,3820)"/>
+    <wire from="(200,1650)" to="(230,1650)"/>
+    <wire from="(120,2490)" to="(120,2650)"/>
+    <wire from="(200,3890)" to="(230,3890)"/>
+    <wire from="(240,1380)" to="(260,1380)"/>
+    <wire from="(240,2340)" to="(260,2340)"/>
+    <wire from="(240,2660)" to="(260,2660)"/>
+    <wire from="(140,210)" to="(140,250)"/>
+    <wire from="(240,1270)" to="(240,1310)"/>
+    <wire from="(240,100)" to="(260,100)"/>
+    <wire from="(240,420)" to="(260,420)"/>
+    <wire from="(160,2210)" to="(160,2390)"/>
+    <wire from="(320,770)" to="(320,960)"/>
+    <wire from="(200,1110)" to="(260,1110)"/>
+    <wire from="(60,1040)" to="(180,1040)"/>
+    <wire from="(230,1070)" to="(230,1080)"/>
+    <wire from="(220,1700)" to="(220,1710)"/>
+    <wire from="(160,740)" to="(160,880)"/>
+    <wire from="(220,3620)" to="(220,3630)"/>
+    <wire from="(220,3940)" to="(220,3950)"/>
+    <wire from="(230,1710)" to="(230,1730)"/>
+    <wire from="(240,1720)" to="(240,1740)"/>
+    <wire from="(230,3950)" to="(230,3970)"/>
+    <wire from="(240,3960)" to="(240,3980)"/>
+    <wire from="(230,3630)" to="(230,3660)"/>
+    <wire from="(200,3690)" to="(240,3690)"/>
+    <wire from="(230,850)" to="(260,850)"/>
+    <wire from="(200,1140)" to="(230,1140)"/>
+    <wire from="(100,1960)" to="(100,2120)"/>
+    <wire from="(100,4050)" to="(260,4050)"/>
+    <wire from="(140,3070)" to="(230,3070)"/>
+    <wire from="(230,1810)" to="(260,1810)"/>
+    <wire from="(120,1980)" to="(120,2150)"/>
+    <wire from="(240,2790)" to="(260,2790)"/>
+    <wire from="(240,4070)" to="(260,4070)"/>
+    <wire from="(40,30)" to="(60,30)"/>
+    <wire from="(60,130)" to="(60,240)"/>
+    <wire from="(160,2390)" to="(180,2390)"/>
+    <wire from="(160,220)" to="(240,220)"/>
+    <wire from="(60,2240)" to="(60,2420)"/>
+    <wire from="(240,3640)" to="(240,3690)"/>
+    <wire from="(140,2000)" to="(140,2180)"/>
+    <wire from="(80,150)" to="(80,270)"/>
+    <wire from="(100,170)" to="(100,290)"/>
+    <wire from="(120,190)" to="(120,310)"/>
+    <wire from="(200,3480)" to="(260,3480)"/>
+    <wire from="(330,4050)" to="(330,4120)"/>
+    <wire from="(60,770)" to="(60,900)"/>
+    <wire from="(200,1560)" to="(260,1560)"/>
+    <wire from="(200,620)" to="(240,620)"/>
+    <wire from="(200,1900)" to="(240,1900)"/>
+    <wire from="(80,1210)" to="(180,1210)"/>
+    <wire from="(290,2630)" to="(330,2630)"/>
+    <wire from="(200,4140)" to="(240,4140)"/>
+    <wire from="(80,1530)" to="(180,1530)"/>
+    <wire from="(80,3450)" to="(180,3450)"/>
+    <wire from="(230,660)" to="(260,660)"/>
+    <wire from="(230,980)" to="(260,980)"/>
+    <wire from="(100,2900)" to="(260,2900)"/>
+    <wire from="(340,3010)" to="(370,3010)"/>
+    <wire from="(230,4180)" to="(260,4180)"/>
+    <wire from="(240,2280)" to="(260,2280)"/>
+    <wire from="(240,2600)" to="(260,2600)"/>
+    <wire from="(240,40)" to="(260,40)"/>
+    <wire from="(120,1980)" to="(260,1980)"/>
+    <wire from="(330,780)" to="(330,1100)"/>
+    <wire from="(120,970)" to="(180,970)"/>
+    <wire from="(60,3860)" to="(180,3860)"/>
+    <wire from="(60,900)" to="(60,1040)"/>
+    <wire from="(230,2930)" to="(230,2940)"/>
+    <wire from="(140,3220)" to="(140,3360)"/>
+    <wire from="(230,1650)" to="(230,1670)"/>
+    <wire from="(240,2940)" to="(240,2960)"/>
+    <wire from="(230,3890)" to="(230,3910)"/>
+    <wire from="(160,3240)" to="(160,3390)"/>
+    <wire from="(140,340)" to="(140,490)"/>
+    <wire from="(240,3260)" to="(240,3290)"/>
+    <wire from="(200,2030)" to="(240,2030)"/>
+    <wire from="(230,470)" to="(260,470)"/>
+    <wire from="(140,3970)" to="(230,3970)"/>
+    <wire from="(100,3030)" to="(260,3030)"/>
+    <wire from="(140,1730)" to="(230,1730)"/>
+    <wire from="(230,1430)" to="(260,1430)"/>
+    <wire from="(200,2360)" to="(230,2360)"/>
+    <wire from="(240,1130)" to="(260,1130)"/>
+    <wire from="(240,2730)" to="(260,2730)"/>
+    <wire from="(160,4250)" to="(180,4250)"/>
+    <wire from="(240,1340)" to="(240,1380)"/>
+    <wire from="(320,2760)" to="(320,2950)"/>
+    <wire from="(60,390)" to="(60,510)"/>
+    <wire from="(80,410)" to="(80,530)"/>
+    <wire from="(310,1410)" to="(310,1480)"/>
+    <wire from="(160,300)" to="(160,370)"/>
+    <wire from="(200,1820)" to="(260,1820)"/>
+    <wire from="(230,3060)" to="(230,3070)"/>
+    <wire from="(240,3070)" to="(240,3090)"/>
+    <wire from="(160,3690)" to="(160,3840)"/>
+    <wire from="(60,10)" to="(60,30)"/>
+    <wire from="(240,510)" to="(240,530)"/>
+    <wire from="(40,80)" to="(80,80)"/>
+    <wire from="(140,1140)" to="(180,1140)"/>
+    <wire from="(200,240)" to="(240,240)"/>
+    <wire from="(200,3120)" to="(240,3120)"/>
+    <wire from="(80,1790)" to="(180,1790)"/>
+    <wire from="(80,4030)" to="(180,4030)"/>
+    <wire from="(230,280)" to="(260,280)"/>
+    <wire from="(200,1210)" to="(230,1210)"/>
+    <wire from="(200,1530)" to="(230,1530)"/>
+    <wire from="(80,1370)" to="(80,1530)"/>
+    <wire from="(80,3290)" to="(80,3450)"/>
+    <wire from="(200,3450)" to="(230,3450)"/>
+    <wire from="(230,3160)" to="(260,3160)"/>
+    <wire from="(290,2910)" to="(310,2910)"/>
+    <wire from="(240,3820)" to="(260,3820)"/>
+    <wire from="(100,3310)" to="(100,3480)"/>
+    <wire from="(80,30)" to="(80,80)"/>
+    <wire from="(120,3330)" to="(120,3510)"/>
+    <wire from="(290,180)" to="(420,180)"/>
+    <wire from="(340,790)" to="(340,1240)"/>
+    <wire from="(60,1630)" to="(240,1630)"/>
+    <wire from="(220,1580)" to="(220,1590)"/>
+    <wire from="(60,3720)" to="(60,3860)"/>
+    <wire from="(220,3500)" to="(220,3510)"/>
+    <wire from="(230,1590)" to="(230,1610)"/>
+    <wire from="(240,1600)" to="(240,1620)"/>
+    <wire from="(230,3510)" to="(230,3530)"/>
+    <wire from="(240,3520)" to="(240,3540)"/>
+    <wire from="(140,2520)" to="(140,2670)"/>
+    <wire from="(200,370)" to="(240,370)"/>
+    <wire from="(200,1010)" to="(240,1010)"/>
+    <wire from="(290,1100)" to="(330,1100)"/>
+    <wire from="(80,2880)" to="(180,2880)"/>
+    <wire from="(230,90)" to="(260,90)"/>
+    <wire from="(140,4230)" to="(230,4230)"/>
+    <wire from="(230,2330)" to="(260,2330)"/>
+    <wire from="(230,2650)" to="(260,2650)"/>
+    <wire from="(200,2940)" to="(230,2940)"/>
+    <wire from="(240,1070)" to="(260,1070)"/>
+    <wire from="(290,3040)" to="(310,3040)"/>
+    <wire from="(240,2240)" to="(240,2280)"/>
+    <wire from="(160,1310)" to="(180,1310)"/>
+    <wire from="(100,1960)" to="(180,1960)"/>
+    <wire from="(60,2570)" to="(60,2700)"/>
+    <wire from="(80,2590)" to="(80,2730)"/>
+    <wire from="(240,130)" to="(240,150)"/>
+    <wire from="(240,770)" to="(240,800)"/>
+    <wire from="(140,2360)" to="(180,2360)"/>
+    <wire from="(200,2420)" to="(240,2420)"/>
+    <wire from="(80,3010)" to="(180,3010)"/>
+    <wire from="(230,540)" to="(260,540)"/>
+    <wire from="(200,1790)" to="(230,1790)"/>
+    <wire from="(230,2460)" to="(260,2460)"/>
+    <wire from="(230,2780)" to="(260,2780)"/>
+    <wire from="(200,4030)" to="(230,4030)"/>
+    <wire from="(230,4060)" to="(260,4060)"/>
+    <wire from="(240,2160)" to="(260,2160)"/>
+    <wire from="(290,1570)" to="(310,1570)"/>
+    <wire from="(310,1910)" to="(330,1910)"/>
+    <wire from="(240,3760)" to="(260,3760)"/>
+    <wire from="(80,2270)" to="(80,2450)"/>
+    <wire from="(160,2030)" to="(160,2210)"/>
+    <wire from="(120,840)" to="(120,970)"/>
+    <wire from="(140,860)" to="(140,990)"/>
+    <wire from="(160,880)" to="(160,1010)"/>
+    <wire from="(310,2960)" to="(370,2960)"/>
+    <wire from="(80,800)" to="(80,930)"/>
+    <wire from="(100,820)" to="(100,950)"/>
+    <wire from="(200,1250)" to="(260,1250)"/>
+    <wire from="(60,1180)" to="(180,1180)"/>
+    <wire from="(60,1500)" to="(180,1500)"/>
+    <wire from="(60,3420)" to="(180,3420)"/>
+    <wire from="(230,1210)" to="(230,1220)"/>
+    <wire from="(230,1850)" to="(230,1860)"/>
+    <wire from="(230,1530)" to="(230,1550)"/>
+    <wire from="(240,1860)" to="(240,1880)"/>
+    <wire from="(230,3450)" to="(230,3470)"/>
+    <wire from="(60,2700)" to="(60,2850)"/>
+    <wire from="(240,900)" to="(240,930)"/>
+    <wire from="(200,2550)" to="(240,2550)"/>
+    <wire from="(140,4090)" to="(180,4090)"/>
+    <wire from="(330,3000)" to="(370,3000)"/>
+    <wire from="(100,670)" to="(260,670)"/>
+    <wire from="(200,1280)" to="(230,1280)"/>
+    <wire from="(100,4190)" to="(260,4190)"/>
+    <wire from="(140,1610)" to="(230,1610)"/>
+    <wire from="(140,3530)" to="(230,3530)"/>
+    <wire from="(230,1950)" to="(260,1950)"/>
+    <wire from="(200,2880)" to="(230,2880)"/>
+    <wire from="(340,790)" to="(360,790)"/>
+    <wire from="(160,2210)" to="(180,2210)"/>
+    <wire from="(160,3240)" to="(240,3240)"/>
+    <wire from="(60,2060)" to="(60,2240)"/>
+    <wire from="(160,370)" to="(160,500)"/>
+    <wire from="(230,700)" to="(230,710)"/>
+    <wire from="(80,930)" to="(80,1070)"/>
+    <wire from="(100,950)" to="(100,1090)"/>
+    <wire from="(120,970)" to="(120,1110)"/>
+    <wire from="(230,3580)" to="(230,3590)"/>
+    <wire from="(230,4220)" to="(230,4230)"/>
+    <wire from="(240,4230)" to="(240,4250)"/>
+    <wire from="(140,990)" to="(140,1140)"/>
+    <wire from="(160,1010)" to="(160,1160)"/>
+    <wire from="(220,460)" to="(260,460)"/>
+    <wire from="(140,2940)" to="(180,2940)"/>
+    <wire from="(220,1420)" to="(260,1420)"/>
+    <wire from="(240,390)" to="(240,420)"/>
+    <wire from="(240,710)" to="(240,740)"/>
+    <wire from="(290,4050)" to="(330,4050)"/>
+    <wire from="(230,160)" to="(260,160)"/>
+    <wire from="(230,1120)" to="(260,1120)"/>
+    <wire from="(200,3010)" to="(230,3010)"/>
+    <wire from="(160,500)" to="(160,600)"/>
+    <wire from="(240,2100)" to="(260,2100)"/>
+    <wire from="(290,1830)" to="(310,1830)"/>
+    <wire from="(160,740)" to="(180,740)"/>
+    <wire from="(100,440)" to="(100,550)"/>
+    <wire from="(120,840)" to="(260,840)"/>
+    <wire from="(120,470)" to="(180,470)"/>
+    <wire from="(120,1110)" to="(180,1110)"/>
+    <wire from="(120,1430)" to="(180,1430)"/>
+    <wire from="(60,1760)" to="(180,1760)"/>
+    <wire from="(60,4000)" to="(180,4000)"/>
+    <wire from="(60,1040)" to="(60,1180)"/>
+    <wire from="(230,4030)" to="(230,4040)"/>
+    <wire from="(230,1790)" to="(230,1810)"/>
+    <wire from="(120,4070)" to="(230,4070)"/>
+    <wire from="(200,4090)" to="(240,4090)"/>
+    <wire from="(330,2940)" to="(370,2940)"/>
+    <wire from="(100,290)" to="(260,290)"/>
+    <wire from="(200,1860)" to="(230,1860)"/>
+    <wire from="(100,1400)" to="(100,1560)"/>
+    <wire from="(100,3170)" to="(260,3170)"/>
+    <wire from="(140,590)" to="(230,590)"/>
+    <wire from="(200,2180)" to="(230,2180)"/>
+    <wire from="(230,3810)" to="(260,3810)"/>
+    <wire from="(290,680)" to="(310,680)"/>
+    <wire from="(240,1270)" to="(260,1270)"/>
+    <wire from="(140,3360)" to="(140,3530)"/>
+    <wire from="(240,3720)" to="(240,3760)"/>
+    <wire from="(200,1960)" to="(260,1960)"/>
+    <wire from="(160,2550)" to="(160,2680)"/>
+    <wire from="(60,2850)" to="(180,2850)"/>
+    <wire from="(230,2880)" to="(230,2890)"/>
+    <wire from="(80,3750)" to="(80,3890)"/>
+    <wire from="(230,3200)" to="(230,3220)"/>
+    <wire from="(100,60)" to="(100,140)"/>
+    <wire from="(230,320)" to="(230,340)"/>
+    <wire from="(140,1280)" to="(180,1280)"/>
+    <wire from="(240,2570)" to="(240,2600)"/>
+    <wire from="(220,80)" to="(260,80)"/>
+    <wire from="(200,1340)" to="(240,1340)"/>
+    <wire from="(240,3210)" to="(240,3240)"/>
+    <wire from="(220,2320)" to="(260,2320)"/>
+    <wire from="(220,2640)" to="(260,2640)"/>
+    <wire from="(200,3260)" to="(240,3260)"/>
+    <wire from="(240,10)" to="(240,40)"/>
+    <wire from="(80,650)" to="(180,650)"/>
+    <wire from="(80,1930)" to="(180,1930)"/>
+    <wire from="(80,4170)" to="(180,4170)"/>
+    <wire from="(200,710)" to="(230,710)"/>
+    <wire from="(160,120)" to="(160,220)"/>
+    <wire from="(230,3300)" to="(260,3300)"/>
+    <wire from="(240,1720)" to="(260,1720)"/>
+    <wire from="(240,3640)" to="(260,3640)"/>
+    <wire from="(240,3960)" to="(260,3960)"/>
+    <wire from="(240,330)" to="(240,370)"/>
+    <wire from="(200,3050)" to="(260,3050)"/>
+    <wire from="(100,2620)" to="(100,2750)"/>
+    <wire from="(120,90)" to="(180,90)"/>
+    <wire from="(120,2330)" to="(180,2330)"/>
+    <wire from="(120,2650)" to="(180,2650)"/>
+    <wire from="(60,2980)" to="(180,2980)"/>
+    <wire from="(230,3010)" to="(230,3020)"/>
+    <wire from="(60,3860)" to="(60,4000)"/>
+    <wire from="(160,2680)" to="(160,2820)"/>
+    <wire from="(240,2700)" to="(240,2730)"/>
+    <wire from="(200,1470)" to="(240,1470)"/>
+    <wire from="(200,3390)" to="(240,3390)"/>
+    <wire from="(100,550)" to="(260,550)"/>
+    <wire from="(100,2470)" to="(260,2470)"/>
+    <wire from="(140,210)" to="(230,210)"/>
+    <wire from="(230,2150)" to="(260,2150)"/>
+    <wire from="(240,1210)" to="(260,1210)"/>
+    <wire from="(160,3690)" to="(180,3690)"/>
+    <wire from="(100,2300)" to="(100,2470)"/>
+    <wire from="(350,2920)" to="(370,2920)"/>
+    <wire from="(400,2970)" to="(420,2970)"/>
+    <wire from="(240,2060)" to="(240,2100)"/>
+    <wire from="(160,880)" to="(240,880)"/>
+    <wire from="(290,2310)" to="(350,2310)"/>
+    <wire from="(40,140)" to="(100,140)"/>
+    <wire from="(320,2990)" to="(370,2990)"/>
+    <wire from="(230,580)" to="(230,590)"/>
+    <wire from="(240,590)" to="(240,600)"/>
+    <wire from="(310,740)" to="(360,740)"/>
+    <wire from="(230,2500)" to="(230,2520)"/>
+    <wire from="(80,2730)" to="(80,2880)"/>
+    <wire from="(100,2750)" to="(100,2900)"/>
+    <wire from="(120,2770)" to="(120,2920)"/>
+    <wire from="(140,2790)" to="(140,2940)"/>
+    <wire from="(140,1860)" to="(180,1860)"/>
+    <wire from="(140,2180)" to="(180,2180)"/>
+    <wire from="(200,2240)" to="(240,2240)"/>
+    <wire from="(80,270)" to="(180,270)"/>
+    <wire from="(80,3150)" to="(180,3150)"/>
+    <wire from="(200,650)" to="(230,650)"/>
+    <wire from="(200,1930)" to="(230,1930)"/>
+    <wire from="(330,780)" to="(360,780)"/>
+    <wire from="(200,4170)" to="(230,4170)"/>
+    <wire from="(240,1660)" to="(260,1660)"/>
+    <wire from="(240,2940)" to="(260,2940)"/>
+    <wire from="(240,3580)" to="(260,3580)"/>
+    <wire from="(240,3900)" to="(260,3900)"/>
+    <wire from="(240,2510)" to="(240,2550)"/>
+    <wire from="(80,2090)" to="(80,2270)"/>
+    <wire from="(60,3560)" to="(180,3560)"/>
+    <wire from="(230,1990)" to="(230,2000)"/>
+    <wire from="(140,710)" to="(180,710)"/>
+    <wire from="(240,1040)" to="(240,1070)"/>
+    <wire from="(240,2000)" to="(240,2030)"/>
+    <wire from="(200,770)" to="(240,770)"/>
+    <wire from="(100,170)" to="(260,170)"/>
+    <wire from="(230,810)" to="(260,810)"/>
+    <wire from="(200,3660)" to="(230,3660)"/>
+    <wire from="(120,470)" to="(120,570)"/>
+    <wire from="(140,490)" to="(140,590)"/>
+    <wire from="(240,3070)" to="(260,3070)"/>
+    <wire from="(240,4030)" to="(260,4030)"/>
+    <wire from="(200,470)" to="(220,470)"/>
+    <wire from="(200,1430)" to="(220,1430)"/>
+    <wire from="(160,2030)" to="(180,2030)"/>
+    <wire from="(100,440)" to="(180,440)"/>
+    <wire from="(160,500)" to="(240,500)"/>
+    <wire from="(100,1400)" to="(180,1400)"/>
+    <wire from="(120,2770)" to="(260,2770)"/>
+    <wire from="(290,70)" to="(420,70)"/>
+    <wire from="(230,200)" to="(230,210)"/>
+    <wire from="(240,210)" to="(240,220)"/>
+    <wire from="(80,1070)" to="(80,1210)"/>
+    <wire from="(100,1090)" to="(100,1230)"/>
+    <wire from="(120,1110)" to="(120,1250)"/>
+    <wire from="(160,3390)" to="(160,3540)"/>
+    <wire from="(160,1470)" to="(160,1620)"/>
+    <wire from="(200,900)" to="(240,900)"/>
+    <wire from="(200,2820)" to="(240,2820)"/>
+    <wire from="(80,530)" to="(180,530)"/>
+    <wire from="(80,2450)" to="(180,2450)"/>
+    <wire from="(200,270)" to="(230,270)"/>
+    <wire from="(230,940)" to="(260,940)"/>
+    <wire from="(120,1430)" to="(120,1590)"/>
+    <wire from="(140,1450)" to="(140,1610)"/>
+    <wire from="(230,1260)" to="(260,1260)"/>
+    <wire from="(200,3150)" to="(230,3150)"/>
+    <wire from="(330,720)" to="(360,720)"/>
+    <wire from="(240,1600)" to="(260,1600)"/>
+    <wire from="(290,1970)" to="(310,1970)"/>
+    <wire from="(240,2880)" to="(260,2880)"/>
+    <wire from="(240,3520)" to="(260,3520)"/>
+    <wire from="(40,190)" to="(120,190)"/>
+    <wire from="(330,4140)" to="(330,4200)"/>
+    <wire from="(360,1490)" to="(420,1490)"/>
+    <wire from="(60,1500)" to="(60,1630)"/>
+    <wire from="(120,1250)" to="(180,1250)"/>
+    <wire from="(160,3840)" to="(160,3980)"/>
+    <wire from="(60,620)" to="(180,620)"/>
+    <wire from="(230,650)" to="(230,660)"/>
+    <wire from="(60,1900)" to="(180,1900)"/>
+    <wire from="(60,4140)" to="(180,4140)"/>
+    <wire from="(60,3420)" to="(60,3560)"/>
+    <wire from="(100,3780)" to="(100,3920)"/>
+    <wire from="(230,4170)" to="(230,4180)"/>
+    <wire from="(230,1930)" to="(230,1950)"/>
+    <wire from="(120,3800)" to="(120,3950)"/>
+    <wire from="(140,3820)" to="(140,3970)"/>
+    <wire from="(340,300)" to="(340,710)"/>
+    <wire from="(230,430)" to="(260,430)"/>
+    <wire from="(60,1180)" to="(60,1340)"/>
+    <wire from="(100,3310)" to="(260,3310)"/>
+    <wire from="(60,30)" to="(60,130)"/>
+    <wire from="(120,90)" to="(120,190)"/>
+    <wire from="(230,1390)" to="(260,1390)"/>
+    <wire from="(230,1710)" to="(260,1710)"/>
+    <wire from="(200,2000)" to="(230,2000)"/>
+    <wire from="(140,110)" to="(140,210)"/>
+    <wire from="(230,3630)" to="(260,3630)"/>
+    <wire from="(230,3950)" to="(260,3950)"/>
+    <wire from="(200,2330)" to="(220,2330)"/>
+    <wire from="(200,2650)" to="(220,2650)"/>
+    <wire from="(310,1480)" to="(330,1480)"/>
+    <wire from="(240,3010)" to="(260,3010)"/>
+    <wire from="(240,3860)" to="(240,3900)"/>
+    <wire from="(160,370)" to="(180,370)"/>
+    <wire from="(160,1010)" to="(180,1010)"/>
+    <wire from="(200,90)" to="(220,90)"/>
+    <wire from="(100,60)" to="(180,60)"/>
+    <wire from="(160,120)" to="(240,120)"/>
+    <wire from="(100,2300)" to="(180,2300)"/>
+    <wire from="(100,2620)" to="(180,2620)"/>
+    <wire from="(160,2680)" to="(240,2680)"/>
+    <wire from="(120,2650)" to="(120,2770)"/>
+    <wire from="(140,2670)" to="(140,2790)"/>
+    <wire from="(60,1630)" to="(60,1760)"/>
+    <wire from="(290,1240)" to="(340,1240)"/>
+    <wire from="(80,1650)" to="(80,1790)"/>
+    <wire from="(80,3890)" to="(80,4030)"/>
+    <wire from="(230,3340)" to="(230,3360)"/>
+    <wire from="(140,3660)" to="(180,3660)"/>
+    <wire from="(220,2140)" to="(260,2140)"/>
+    <wire from="(200,3720)" to="(240,3720)"/>
+    <wire from="(80,150)" to="(180,150)"/>
+    <wire from="(200,530)" to="(230,530)"/>
+    <wire from="(120,2330)" to="(120,2490)"/>
+    <wire from="(200,2450)" to="(230,2450)"/>
+    <wire from="(290,3180)" to="(320,3180)"/>
+    <wire from="(240,1540)" to="(260,1540)"/>
+    <wire from="(240,1860)" to="(260,1860)"/>
+    <wire from="(240,3460)" to="(260,3460)"/>
+    <wire from="(240,3350)" to="(240,3390)"/>
+    <wire from="(120,3800)" to="(260,3800)"/>
+    <wire from="(200,3190)" to="(260,3190)"/>
+    <wire from="(310,2980)" to="(370,2980)"/>
+    <wire from="(310,1500)" to="(310,1570)"/>
+    <wire from="(120,2150)" to="(180,2150)"/>
+    <wire from="(200,310)" to="(260,310)"/>
+    <wire from="(60,240)" to="(180,240)"/>
+    <wire from="(230,270)" to="(230,280)"/>
+    <wire from="(60,3120)" to="(180,3120)"/>
+    <wire from="(60,1760)" to="(60,1900)"/>
+    <wire from="(60,4000)" to="(60,4140)"/>
+    <wire from="(230,3150)" to="(230,3160)"/>
+    <wire from="(160,2820)" to="(160,2960)"/>
+    <wire from="(320,770)" to="(360,770)"/>
+    <wire from="(100,140)" to="(100,170)"/>
+    <wire from="(230,50)" to="(260,50)"/>
+    <wire from="(200,340)" to="(230,340)"/>
+    <wire from="(140,990)" to="(230,990)"/>
+    <wire from="(230,2290)" to="(260,2290)"/>
+    <wire from="(230,2610)" to="(260,2610)"/>
+    <wire from="(230,2930)" to="(260,2930)"/>
+    <wire from="(200,3220)" to="(230,3220)"/>
+    <wire from="(240,4230)" to="(260,4230)"/>
+    <wire from="(240,710)" to="(260,710)"/>
+    <wire from="(160,2550)" to="(180,2550)"/>
+    <wire from="(310,2910)" to="(310,2960)"/>
+    <wire from="(100,2120)" to="(100,2300)"/>
+    <wire from="(290,3790)" to="(420,3790)"/>
+    <wire from="(60,2850)" to="(60,2980)"/>
+    <wire from="(340,2480)" to="(340,2930)"/>
+    <wire from="(200,440)" to="(260,440)"/>
+    <wire from="(200,1400)" to="(260,1400)"/>
+    <wire from="(140,2000)" to="(180,2000)"/>
+    <wire from="(200,2060)" to="(240,2060)"/>
+    <wire from="(200,2700)" to="(240,2700)"/>
+    <wire from="(80,410)" to="(180,410)"/>
+    <wire from="(80,1370)" to="(180,1370)"/>
+    <wire from="(80,3290)" to="(180,3290)"/>
+    <wire from="(200,150)" to="(230,150)"/>
+    <wire from="(100,820)" to="(260,820)"/>
+    <wire from="(330,4120)" to="(360,4120)"/>
+    <wire from="(290,560)" to="(320,560)"/>
+    <wire from="(230,2740)" to="(260,2740)"/>
+    <wire from="(230,3060)" to="(260,3060)"/>
+    <wire from="(240,1800)" to="(260,1800)"/>
+    <wire from="(200,2490)" to="(260,2490)"/>
+    <wire from="(200,570)" to="(260,570)"/>
+    <wire from="(120,3050)" to="(180,3050)"/>
+    <wire from="(230,530)" to="(230,540)"/>
+    <wire from="(230,850)" to="(230,860)"/>
+    <wire from="(60,2420)" to="(180,2420)"/>
+    <wire from="(230,2450)" to="(230,2460)"/>
+    <wire from="(60,2980)" to="(60,3120)"/>
+    <wire from="(140,1140)" to="(140,1280)"/>
+    <wire from="(240,860)" to="(240,880)"/>
+    <wire from="(160,1160)" to="(160,1310)"/>
+    <wire from="(240,1180)" to="(240,1210)"/>
+    <wire from="(290,4200)" to="(330,4200)"/>
+    <wire from="(100,950)" to="(260,950)"/>
+    <wire from="(230,1590)" to="(260,1590)"/>
+    <wire from="(200,2520)" to="(230,2520)"/>
+    <wire from="(230,3510)" to="(260,3510)"/>
+    <wire from="(240,3210)" to="(260,3210)"/>
+    <wire from="(240,4170)" to="(260,4170)"/>
+    <wire from="(240,1500)" to="(240,1540)"/>
+    <wire from="(240,3420)" to="(240,3460)"/>
+    <wire from="(240,330)" to="(260,330)"/>
+    <wire from="(240,650)" to="(260,650)"/>
+    <wire from="(100,3780)" to="(180,3780)"/>
+    <wire from="(160,3840)" to="(240,3840)"/>
+    <wire from="(80,1530)" to="(80,1650)"/>
+    <wire from="(290,2130)" to="(420,2130)"/>
+    <wire from="(200,2300)" to="(260,2300)"/>
+    <wire from="(200,2620)" to="(260,2620)"/>
+    <wire from="(80,3450)" to="(80,3580)"/>
+    <wire from="(200,60)" to="(260,60)"/>
+    <wire from="(230,980)" to="(230,990)"/>
+    <wire from="(240,990)" to="(240,1010)"/>
+    <wire from="(140,340)" to="(180,340)"/>
+    <wire from="(240,1630)" to="(240,1660)"/>
+    <wire from="(200,1040)" to="(240,1040)"/>
+    <wire from="(140,3220)" to="(180,3220)"/>
+    <wire from="(220,1700)" to="(260,1700)"/>
+    <wire from="(80,30)" to="(180,30)"/>
+    <wire from="(220,3620)" to="(260,3620)"/>
+    <wire from="(220,3940)" to="(260,3940)"/>
+    <wire from="(80,2270)" to="(180,2270)"/>
+    <wire from="(80,2590)" to="(180,2590)"/>
+    <wire from="(200,410)" to="(230,410)"/>
+    <wire from="(200,1370)" to="(230,1370)"/>
+    <wire from="(80,1210)" to="(80,1370)"/>
+    <wire from="(230,1080)" to="(260,1080)"/>
+    <wire from="(200,3290)" to="(230,3290)"/>
+    <wire from="(290,830)" to="(310,830)"/>
+    <wire from="(100,1230)" to="(100,1400)"/>
+    <wire from="(120,1250)" to="(120,1430)"/>
+    <wire from="(310,2980)" to="(310,3040)"/>
+    <wire from="(100,3920)" to="(100,4050)"/>
+    <wire from="(120,1710)" to="(180,1710)"/>
+    <wire from="(200,190)" to="(260,190)"/>
+    <wire from="(120,3630)" to="(180,3630)"/>
+    <wire from="(120,3950)" to="(180,3950)"/>
+    <wire from="(290,3490)" to="(340,3490)"/>
+    <wire from="(230,150)" to="(230,160)"/>
+    <wire from="(220,460)" to="(220,470)"/>
+    <wire from="(60,510)" to="(240,510)"/>
+    <wire from="(220,1420)" to="(220,1430)"/>
+    <wire from="(100,1680)" to="(100,1820)"/>
+    <wire from="(160,1740)" to="(160,1880)"/>
+    <wire from="(230,1430)" to="(230,1450)"/>
+    <wire from="(230,470)" to="(230,490)"/>
+    <wire from="(240,480)" to="(240,500)"/>
+    <wire from="(140,250)" to="(140,340)"/>
+    <wire from="(240,1440)" to="(240,1470)"/>
+    <wire from="(240,4000)" to="(240,4030)"/>
+    <wire from="(200,3090)" to="(240,3090)"/>
+    <wire from="(80,800)" to="(180,800)"/>
+    <wire from="(200,860)" to="(230,860)"/>
+    <wire from="(60,3560)" to="(60,3720)"/>
+    <wire from="(140,2360)" to="(140,2520)"/>
+    <wire from="(230,1850)" to="(260,1850)"/>
+    <wire from="(230,3770)" to="(260,3770)"/>
+    <wire from="(200,2150)" to="(220,2150)"/>
+    <wire from="(240,2510)" to="(260,2510)"/>
+    <wire from="(160,3390)" to="(180,3390)"/>
+    <wire from="(80,3580)" to="(80,3750)"/>
+    <wire from="(240,3150)" to="(260,3150)"/>
+    <wire from="(240,1760)" to="(240,1800)"/>
+    <wire from="(240,270)" to="(260,270)"/>
+    <wire from="(240,590)" to="(260,590)"/>
+    <wire from="(160,1470)" to="(180,1470)"/>
+    <wire from="(100,2120)" to="(180,2120)"/>
+    <wire from="(100,3600)" to="(100,3780)"/>
+    <wire from="(310,1830)" to="(310,1890)"/>
+    <wire from="(290,3610)" to="(350,3610)"/>
+    <wire from="(140,4090)" to="(140,4230)"/>
+    <wire from="(310,760)" to="(360,760)"/>
+    <wire from="(80,1790)" to="(80,1930)"/>
+    <wire from="(80,4030)" to="(80,4170)"/>
+    <wire from="(100,4050)" to="(100,4190)"/>
+    <wire from="(120,4070)" to="(120,4210)"/>
+    <wire from="(140,2520)" to="(180,2520)"/>
+    <wire from="(240,2850)" to="(240,2880)"/>
+    <wire from="(200,3860)" to="(240,3860)"/>
+    <wire from="(40,250)" to="(140,250)"/>
+    <wire from="(80,930)" to="(180,930)"/>
+    <wire from="(200,30)" to="(230,30)"/>
+    <wire from="(230,700)" to="(260,700)"/>
+    <wire from="(200,2270)" to="(230,2270)"/>
+    <wire from="(200,2590)" to="(230,2590)"/>
+    <wire from="(230,4220)" to="(260,4220)"/>
+    <wire from="(240,2000)" to="(260,2000)"/>
+    <wire from="(290,1410)" to="(310,1410)"/>
+    <wire from="(120,2150)" to="(120,2330)"/>
+    <wire from="(320,2990)" to="(320,3180)"/>
+    <wire from="(310,680)" to="(310,740)"/>
+    <wire from="(200,3330)" to="(260,3330)"/>
+    <wire from="(80,2880)" to="(80,3010)"/>
+    <wire from="(100,2900)" to="(100,3030)"/>
+    <wire from="(120,2920)" to="(120,3050)"/>
+    <wire from="(140,2940)" to="(140,3070)"/>
+    <wire from="(160,2960)" to="(160,3090)"/>
+    <wire from="(220,80)" to="(220,90)"/>
+    <wire from="(60,1340)" to="(180,1340)"/>
+    <wire from="(60,3260)" to="(180,3260)"/>
+    <wire from="(160,3980)" to="(160,4250)"/>
+    <wire from="(60,130)" to="(240,130)"/>
+    <wire from="(220,2320)" to="(220,2330)"/>
+    <wire from="(220,2640)" to="(220,2650)"/>
+    <wire from="(230,3290)" to="(230,3300)"/>
+    <wire from="(230,1370)" to="(230,1390)"/>
+    <wire from="(230,2650)" to="(230,2670)"/>
+    <wire from="(240,2660)" to="(240,2680)"/>
+    <wire from="(230,90)" to="(230,110)"/>
+    <wire from="(240,100)" to="(240,120)"/>
+    <wire from="(230,410)" to="(230,430)"/>
+    <wire from="(60,620)" to="(60,770)"/>
+    <wire from="(230,2330)" to="(230,2360)"/>
+    <wire from="(240,2980)" to="(240,3010)"/>
+    <wire from="(200,2390)" to="(240,2390)"/>
+    <wire from="(200,800)" to="(230,800)"/>
+    <wire from="(60,1900)" to="(60,2060)"/>
+    <wire from="(100,2750)" to="(260,2750)"/>
+    <wire from="(140,490)" to="(230,490)"/>
+    <wire from="(140,1450)" to="(230,1450)"/>
+    <wire from="(230,2110)" to="(260,2110)"/>
+    <wire from="(200,3360)" to="(230,3360)"/>
+    <wire from="(240,2450)" to="(260,2450)"/>
+    <wire from="(240,210)" to="(260,210)"/>
+    <wire from="(320,560)" to="(320,730)"/>
+    <wire from="(240,530)" to="(260,530)"/>
+    <wire from="(160,1160)" to="(240,1160)"/>
+    <wire from="(240,2340)" to="(240,2390)"/>
+    <wire from="(290,3930)" to="(420,3930)"/>
+    <wire from="(290,1690)" to="(420,1690)"/>
+    <wire from="(200,3780)" to="(260,3780)"/>
+    <wire from="(320,2950)" to="(370,2950)"/>
+    <wire from="(230,2780)" to="(230,2790)"/>
+    <wire from="(80,3010)" to="(80,3150)"/>
+    <wire from="(100,3030)" to="(100,3170)"/>
+    <wire from="(120,3050)" to="(120,3190)"/>
+    <wire from="(230,4060)" to="(230,4070)"/>
+    <wire from="(240,4070)" to="(240,4090)"/>
+    <wire from="(140,3070)" to="(140,3220)"/>
+    <wire from="(160,3090)" to="(160,3240)"/>
+    <wire from="(140,860)" to="(180,860)"/>
+    <wire from="(240,2790)" to="(240,2820)"/>
+    <wire from="(220,1580)" to="(260,1580)"/>
+    <wire from="(220,3500)" to="(260,3500)"/>
+    <wire from="(80,3750)" to="(180,3750)"/>
+    <wire from="(230,320)" to="(260,320)"/>
+    <wire from="(200,930)" to="(230,930)"/>
+    <wire from="(230,3200)" to="(260,3200)"/>
+    <wire from="(240,1940)" to="(260,1940)"/>
+    <wire from="(160,2820)" to="(180,2820)"/>
+    <wire from="(120,2920)" to="(260,2920)"/>
+    <wire from="(100,1560)" to="(100,1680)"/>
+    <wire from="(100,3480)" to="(100,3600)"/>
+    <wire from="(160,1620)" to="(160,1740)"/>
+    <wire from="(120,310)" to="(180,310)"/>
+    <wire from="(120,1590)" to="(180,1590)"/>
+    <wire from="(330,3000)" to="(330,3320)"/>
+    <wire from="(120,3190)" to="(180,3190)"/>
+    <wire from="(120,3510)" to="(180,3510)"/>
+    <wire from="(40,300)" to="(160,300)"/>
+    <wire from="(60,2240)" to="(180,2240)"/>
+    <wire from="(60,390)" to="(240,390)"/>
+    <wire from="(60,3120)" to="(60,3260)"/>
+    <wire from="(230,2270)" to="(230,2290)"/>
+    <wire from="(230,2590)" to="(230,2610)"/>
+    <wire from="(240,3560)" to="(240,3580)"/>
+    <wire from="(160,3540)" to="(160,3690)"/>
+    <wire from="(230,30)" to="(230,50)"/>
+    <wire from="(60,240)" to="(60,390)"/>
+    <wire from="(200,4250)" to="(240,4250)"/>
+    <wire from="(100,1090)" to="(260,1090)"/>
+    <wire from="(140,110)" to="(230,110)"/>
+    <wire from="(140,2670)" to="(230,2670)"/>
+    <wire from="(390,4130)" to="(420,4130)"/>
+    <wire from="(200,3630)" to="(220,3630)"/>
+    <wire from="(200,3950)" to="(220,3950)"/>
+    <wire from="(140,1280)" to="(140,1450)"/>
+    <wire from="(310,1500)" to="(330,1500)"/>
+    <wire from="(240,3350)" to="(260,3350)"/>
+    <wire from="(240,150)" to="(260,150)"/>
+    <wire from="(200,1710)" to="(220,1710)"/>
+    <wire from="(100,1680)" to="(180,1680)"/>
+    <wire from="(160,1740)" to="(240,1740)"/>
+    <wire from="(100,3600)" to="(180,3600)"/>
+    <wire from="(100,3920)" to="(180,3920)"/>
+    <wire from="(160,3980)" to="(240,3980)"/>
+    <wire from="(120,3950)" to="(120,4070)"/>
+    <wire from="(140,3970)" to="(140,4090)"/>
+    <wire from="(200,2120)" to="(260,2120)"/>
+    <wire from="(120,1710)" to="(120,1840)"/>
+    <wire from="(140,1730)" to="(140,1860)"/>
+    <wire from="(60,770)" to="(180,770)"/>
+    <wire from="(230,800)" to="(230,810)"/>
+    <wire from="(290,300)" to="(340,300)"/>
+    <wire from="(230,1120)" to="(230,1140)"/>
+    <wire from="(240,1130)" to="(240,1160)"/>
+    <wire from="(200,1180)" to="(240,1180)"/>
+    <wire from="(200,1500)" to="(240,1500)"/>
+    <wire from="(140,3360)" to="(180,3360)"/>
+    <wire from="(200,3420)" to="(240,3420)"/>
+    <wire from="(80,2090)" to="(180,2090)"/>
+    <wire from="(80,2730)" to="(180,2730)"/>
+    <wire from="(230,580)" to="(260,580)"/>
+    <wire from="(160,2390)" to="(160,2550)"/>
+    <wire from="(350,2310)" to="(350,2920)"/>
+    <wire from="(340,2930)" to="(370,2930)"/>
+    <wire from="(290,960)" to="(320,960)"/>
+    <wire from="(230,1220)" to="(260,1220)"/>
+    <wire from="(230,2500)" to="(260,2500)"/>
+    <wire from="(200,2790)" to="(230,2790)"/>
+    <wire from="(200,3750)" to="(230,3750)"/>
+    <wire from="(120,3630)" to="(120,3800)"/>
+    <wire from="(120,570)" to="(180,570)"/>
+    <wire from="(200,970)" to="(260,970)"/>
+    <wire from="(120,2490)" to="(180,2490)"/>
+    <wire from="(60,900)" to="(180,900)"/>
+    <wire from="(230,930)" to="(230,940)"/>
+    <wire from="(60,10)" to="(240,10)"/>
+    <wire from="(60,2570)" to="(240,2570)"/>
+    <wire from="(100,1820)" to="(100,1960)"/>
+    <wire from="(120,1840)" to="(120,1980)"/>
+    <wire from="(160,600)" to="(160,740)"/>
+    <wire from="(230,3810)" to="(230,3820)"/>
+    <wire from="(140,1860)" to="(140,2000)"/>
+    <wire from="(240,3820)" to="(240,3840)"/>
+    <wire from="(60,2420)" to="(60,2570)"/>
+    <wire from="(160,1880)" to="(160,2030)"/>
+    <wire from="(200,1310)" to="(240,1310)"/>
+    <wire from="(240,4140)" to="(240,4170)"/>
+    <wire from="(240,620)" to="(240,650)"/>
+    <wire from="(290,3320)" to="(330,3320)"/>
+    <wire from="(230,1670)" to="(260,1670)"/>
+    <wire from="(230,1990)" to="(260,1990)"/>
+    <wire from="(340,3010)" to="(340,3490)"/>
+    <wire from="(230,3590)" to="(260,3590)"/>
+    <wire from="(230,3910)" to="(260,3910)"/>
+    <wire from="(240,3290)" to="(260,3290)"/>
+    <wire from="(80,3580)" to="(230,3580)"/>
+    <wire from="(240,1900)" to="(240,1940)"/>
+    <wire from="(160,2960)" to="(240,2960)"/>
+    <wire from="(140,2180)" to="(140,2360)"/>
+    <wire from="(360,1900)" to="(420,1900)"/>
+    <wire from="(290,2480)" to="(340,2480)"/>
+    <wire from="(160,220)" to="(160,300)"/>
+    <wire from="(120,690)" to="(120,840)"/>
+    <wire from="(140,710)" to="(140,860)"/>
+    <wire from="(80,650)" to="(80,800)"/>
+    <wire from="(100,670)" to="(100,820)"/>
+    <wire from="(200,1760)" to="(240,1760)"/>
+    <wire from="(200,4000)" to="(240,4000)"/>
+    <wire from="(80,1070)" to="(180,1070)"/>
+    <wire from="(230,200)" to="(260,200)"/>
+    <wire from="(80,1930)" to="(80,2090)"/>
+    <wire from="(330,4140)" to="(360,4140)"/>
+    <wire from="(200,2090)" to="(230,2090)"/>
+    <wire from="(200,2730)" to="(230,2730)"/>
+    <wire from="(230,4040)" to="(260,4040)"/>
+    <wire from="(240,860)" to="(260,860)"/>
+    <wire from="(310,1890)" to="(330,1890)"/>
+    <wire from="(120,1840)" to="(260,1840)"/>
+    <comp lib="1" loc="(290,1240)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,1490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Jump"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,960)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3920)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2480)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2910)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3790)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(390,4130)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(390,750)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="8"/>
+    </comp>
+    <comp lib="1" loc="(200,3690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1530)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,3780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(360,1900)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,2270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3890)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(360,1490)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(40,250)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,60)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(420,2130)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegDst"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(420,2970)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWrite"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,1900)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Branch"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(400,2970)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(200,1860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3050)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,3040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1100)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,4200)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2760)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2130)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,3930)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJAL"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1970)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,680)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,2630)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,4140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,90)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,530)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3930)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,1690)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoReg"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,3450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2590)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1900)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,30)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,560)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,970)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1070)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,70)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemRead"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,2730)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,4050)" name="AND Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(200,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,3180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,3390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,300)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(420,750)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrc"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,3790)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneBeq"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,70)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,4090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,900)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,4130)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ZeroExtend"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,2700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,2090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,300)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1590)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,190)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWrite"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+  </circuit>
+  <circuit name="RegisterRead_Detector">
+    <a name="circuit" val="RegisterRead_Detector"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <rect fill="none" height="120" stroke="#000000" stroke-width="2" width="30" x="50" y="55"/>
+      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
+      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
+      <circ-port height="8" pin="40,130" width="8" x="46" y="76"/>
+      <circ-port height="8" pin="40,180" width="8" x="46" y="86"/>
+      <circ-port height="8" pin="40,230" width="8" x="46" y="96"/>
+      <circ-port height="8" pin="40,280" width="8" x="46" y="106"/>
+      <circ-port height="8" pin="40,330" width="8" x="46" y="116"/>
+      <circ-port height="8" pin="40,380" width="8" x="46" y="126"/>
+      <circ-port height="8" pin="40,430" width="8" x="46" y="136"/>
+      <circ-port height="8" pin="40,480" width="8" x="46" y="146"/>
+      <circ-port height="8" pin="40,530" width="8" x="46" y="156"/>
+      <circ-port height="8" pin="40,580" width="8" x="46" y="166"/>
+      <circ-port height="10" pin="730,1960" width="10" x="75" y="95"/>
+      <circ-port height="10" pin="730,4550" width="10" x="75" y="115"/>
+      <circ-anchor facing="east" height="6" width="6" x="77" y="107"/>
+    </appear>
+    <wire from="(240,4150)" to="(300,4150)"/>
+    <wire from="(320,3910)" to="(380,3910)"/>
+    <wire from="(200,3460)" to="(200,3600)"/>
+    <wire from="(620,1970)" to="(680,1970)"/>
+    <wire from="(360,1000)" to="(360,1020)"/>
+    <wire from="(350,1310)" to="(350,1330)"/>
+    <wire from="(520,4450)" to="(560,4450)"/>
+    <wire from="(200,3880)" to="(300,3880)"/>
+    <wire from="(140,4720)" to="(500,4720)"/>
+    <wire from="(260,2910)" to="(300,2910)"/>
+    <wire from="(440,850)" to="(480,850)"/>
+    <wire from="(80,1420)" to="(80,1580)"/>
+    <wire from="(100,1440)" to="(100,1600)"/>
+    <wire from="(120,1460)" to="(120,1620)"/>
+    <wire from="(320,2980)" to="(350,2980)"/>
+    <wire from="(180,2800)" to="(180,2960)"/>
+    <wire from="(200,2820)" to="(200,2980)"/>
+    <wire from="(280,470)" to="(280,580)"/>
+    <wire from="(540,1920)" to="(570,1920)"/>
+    <wire from="(360,3350)" to="(380,3350)"/>
+    <wire from="(360,3670)" to="(380,3670)"/>
+    <wire from="(80,1870)" to="(80,1980)"/>
+    <wire from="(360,1320)" to="(360,1360)"/>
+    <wire from="(140,230)" to="(140,1490)"/>
+    <wire from="(280,3220)" to="(280,3400)"/>
+    <wire from="(220,400)" to="(300,400)"/>
+    <wire from="(280,4300)" to="(360,4300)"/>
+    <wire from="(620,1900)" to="(620,1950)"/>
+    <wire from="(100,1890)" to="(100,2010)"/>
+    <wire from="(160,1950)" to="(160,2070)"/>
+    <wire from="(550,4840)" to="(550,4850)"/>
+    <wire from="(560,4850)" to="(560,4860)"/>
+    <wire from="(120,1910)" to="(120,2040)"/>
+    <wire from="(140,1930)" to="(140,2060)"/>
+    <wire from="(540,2590)" to="(540,2600)"/>
+    <wire from="(550,2600)" to="(550,2610)"/>
+    <wire from="(410,4140)" to="(460,4140)"/>
+    <wire from="(600,1450)" to="(650,1450)"/>
+    <wire from="(180,3720)" to="(360,3720)"/>
+    <wire from="(430,3500)" to="(430,3630)"/>
+    <wire from="(120,1620)" to="(490,1620)"/>
+    <wire from="(510,2310)" to="(570,2310)"/>
+    <wire from="(340,3030)" to="(340,3040)"/>
+    <wire from="(120,2580)" to="(490,2580)"/>
+    <wire from="(510,1690)" to="(550,1690)"/>
+    <wire from="(530,2030)" to="(570,2030)"/>
+    <wire from="(180,3570)" to="(180,3720)"/>
+    <wire from="(350,4000)" to="(350,4020)"/>
+    <wire from="(550,1640)" to="(550,1670)"/>
+    <wire from="(550,1960)" to="(550,1990)"/>
+    <wire from="(350,3040)" to="(350,3070)"/>
+    <wire from="(140,140)" to="(140,230)"/>
+    <wire from="(360,490)" to="(360,520)"/>
+    <wire from="(540,1630)" to="(540,1650)"/>
+    <wire from="(340,560)" to="(380,560)"/>
+    <wire from="(260,1200)" to="(350,1200)"/>
+    <wire from="(470,3590)" to="(490,3590)"/>
+    <wire from="(350,3140)" to="(380,3140)"/>
+    <wire from="(560,4640)" to="(580,4640)"/>
+    <wire from="(100,1440)" to="(570,1440)"/>
+    <wire from="(360,280)" to="(380,280)"/>
+    <wire from="(360,920)" to="(380,920)"/>
+    <wire from="(280,3400)" to="(300,3400)"/>
+    <wire from="(540,130)" to="(570,130)"/>
+    <wire from="(540,1730)" to="(570,1730)"/>
+    <wire from="(550,2700)" to="(580,2700)"/>
+    <wire from="(360,3050)" to="(360,3090)"/>
+    <wire from="(180,3250)" to="(180,3430)"/>
+    <wire from="(140,2060)" to="(540,2060)"/>
+    <wire from="(120,2040)" to="(120,2170)"/>
+    <wire from="(140,2060)" to="(140,2190)"/>
+    <wire from="(440,3660)" to="(490,3660)"/>
+    <wire from="(240,570)" to="(300,570)"/>
+    <wire from="(410,4260)" to="(470,4260)"/>
+    <wire from="(220,540)" to="(220,680)"/>
+    <wire from="(40,580)" to="(280,580)"/>
+    <wire from="(320,4190)" to="(360,4190)"/>
+    <wire from="(200,1260)" to="(300,1260)"/>
+    <wire from="(80,4350)" to="(500,4350)"/>
+    <wire from="(550,2090)" to="(550,2130)"/>
+    <wire from="(80,2120)" to="(490,2120)"/>
+    <wire from="(320,3880)" to="(350,3880)"/>
+    <wire from="(350,390)" to="(380,390)"/>
+    <wire from="(350,710)" to="(380,710)"/>
+    <wire from="(350,1030)" to="(380,1030)"/>
+    <wire from="(640,4530)" to="(660,4530)"/>
+    <wire from="(280,330)" to="(300,330)"/>
+    <wire from="(100,1890)" to="(570,1890)"/>
+    <wire from="(520,4720)" to="(550,4720)"/>
+    <wire from="(540,2180)" to="(570,2180)"/>
+    <wire from="(360,3290)" to="(380,3290)"/>
+    <wire from="(360,3610)" to="(380,3610)"/>
+    <wire from="(160,2780)" to="(500,2780)"/>
+    <wire from="(180,3980)" to="(360,3980)"/>
+    <wire from="(350,3940)" to="(350,3950)"/>
+    <wire from="(180,630)" to="(180,770)"/>
+    <wire from="(200,650)" to="(200,790)"/>
+    <wire from="(350,2980)" to="(350,3000)"/>
+    <wire from="(160,4450)" to="(160,4600)"/>
+    <wire from="(360,3950)" to="(360,3970)"/>
+    <wire from="(60,1960)" to="(550,1960)"/>
+    <wire from="(100,130)" to="(100,1440)"/>
+    <wire from="(100,2150)" to="(100,2310)"/>
+    <wire from="(120,2170)" to="(120,2330)"/>
+    <wire from="(220,1160)" to="(380,1160)"/>
+    <wire from="(140,2190)" to="(140,2350)"/>
+    <wire from="(320,3370)" to="(350,3370)"/>
+    <wire from="(560,4580)" to="(580,4580)"/>
+    <wire from="(280,1100)" to="(300,1100)"/>
+    <wire from="(360,220)" to="(380,220)"/>
+    <wire from="(360,860)" to="(380,860)"/>
+    <wire from="(510,2280)" to="(540,2280)"/>
+    <wire from="(280,3090)" to="(360,3090)"/>
+    <wire from="(620,1970)" to="(620,2020)"/>
+    <wire from="(320,3150)" to="(380,3150)"/>
+    <wire from="(540,2340)" to="(540,2350)"/>
+    <wire from="(430,690)" to="(430,820)"/>
+    <wire from="(360,1200)" to="(360,1210)"/>
+    <wire from="(350,1190)" to="(350,1200)"/>
+    <wire from="(60,4480)" to="(60,4620)"/>
+    <wire from="(550,1390)" to="(550,1420)"/>
+    <wire from="(360,2800)" to="(360,2830)"/>
+    <wire from="(200,3120)" to="(300,3120)"/>
+    <wire from="(80,2660)" to="(80,4350)"/>
+    <wire from="(550,2350)" to="(550,2370)"/>
+    <wire from="(340,2870)" to="(380,2870)"/>
+    <wire from="(340,3510)" to="(380,3510)"/>
+    <wire from="(80,1420)" to="(490,1420)"/>
+    <wire from="(440,3320)" to="(440,3620)"/>
+    <wire from="(510,170)" to="(540,170)"/>
+    <wire from="(520,2750)" to="(540,2750)"/>
+    <wire from="(320,300)" to="(350,300)"/>
+    <wire from="(320,1260)" to="(350,1260)"/>
+    <wire from="(550,4370)" to="(580,4370)"/>
+    <wire from="(550,4690)" to="(580,4690)"/>
+    <wire from="(280,4190)" to="(280,4300)"/>
+    <wire from="(260,970)" to="(260,1080)"/>
+    <wire from="(40,30)" to="(60,30)"/>
+    <wire from="(180,890)" to="(180,1000)"/>
+    <wire from="(200,910)" to="(200,1020)"/>
+    <wire from="(160,170)" to="(490,170)"/>
+    <wire from="(180,4090)" to="(180,4210)"/>
+    <wire from="(200,4110)" to="(200,4230)"/>
+    <wire from="(220,4130)" to="(220,4250)"/>
+    <wire from="(240,4150)" to="(240,4270)"/>
+    <wire from="(260,4170)" to="(260,4290)"/>
+    <wire from="(120,4690)" to="(500,4690)"/>
+    <wire from="(320,400)" to="(380,400)"/>
+    <wire from="(240,2880)" to="(300,2880)"/>
+    <wire from="(240,3520)" to="(300,3520)"/>
+    <wire from="(540,2470)" to="(540,2480)"/>
+    <wire from="(430,840)" to="(480,840)"/>
+    <wire from="(180,2960)" to="(360,2960)"/>
+    <wire from="(220,3490)" to="(220,3630)"/>
+    <wire from="(120,2460)" to="(490,2460)"/>
+    <wire from="(60,4770)" to="(560,4770)"/>
+    <wire from="(350,3880)" to="(350,3900)"/>
+    <wire from="(360,4210)" to="(360,4230)"/>
+    <wire from="(280,3550)" to="(280,3700)"/>
+    <wire from="(550,1840)" to="(550,1870)"/>
+    <wire from="(550,2480)" to="(550,2500)"/>
+    <wire from="(200,370)" to="(300,370)"/>
+    <wire from="(180,1230)" to="(180,2800)"/>
+    <wire from="(260,1080)" to="(350,1080)"/>
+    <wire from="(140,1490)" to="(140,1650)"/>
+    <wire from="(80,1870)" to="(490,1870)"/>
+    <wire from="(350,3340)" to="(380,3340)"/>
+    <wire from="(320,3950)" to="(350,3950)"/>
+    <wire from="(220,2850)" to="(220,3010)"/>
+    <wire from="(350,3660)" to="(380,3660)"/>
+    <wire from="(560,4520)" to="(580,4520)"/>
+    <wire from="(280,1360)" to="(300,1360)"/>
+    <wire from="(160,4450)" to="(500,4450)"/>
+    <wire from="(520,4790)" to="(550,4790)"/>
+    <wire from="(360,800)" to="(380,800)"/>
+    <wire from="(510,1580)" to="(540,1580)"/>
+    <wire from="(510,2540)" to="(540,2540)"/>
+    <wire from="(360,3250)" to="(360,3290)"/>
+    <wire from="(360,3570)" to="(360,3610)"/>
+    <wire from="(160,2220)" to="(490,2220)"/>
+    <wire from="(160,2610)" to="(550,2610)"/>
+    <wire from="(630,1980)" to="(630,2160)"/>
+    <wire from="(410,2860)" to="(470,2860)"/>
+    <wire from="(200,3600)" to="(200,3740)"/>
+    <wire from="(260,4060)" to="(380,4060)"/>
+    <wire from="(530,120)" to="(570,120)"/>
+    <wire from="(60,30)" to="(60,1390)"/>
+    <wire from="(540,2280)" to="(540,2300)"/>
+    <wire from="(260,3370)" to="(300,3370)"/>
+    <wire from="(320,3430)" to="(360,3430)"/>
+    <wire from="(200,1140)" to="(300,1140)"/>
+    <wire from="(510,2040)" to="(530,2040)"/>
+    <wire from="(320,3120)" to="(350,3120)"/>
+    <wire from="(520,2690)" to="(540,2690)"/>
+    <wire from="(350,270)" to="(380,270)"/>
+    <wire from="(320,570)" to="(340,570)"/>
+    <wire from="(510,2350)" to="(540,2350)"/>
+    <wire from="(360,3810)" to="(380,3810)"/>
+    <wire from="(160,170)" to="(160,280)"/>
+    <wire from="(200,3280)" to="(200,3460)"/>
+    <wire from="(220,540)" to="(300,540)"/>
+    <wire from="(320,1300)" to="(380,1300)"/>
+    <wire from="(540,1770)" to="(540,1780)"/>
+    <wire from="(630,1940)" to="(680,1940)"/>
+    <wire from="(180,3860)" to="(360,3860)"/>
+    <wire from="(180,1230)" to="(300,1230)"/>
+    <wire from="(60,4320)" to="(500,4320)"/>
+    <wire from="(350,3180)" to="(350,3190)"/>
+    <wire from="(430,3650)" to="(490,3650)"/>
+    <wire from="(520,4380)" to="(580,4380)"/>
+    <wire from="(180,190)" to="(180,330)"/>
+    <wire from="(350,1260)" to="(350,1270)"/>
+    <wire from="(240,570)" to="(240,710)"/>
+    <wire from="(60,2090)" to="(490,2090)"/>
+    <wire from="(550,1780)" to="(550,1810)"/>
+    <wire from="(40,80)" to="(80,80)"/>
+    <wire from="(360,3190)" to="(360,3220)"/>
+    <wire from="(360,630)" to="(360,660)"/>
+    <wire from="(140,2750)" to="(500,2750)"/>
+    <wire from="(260,300)" to="(300,300)"/>
+    <wire from="(340,700)" to="(380,700)"/>
+    <wire from="(540,2730)" to="(540,2750)"/>
+    <wire from="(550,2740)" to="(550,2780)"/>
+    <wire from="(220,1040)" to="(380,1040)"/>
+    <wire from="(200,210)" to="(200,370)"/>
+    <wire from="(350,4240)" to="(380,4240)"/>
+    <wire from="(320,370)" to="(350,370)"/>
+    <wire from="(320,1330)" to="(350,1330)"/>
+    <wire from="(280,3220)" to="(300,3220)"/>
+    <wire from="(610,4820)" to="(640,4820)"/>
+    <wire from="(160,1520)" to="(490,1520)"/>
+    <wire from="(240,710)" to="(300,710)"/>
+    <wire from="(640,1990)" to="(640,2320)"/>
+    <wire from="(550,4790)" to="(550,4800)"/>
+    <wire from="(540,1580)" to="(540,1590)"/>
+    <wire from="(260,530)" to="(260,600)"/>
+    <wire from="(540,2540)" to="(540,2550)"/>
+    <wire from="(410,250)" to="(460,250)"/>
+    <wire from="(510,1620)" to="(570,1620)"/>
+    <wire from="(600,110)" to="(660,110)"/>
+    <wire from="(510,2580)" to="(570,2580)"/>
+    <wire from="(520,4830)" to="(580,4830)"/>
+    <wire from="(350,430)" to="(350,440)"/>
+    <wire from="(350,1070)" to="(350,1080)"/>
+    <wire from="(220,680)" to="(220,820)"/>
+    <wire from="(360,1080)" to="(360,1100)"/>
+    <wire from="(160,2220)" to="(160,2370)"/>
+    <wire from="(360,440)" to="(360,470)"/>
+    <wire from="(260,3950)" to="(300,3950)"/>
+    <wire from="(140,1930)" to="(490,1930)"/>
+    <wire from="(560,4480)" to="(560,4520)"/>
+    <wire from="(510,50)" to="(540,50)"/>
+    <wire from="(350,530)" to="(380,530)"/>
+    <wire from="(350,850)" to="(380,850)"/>
+    <wire from="(320,1140)" to="(350,1140)"/>
+    <wire from="(280,470)" to="(300,470)"/>
+    <wire from="(550,4570)" to="(580,4570)"/>
+    <wire from="(510,1650)" to="(540,1650)"/>
+    <wire from="(540,2000)" to="(570,2000)"/>
+    <wire from="(360,3750)" to="(380,3750)"/>
+    <wire from="(180,770)" to="(180,890)"/>
+    <wire from="(200,790)" to="(200,910)"/>
+    <wire from="(280,4070)" to="(280,4190)"/>
+    <wire from="(80,4510)" to="(80,4640)"/>
+    <wire from="(660,110)" to="(660,1910)"/>
+    <wire from="(460,3020)" to="(460,3600)"/>
+    <wire from="(520,2720)" to="(580,2720)"/>
+    <wire from="(60,2250)" to="(60,2390)"/>
+    <wire from="(510,2090)" to="(550,2090)"/>
+    <wire from="(350,3120)" to="(350,3140)"/>
+    <wire from="(540,4680)" to="(580,4680)"/>
+    <wire from="(60,1390)" to="(490,1390)"/>
+    <wire from="(360,4090)" to="(360,4110)"/>
+    <wire from="(100,2690)" to="(100,4380)"/>
+    <wire from="(360,890)" to="(360,920)"/>
+    <wire from="(140,140)" to="(490,140)"/>
+    <wire from="(240,960)" to="(240,1060)"/>
+    <wire from="(320,3190)" to="(350,3190)"/>
+    <wire from="(220,940)" to="(220,1040)"/>
+    <wire from="(650,1920)" to="(680,1920)"/>
+    <wire from="(520,4350)" to="(550,4350)"/>
+    <wire from="(360,1320)" to="(380,1320)"/>
+    <wire from="(510,1780)" to="(540,1780)"/>
+    <wire from="(510,2420)" to="(540,2420)"/>
+    <wire from="(320,2880)" to="(340,2880)"/>
+    <wire from="(320,3520)" to="(340,3520)"/>
+    <wire from="(410,3920)" to="(440,3920)"/>
+    <wire from="(100,4660)" to="(500,4660)"/>
+    <wire from="(220,2850)" to="(300,2850)"/>
+    <wire from="(220,3490)" to="(300,3490)"/>
+    <wire from="(280,3550)" to="(360,3550)"/>
+    <wire from="(550,4410)" to="(550,4420)"/>
+    <wire from="(40,130)" to="(100,130)"/>
+    <wire from="(610,4550)" to="(660,4550)"/>
+    <wire from="(650,2000)" to="(650,2450)"/>
+    <wire from="(240,3520)" to="(240,3660)"/>
+    <wire from="(260,3540)" to="(260,3680)"/>
+    <wire from="(640,1610)" to="(640,1930)"/>
+    <wire from="(60,1840)" to="(490,1840)"/>
+    <wire from="(510,2220)" to="(550,2220)"/>
+    <wire from="(410,4040)" to="(450,4040)"/>
+    <wire from="(350,370)" to="(350,390)"/>
+    <wire from="(560,4420)" to="(560,4450)"/>
+    <wire from="(60,4620)" to="(60,4770)"/>
+    <wire from="(80,4640)" to="(80,4790)"/>
+    <wire from="(100,4660)" to="(100,4810)"/>
+    <wire from="(160,1520)" to="(160,1670)"/>
+    <wire from="(200,1260)" to="(200,2820)"/>
+    <wire from="(260,1330)" to="(300,1330)"/>
+    <wire from="(140,4420)" to="(500,4420)"/>
+    <wire from="(320,750)" to="(360,750)"/>
+    <wire from="(340,3330)" to="(380,3330)"/>
+    <wire from="(340,3650)" to="(380,3650)"/>
+    <wire from="(200,1020)" to="(300,1020)"/>
+    <wire from="(260,4290)" to="(350,4290)"/>
+    <wire from="(140,2190)" to="(490,2190)"/>
+    <wire from="(220,1280)" to="(220,2850)"/>
+    <wire from="(550,1640)" to="(570,1640)"/>
+    <wire from="(550,2600)" to="(570,2600)"/>
+    <wire from="(240,2880)" to="(240,3040)"/>
+    <wire from="(560,4850)" to="(580,4850)"/>
+    <wire from="(320,440)" to="(350,440)"/>
+    <wire from="(240,1300)" to="(240,2880)"/>
+    <wire from="(360,3050)" to="(380,3050)"/>
+    <wire from="(360,4010)" to="(380,4010)"/>
+    <wire from="(220,430)" to="(220,540)"/>
+    <wire from="(120,4560)" to="(580,4560)"/>
+    <wire from="(120,2330)" to="(570,2330)"/>
+    <wire from="(120,4830)" to="(500,4830)"/>
+    <wire from="(320,540)" to="(380,540)"/>
+    <wire from="(320,1180)" to="(380,1180)"/>
+    <wire from="(240,3340)" to="(300,3340)"/>
+    <wire from="(240,3660)" to="(300,3660)"/>
+    <wire from="(180,3100)" to="(360,3100)"/>
+    <wire from="(220,3630)" to="(220,3770)"/>
+    <wire from="(510,2010)" to="(570,2010)"/>
+    <wire from="(60,1550)" to="(60,1690)"/>
+    <wire from="(350,1140)" to="(350,1150)"/>
+    <wire from="(510,1390)" to="(550,1390)"/>
+    <wire from="(520,3640)" to="(560,3640)"/>
+    <wire from="(180,330)" to="(180,350)"/>
+    <wire from="(360,190)" to="(360,220)"/>
+    <wire from="(340,260)" to="(380,260)"/>
+    <wire from="(200,510)" to="(300,510)"/>
+    <wire from="(540,50)" to="(540,90)"/>
+    <wire from="(350,2840)" to="(380,2840)"/>
+    <wire from="(350,3480)" to="(380,3480)"/>
+    <wire from="(350,3800)" to="(380,3800)"/>
+    <wire from="(350,4120)" to="(380,4120)"/>
+    <wire from="(610,4390)" to="(630,4390)"/>
+    <wire from="(80,4640)" to="(550,4640)"/>
+    <wire from="(160,2610)" to="(160,2780)"/>
+    <wire from="(360,1260)" to="(380,1260)"/>
+    <wire from="(540,1430)" to="(570,1430)"/>
+    <wire from="(510,1720)" to="(540,1720)"/>
+    <wire from="(240,960)" to="(380,960)"/>
+    <wire from="(220,3310)" to="(220,3490)"/>
+    <wire from="(560,2630)" to="(560,2690)"/>
+    <wire from="(660,2010)" to="(660,2570)"/>
+    <wire from="(540,2420)" to="(540,2430)"/>
+    <wire from="(260,600)" to="(260,730)"/>
+    <wire from="(280,620)" to="(280,750)"/>
+    <wire from="(240,270)" to="(300,270)"/>
+    <wire from="(120,2720)" to="(500,2720)"/>
+    <wire from="(180,3720)" to="(180,3860)"/>
+    <wire from="(200,3740)" to="(200,3880)"/>
+    <wire from="(430,3650)" to="(430,3780)"/>
+    <wire from="(60,20)" to="(60,30)"/>
+    <wire from="(510,2460)" to="(570,2460)"/>
+    <wire from="(180,350)" to="(360,350)"/>
+    <wire from="(510,1520)" to="(550,1520)"/>
+    <wire from="(510,1840)" to="(550,1840)"/>
+    <wire from="(600,1610)" to="(640,1610)"/>
+    <wire from="(640,2720)" to="(640,4530)"/>
+    <wire from="(260,3190)" to="(300,3190)"/>
+    <wire from="(320,3250)" to="(360,3250)"/>
+    <wire from="(320,3570)" to="(360,3570)"/>
+    <wire from="(550,4350)" to="(550,4370)"/>
+    <wire from="(440,810)" to="(480,810)"/>
+    <wire from="(140,1490)" to="(490,1490)"/>
+    <wire from="(220,240)" to="(220,400)"/>
+    <wire from="(550,1580)" to="(570,1580)"/>
+    <wire from="(550,2540)" to="(570,2540)"/>
+    <wire from="(220,4250)" to="(380,4250)"/>
+    <wire from="(660,2010)" to="(680,2010)"/>
+    <wire from="(560,4790)" to="(580,4790)"/>
+    <wire from="(320,1020)" to="(350,1020)"/>
+    <wire from="(520,4420)" to="(550,4420)"/>
+    <wire from="(320,710)" to="(340,710)"/>
+    <wire from="(360,2990)" to="(380,2990)"/>
+    <wire from="(280,4190)" to="(300,4190)"/>
+    <wire from="(540,1880)" to="(570,1880)"/>
+    <wire from="(360,3950)" to="(380,3950)"/>
+    <wire from="(40,180)" to="(120,180)"/>
+    <wire from="(220,680)" to="(300,680)"/>
+    <wire from="(240,710)" to="(240,840)"/>
+    <wire from="(260,730)" to="(260,860)"/>
+    <wire from="(280,750)" to="(280,880)"/>
+    <wire from="(350,4280)" to="(350,4290)"/>
+    <wire from="(360,4290)" to="(360,4300)"/>
+    <wire from="(180,1120)" to="(360,1120)"/>
+    <wire from="(360,770)" to="(360,800)"/>
+    <wire from="(260,440)" to="(300,440)"/>
+    <wire from="(320,3700)" to="(360,3700)"/>
+    <wire from="(280,880)" to="(280,980)"/>
+    <wire from="(320,3070)" to="(350,3070)"/>
+    <wire from="(550,2350)" to="(570,2350)"/>
+    <wire from="(320,510)" to="(350,510)"/>
+    <wire from="(610,2720)" to="(640,2720)"/>
+    <wire from="(540,90)" to="(570,90)"/>
+    <wire from="(360,1200)" to="(380,1200)"/>
+    <wire from="(510,1980)" to="(540,1980)"/>
+    <wire from="(180,3980)" to="(180,4090)"/>
+    <wire from="(200,4000)" to="(200,4110)"/>
+    <wire from="(260,860)" to="(260,970)"/>
+    <wire from="(600,1750)" to="(630,1750)"/>
+    <wire from="(260,4060)" to="(260,4170)"/>
+    <wire from="(100,4540)" to="(500,4540)"/>
+    <wire from="(160,4600)" to="(560,4600)"/>
+    <wire from="(100,2310)" to="(490,2310)"/>
+    <wire from="(160,2370)" to="(550,2370)"/>
+    <wire from="(100,4540)" to="(100,4660)"/>
+    <wire from="(220,820)" to="(220,940)"/>
+    <wire from="(120,1760)" to="(570,1760)"/>
+    <wire from="(240,840)" to="(240,960)"/>
+    <wire from="(320,2850)" to="(380,2850)"/>
+    <wire from="(320,3490)" to="(380,3490)"/>
+    <wire from="(540,1720)" to="(540,1730)"/>
+    <wire from="(530,2030)" to="(530,2040)"/>
+    <wire from="(440,3620)" to="(490,3620)"/>
+    <wire from="(120,4560)" to="(120,4690)"/>
+    <wire from="(140,4580)" to="(140,4720)"/>
+    <wire from="(120,110)" to="(490,110)"/>
+    <wire from="(440,3660)" to="(440,3920)"/>
+    <wire from="(80,2280)" to="(80,2420)"/>
+    <wire from="(340,560)" to="(340,570)"/>
+    <wire from="(160,4600)" to="(160,4750)"/>
+    <wire from="(120,2720)" to="(120,4400)"/>
+    <wire from="(280,980)" to="(380,980)"/>
+    <wire from="(200,2820)" to="(300,2820)"/>
+    <wire from="(200,3460)" to="(300,3460)"/>
+    <wire from="(350,570)" to="(350,600)"/>
+    <wire from="(540,2040)" to="(540,2060)"/>
+    <wire from="(550,2050)" to="(550,2070)"/>
+    <wire from="(560,4620)" to="(560,4640)"/>
+    <wire from="(260,4170)" to="(350,4170)"/>
+    <wire from="(410,1050)" to="(440,1050)"/>
+    <wire from="(550,2480)" to="(570,2480)"/>
+    <wire from="(630,4560)" to="(630,4670)"/>
+    <wire from="(520,4690)" to="(540,4690)"/>
+    <wire from="(350,670)" to="(380,670)"/>
+    <wire from="(350,1310)" to="(380,1310)"/>
+    <wire from="(430,840)" to="(430,950)"/>
+    <wire from="(460,790)" to="(480,790)"/>
+    <wire from="(540,2140)" to="(570,2140)"/>
+    <wire from="(360,3890)" to="(380,3890)"/>
+    <wire from="(360,580)" to="(360,620)"/>
+    <wire from="(220,940)" to="(300,940)"/>
+    <wire from="(240,1300)" to="(300,1300)"/>
+    <wire from="(60,2390)" to="(60,2520)"/>
+    <wire from="(320,1060)" to="(380,1060)"/>
+    <wire from="(120,4690)" to="(120,4830)"/>
+    <wire from="(350,1020)" to="(350,1030)"/>
+    <wire from="(600,2320)" to="(640,2320)"/>
+    <wire from="(520,4480)" to="(560,4480)"/>
+    <wire from="(200,4230)" to="(300,4230)"/>
+    <wire from="(160,280)" to="(160,1520)"/>
+    <wire from="(40,230)" to="(140,230)"/>
+    <wire from="(410,1170)" to="(450,1170)"/>
+    <wire from="(350,3040)" to="(380,3040)"/>
+    <wire from="(550,2290)" to="(570,2290)"/>
+    <wire from="(260,2910)" to="(260,3070)"/>
+    <wire from="(600,2020)" to="(620,2020)"/>
+    <wire from="(550,4840)" to="(580,4840)"/>
+    <wire from="(260,1330)" to="(260,2910)"/>
+    <wire from="(360,1140)" to="(380,1140)"/>
+    <wire from="(540,1630)" to="(570,1630)"/>
+    <wire from="(320,3340)" to="(340,3340)"/>
+    <wire from="(320,3660)" to="(340,3660)"/>
+    <wire from="(540,2590)" to="(570,2590)"/>
+    <wire from="(60,2520)" to="(60,2630)"/>
+    <wire from="(240,840)" to="(380,840)"/>
+    <wire from="(140,2600)" to="(540,2600)"/>
+    <wire from="(220,3310)" to="(300,3310)"/>
+    <wire from="(160,4860)" to="(560,4860)"/>
+    <wire from="(220,3630)" to="(300,3630)"/>
+    <wire from="(160,1670)" to="(550,1670)"/>
+    <wire from="(450,3670)" to="(450,4040)"/>
+    <wire from="(80,2540)" to="(80,2660)"/>
+    <wire from="(100,2560)" to="(100,2690)"/>
+    <wire from="(410,1290)" to="(460,1290)"/>
+    <wire from="(180,2960)" to="(180,3100)"/>
+    <wire from="(200,2980)" to="(200,3120)"/>
+    <wire from="(240,3660)" to="(240,3800)"/>
+    <wire from="(260,3680)" to="(260,3820)"/>
+    <wire from="(280,3700)" to="(280,3840)"/>
+    <wire from="(80,1580)" to="(80,1720)"/>
+    <wire from="(100,1600)" to="(100,1740)"/>
+    <wire from="(120,1620)" to="(120,1760)"/>
+    <wire from="(440,850)" to="(440,1050)"/>
+    <wire from="(120,2580)" to="(120,2720)"/>
+    <wire from="(350,510)" to="(350,530)"/>
+    <wire from="(540,2710)" to="(580,2710)"/>
+    <wire from="(140,2600)" to="(140,2750)"/>
+    <wire from="(360,3720)" to="(360,3750)"/>
+    <wire from="(540,1980)" to="(540,2000)"/>
+    <wire from="(260,3070)" to="(300,3070)"/>
+    <wire from="(340,3790)" to="(380,3790)"/>
+    <wire from="(320,2820)" to="(350,2820)"/>
+    <wire from="(320,3460)" to="(350,3460)"/>
+    <wire from="(550,1780)" to="(570,1780)"/>
+    <wire from="(550,2420)" to="(570,2420)"/>
+    <wire from="(560,2750)" to="(580,2750)"/>
+    <wire from="(220,4130)" to="(380,4130)"/>
+    <wire from="(350,930)" to="(380,930)"/>
+    <wire from="(320,270)" to="(340,270)"/>
+    <wire from="(550,4650)" to="(580,4650)"/>
+    <wire from="(460,3600)" to="(490,3600)"/>
+    <wire from="(510,140)" to="(530,140)"/>
+    <wire from="(360,3190)" to="(380,3190)"/>
+    <wire from="(640,4570)" to="(640,4820)"/>
+    <wire from="(240,3340)" to="(240,3520)"/>
+    <wire from="(220,240)" to="(300,240)"/>
+    <wire from="(100,2690)" to="(500,2690)"/>
+    <wire from="(280,620)" to="(360,620)"/>
+    <wire from="(320,680)" to="(380,680)"/>
+    <wire from="(240,3800)" to="(300,3800)"/>
+    <wire from="(460,3680)" to="(460,4140)"/>
+    <wire from="(410,3020)" to="(460,3020)"/>
+    <wire from="(220,3770)" to="(220,3910)"/>
+    <wire from="(120,1460)" to="(490,1460)"/>
+    <wire from="(510,2150)" to="(570,2150)"/>
+    <wire from="(340,2870)" to="(340,2880)"/>
+    <wire from="(340,3510)" to="(340,3520)"/>
+    <wire from="(350,4160)" to="(350,4170)"/>
+    <wire from="(180,1000)" to="(360,1000)"/>
+    <wire from="(350,3520)" to="(350,3540)"/>
+    <wire from="(360,3530)" to="(360,3550)"/>
+    <wire from="(360,4170)" to="(360,4190)"/>
+    <wire from="(240,270)" to="(240,420)"/>
+    <wire from="(60,1690)" to="(60,1840)"/>
+    <wire from="(350,2880)" to="(350,2910)"/>
+    <wire from="(540,1470)" to="(540,1490)"/>
+    <wire from="(320,2940)" to="(360,2940)"/>
+    <wire from="(200,650)" to="(300,650)"/>
+    <wire from="(80,50)" to="(80,80)"/>
+    <wire from="(550,1480)" to="(550,1520)"/>
+    <wire from="(350,3300)" to="(380,3300)"/>
+    <wire from="(320,4230)" to="(350,4230)"/>
+    <wire from="(350,3620)" to="(380,3620)"/>
+    <wire from="(350,3940)" to="(380,3940)"/>
+    <wire from="(100,1600)" to="(570,1600)"/>
+    <wire from="(650,2000)" to="(680,2000)"/>
+    <wire from="(100,2560)" to="(570,2560)"/>
+    <wire from="(360,440)" to="(380,440)"/>
+    <wire from="(360,1080)" to="(380,1080)"/>
+    <wire from="(630,4540)" to="(660,4540)"/>
+    <wire from="(450,860)" to="(450,1170)"/>
+    <wire from="(360,2890)" to="(360,2940)"/>
+    <wire from="(160,2500)" to="(490,2500)"/>
+    <wire from="(180,3860)" to="(180,3980)"/>
+    <wire from="(200,3880)" to="(200,4000)"/>
+    <wire from="(450,410)" to="(450,800)"/>
+    <wire from="(120,180)" to="(120,1460)"/>
+    <wire from="(540,1920)" to="(540,1930)"/>
+    <wire from="(40,280)" to="(160,280)"/>
+    <wire from="(450,3160)" to="(450,3610)"/>
+    <wire from="(180,490)" to="(360,490)"/>
+    <wire from="(520,2630)" to="(560,2630)"/>
+    <wire from="(360,3980)" to="(360,4010)"/>
+    <wire from="(550,1930)" to="(550,1950)"/>
+    <wire from="(410,3160)" to="(450,3160)"/>
+    <wire from="(80,4510)" to="(500,4510)"/>
+    <wire from="(550,2250)" to="(550,2290)"/>
+    <wire from="(220,4030)" to="(220,4130)"/>
+    <wire from="(240,4050)" to="(240,4150)"/>
+    <wire from="(80,2280)" to="(490,2280)"/>
+    <wire from="(550,1720)" to="(570,1720)"/>
+    <wire from="(560,2690)" to="(580,2690)"/>
+    <wire from="(350,230)" to="(380,230)"/>
+    <wire from="(350,1190)" to="(380,1190)"/>
+    <wire from="(360,3130)" to="(380,3130)"/>
+    <wire from="(510,80)" to="(530,80)"/>
+    <wire from="(540,2340)" to="(570,2340)"/>
+    <wire from="(410,3500)" to="(430,3500)"/>
+    <wire from="(470,3690)" to="(470,4260)"/>
+    <wire from="(220,820)" to="(300,820)"/>
+    <wire from="(280,880)" to="(360,880)"/>
+    <wire from="(630,1750)" to="(630,1940)"/>
+    <wire from="(100,80)" to="(490,80)"/>
+    <wire from="(240,1180)" to="(300,1180)"/>
+    <wire from="(100,2310)" to="(100,2440)"/>
+    <wire from="(120,2330)" to="(120,2460)"/>
+    <wire from="(320,940)" to="(380,940)"/>
+    <wire from="(140,2350)" to="(140,2480)"/>
+    <wire from="(160,2370)" to="(160,2500)"/>
+    <wire from="(140,2750)" to="(140,4420)"/>
+    <wire from="(120,2040)" to="(490,2040)"/>
+    <wire from="(180,3430)" to="(300,3430)"/>
+    <wire from="(520,4660)" to="(580,4660)"/>
+    <wire from="(510,830)" to="(550,830)"/>
+    <wire from="(350,2820)" to="(350,2840)"/>
+    <wire from="(350,3460)" to="(350,3480)"/>
+    <wire from="(280,1210)" to="(280,1360)"/>
+    <wire from="(360,1230)" to="(360,1260)"/>
+    <wire from="(200,4110)" to="(300,4110)"/>
+    <wire from="(530,120)" to="(530,140)"/>
+    <wire from="(540,2690)" to="(540,2710)"/>
+    <wire from="(410,410)" to="(450,410)"/>
+    <wire from="(320,3840)" to="(360,3840)"/>
+    <wire from="(200,910)" to="(300,910)"/>
+    <wire from="(540,130)" to="(540,170)"/>
+    <wire from="(460,870)" to="(460,1290)"/>
+    <wire from="(260,3540)" to="(350,3540)"/>
+    <wire from="(470,3690)" to="(490,3690)"/>
+    <wire from="(600,1900)" to="(620,1900)"/>
+    <wire from="(560,4420)" to="(580,4420)"/>
+    <wire from="(320,650)" to="(350,650)"/>
+    <wire from="(360,380)" to="(380,380)"/>
+    <wire from="(360,1020)" to="(380,1020)"/>
+    <wire from="(510,2120)" to="(540,2120)"/>
+    <wire from="(540,2470)" to="(570,2470)"/>
+    <wire from="(160,2500)" to="(160,2610)"/>
+    <wire from="(140,2480)" to="(540,2480)"/>
+    <wire from="(80,2420)" to="(80,2540)"/>
+    <wire from="(100,2440)" to="(100,2560)"/>
+    <wire from="(120,2460)" to="(120,2580)"/>
+    <wire from="(140,2480)" to="(140,2600)"/>
+    <wire from="(410,830)" to="(480,830)"/>
+    <wire from="(320,3310)" to="(380,3310)"/>
+    <wire from="(320,3630)" to="(380,3630)"/>
+    <wire from="(320,4270)" to="(380,4270)"/>
+    <wire from="(540,2180)" to="(540,2190)"/>
+    <wire from="(140,4720)" to="(140,4850)"/>
+    <wire from="(350,4230)" to="(350,4240)"/>
+    <wire from="(340,700)" to="(340,710)"/>
+    <wire from="(350,710)" to="(350,730)"/>
+    <wire from="(280,2940)" to="(280,3090)"/>
+    <wire from="(550,1550)" to="(550,1580)"/>
+    <wire from="(550,2190)" to="(550,2220)"/>
+    <wire from="(360,2960)" to="(360,2990)"/>
+    <wire from="(200,3280)" to="(300,3280)"/>
+    <wire from="(200,3600)" to="(300,3600)"/>
+    <wire from="(360,720)" to="(360,750)"/>
+    <wire from="(340,3030)" to="(380,3030)"/>
+    <wire from="(60,4320)" to="(60,4480)"/>
+    <wire from="(410,550)" to="(440,550)"/>
+    <wire from="(80,1580)" to="(490,1580)"/>
+    <wire from="(80,2540)" to="(490,2540)"/>
+    <wire from="(350,810)" to="(380,810)"/>
+    <wire from="(280,750)" to="(300,750)"/>
+    <wire from="(550,4530)" to="(580,4530)"/>
+    <wire from="(280,1360)" to="(280,2940)"/>
+    <wire from="(510,1930)" to="(540,1930)"/>
+    <wire from="(240,4050)" to="(380,4050)"/>
+    <wire from="(560,2750)" to="(560,3640)"/>
+    <wire from="(40,330)" to="(180,330)"/>
+    <wire from="(80,80)" to="(80,1420)"/>
+    <wire from="(320,240)" to="(380,240)"/>
+    <wire from="(140,1650)" to="(140,1780)"/>
+    <wire from="(240,3040)" to="(300,3040)"/>
+    <wire from="(510,110)" to="(570,110)"/>
+    <wire from="(600,2450)" to="(650,2450)"/>
+    <wire from="(180,2800)" to="(360,2800)"/>
+    <wire from="(220,3010)" to="(220,3150)"/>
+    <wire from="(200,370)" to="(200,380)"/>
+    <wire from="(160,1670)" to="(160,1810)"/>
+    <wire from="(520,4620)" to="(560,4620)"/>
+    <wire from="(80,2660)" to="(500,2660)"/>
+    <wire from="(200,210)" to="(300,210)"/>
+    <wire from="(350,3180)" to="(380,3180)"/>
+    <wire from="(320,4110)" to="(350,4110)"/>
+    <wire from="(560,4360)" to="(580,4360)"/>
+    <wire from="(320,910)" to="(350,910)"/>
+    <wire from="(100,2440)" to="(570,2440)"/>
+    <wire from="(410,690)" to="(430,690)"/>
+    <wire from="(510,1420)" to="(540,1420)"/>
+    <wire from="(320,3800)" to="(340,3800)"/>
+    <wire from="(540,1770)" to="(570,1770)"/>
+    <wire from="(550,2740)" to="(580,2740)"/>
+    <wire from="(260,3370)" to="(260,3540)"/>
+    <wire from="(220,3770)" to="(300,3770)"/>
+    <wire from="(410,3640)" to="(490,3640)"/>
+    <wire from="(540,4680)" to="(540,4690)"/>
+    <wire from="(280,3840)" to="(280,3970)"/>
+    <wire from="(240,3800)" to="(240,3930)"/>
+    <wire from="(260,3820)" to="(260,3950)"/>
+    <wire from="(180,4210)" to="(360,4210)"/>
+    <wire from="(260,300)" to="(260,440)"/>
+    <wire from="(620,1950)" to="(680,1950)"/>
+    <wire from="(600,2570)" to="(660,2570)"/>
+    <wire from="(510,2500)" to="(550,2500)"/>
+    <wire from="(350,650)" to="(350,670)"/>
+    <wire from="(640,1990)" to="(680,1990)"/>
+    <wire from="(470,2860)" to="(470,3590)"/>
+    <wire from="(520,4750)" to="(560,4750)"/>
+    <wire from="(180,3100)" to="(180,3250)"/>
+    <wire from="(550,4690)" to="(550,4720)"/>
+    <wire from="(80,1720)" to="(80,1870)"/>
+    <wire from="(100,1740)" to="(100,1890)"/>
+    <wire from="(120,1760)" to="(120,1910)"/>
+    <wire from="(140,1780)" to="(140,1930)"/>
+    <wire from="(360,3860)" to="(360,3890)"/>
+    <wire from="(540,2120)" to="(540,2140)"/>
+    <wire from="(260,730)" to="(350,730)"/>
+    <wire from="(280,3970)" to="(280,4070)"/>
+    <wire from="(320,3280)" to="(350,3280)"/>
+    <wire from="(320,3600)" to="(350,3600)"/>
+    <wire from="(200,3120)" to="(200,3280)"/>
+    <wire from="(350,430)" to="(380,430)"/>
+    <wire from="(350,1070)" to="(380,1070)"/>
+    <wire from="(640,4570)" to="(660,4570)"/>
+    <wire from="(510,1870)" to="(540,1870)"/>
+    <wire from="(510,2190)" to="(540,2190)"/>
+    <wire from="(460,870)" to="(480,870)"/>
+    <wire from="(360,4290)" to="(380,4290)"/>
+    <wire from="(260,3950)" to="(260,4060)"/>
+    <wire from="(280,580)" to="(280,620)"/>
+    <wire from="(100,80)" to="(100,130)"/>
+    <wire from="(560,4700)" to="(560,4750)"/>
+    <wire from="(220,3910)" to="(220,4030)"/>
+    <wire from="(240,3930)" to="(240,4050)"/>
+    <wire from="(240,1060)" to="(300,1060)"/>
+    <wire from="(320,820)" to="(380,820)"/>
+    <wire from="(60,4480)" to="(500,4480)"/>
+    <wire from="(340,3330)" to="(340,3340)"/>
+    <wire from="(340,3650)" to="(340,3660)"/>
+    <wire from="(520,4540)" to="(580,4540)"/>
+    <wire from="(180,350)" to="(180,490)"/>
+    <wire from="(60,2250)" to="(490,2250)"/>
+    <wire from="(350,3660)" to="(350,3680)"/>
+    <wire from="(350,3340)" to="(350,3370)"/>
+    <wire from="(360,3670)" to="(360,3700)"/>
+    <wire from="(280,4070)" to="(380,4070)"/>
+    <wire from="(650,1450)" to="(650,1920)"/>
+    <wire from="(320,3400)" to="(360,3400)"/>
+    <wire from="(200,790)" to="(300,790)"/>
+    <wire from="(40,380)" to="(200,380)"/>
+    <wire from="(550,2050)" to="(570,2050)"/>
+    <wire from="(350,3760)" to="(380,3760)"/>
+    <wire from="(320,210)" to="(350,210)"/>
+    <wire from="(80,50)" to="(490,50)"/>
+    <wire from="(610,4670)" to="(630,4670)"/>
+    <wire from="(100,1740)" to="(570,1740)"/>
+    <wire from="(360,580)" to="(380,580)"/>
+    <wire from="(410,950)" to="(430,950)"/>
+    <wire from="(280,3700)" to="(300,3700)"/>
+    <wire from="(180,1120)" to="(180,1230)"/>
+    <wire from="(550,20)" to="(550,80)"/>
+    <wire from="(280,1210)" to="(360,1210)"/>
+    <wire from="(360,3350)" to="(360,3400)"/>
+    <wire from="(220,4030)" to="(300,4030)"/>
+    <wire from="(100,2010)" to="(490,2010)"/>
+    <wire from="(160,2070)" to="(550,2070)"/>
+    <wire from="(200,1140)" to="(200,1260)"/>
+    <wire from="(220,1160)" to="(220,1280)"/>
+    <wire from="(240,1180)" to="(240,1300)"/>
+    <wire from="(540,1420)" to="(540,1430)"/>
+    <wire from="(320,4150)" to="(380,4150)"/>
+    <wire from="(60,1960)" to="(60,2090)"/>
+    <wire from="(160,2780)" to="(160,4450)"/>
+    <wire from="(260,1200)" to="(260,1330)"/>
+    <wire from="(510,1460)" to="(570,1460)"/>
+    <wire from="(350,4110)" to="(350,4120)"/>
+    <wire from="(80,1980)" to="(80,2120)"/>
+    <wire from="(340,260)" to="(340,270)"/>
+    <wire from="(180,630)" to="(360,630)"/>
+    <wire from="(350,910)" to="(350,930)"/>
+    <wire from="(640,1930)" to="(680,1930)"/>
+    <wire from="(550,2390)" to="(550,2420)"/>
+    <wire from="(350,270)" to="(350,300)"/>
+    <wire from="(320,330)" to="(360,330)"/>
+    <wire from="(560,4320)" to="(560,4360)"/>
+    <wire from="(80,2420)" to="(490,2420)"/>
+    <wire from="(550,4410)" to="(580,4410)"/>
+    <wire from="(510,1490)" to="(540,1490)"/>
+    <wire from="(460,3680)" to="(490,3680)"/>
+    <wire from="(160,4750)" to="(160,4860)"/>
+    <wire from="(520,2780)" to="(550,2780)"/>
+    <wire from="(360,4230)" to="(380,4230)"/>
+    <wire from="(240,3930)" to="(380,3930)"/>
+    <wire from="(160,1810)" to="(490,1810)"/>
+    <wire from="(360,280)" to="(360,330)"/>
+    <wire from="(120,1910)" to="(570,1910)"/>
+    <wire from="(540,1870)" to="(540,1880)"/>
+    <wire from="(180,3250)" to="(300,3250)"/>
+    <wire from="(180,3570)" to="(300,3570)"/>
+    <wire from="(510,2250)" to="(550,2250)"/>
+    <wire from="(350,3280)" to="(350,3300)"/>
+    <wire from="(60,1550)" to="(490,1550)"/>
+    <wire from="(350,3600)" to="(350,3620)"/>
+    <wire from="(240,480)" to="(240,570)"/>
+    <wire from="(320,1100)" to="(360,1100)"/>
+    <wire from="(550,2520)" to="(550,2540)"/>
+    <wire from="(560,4770)" to="(560,4790)"/>
+    <wire from="(60,2090)" to="(60,2250)"/>
+    <wire from="(140,4850)" to="(550,4850)"/>
+    <wire from="(260,3680)" to="(350,3680)"/>
+    <wire from="(80,4350)" to="(80,4510)"/>
+    <wire from="(550,1990)" to="(570,1990)"/>
+    <wire from="(350,4020)" to="(380,4020)"/>
+    <wire from="(320,790)" to="(350,790)"/>
+    <wire from="(520,4510)" to="(550,4510)"/>
+    <wire from="(360,520)" to="(380,520)"/>
+    <wire from="(320,3040)" to="(340,3040)"/>
+    <wire from="(220,3010)" to="(300,3010)"/>
+    <wire from="(550,4570)" to="(550,4580)"/>
+    <wire from="(320,3770)" to="(380,3770)"/>
+    <wire from="(240,3040)" to="(240,3170)"/>
+    <wire from="(180,4090)" to="(360,4090)"/>
+    <wire from="(60,2630)" to="(500,2630)"/>
+    <wire from="(40,430)" to="(220,430)"/>
+    <wire from="(350,850)" to="(350,860)"/>
+    <wire from="(180,890)" to="(360,890)"/>
+    <wire from="(350,210)" to="(350,230)"/>
+    <wire from="(360,860)" to="(360,880)"/>
+    <wire from="(540,2730)" to="(580,2730)"/>
+    <wire from="(280,3400)" to="(280,3550)"/>
+    <wire from="(550,1690)" to="(550,1720)"/>
+    <wire from="(360,3100)" to="(360,3130)"/>
+    <wire from="(200,3740)" to="(300,3740)"/>
+    <wire from="(140,4580)" to="(500,4580)"/>
+    <wire from="(320,1230)" to="(360,1230)"/>
+    <wire from="(630,4390)" to="(630,4540)"/>
+    <wire from="(220,400)" to="(220,430)"/>
+    <wire from="(560,4580)" to="(560,4600)"/>
+    <wire from="(140,2350)" to="(490,2350)"/>
+    <wire from="(80,1720)" to="(490,1720)"/>
+    <wire from="(550,1480)" to="(570,1480)"/>
+    <wire from="(660,1910)" to="(680,1910)"/>
+    <wire from="(710,1960)" to="(730,1960)"/>
+    <wire from="(320,600)" to="(350,600)"/>
+    <wire from="(350,1270)" to="(380,1270)"/>
+    <wire from="(600,2160)" to="(630,2160)"/>
+    <wire from="(360,2890)" to="(380,2890)"/>
+    <wire from="(360,3530)" to="(380,3530)"/>
+    <wire from="(360,4170)" to="(380,4170)"/>
+    <wire from="(120,4400)" to="(580,4400)"/>
+    <wire from="(120,2170)" to="(570,2170)"/>
+    <wire from="(240,420)" to="(240,480)"/>
+    <wire from="(440,550)" to="(440,810)"/>
+    <wire from="(630,1980)" to="(680,1980)"/>
+    <wire from="(430,820)" to="(480,820)"/>
+    <wire from="(180,3430)" to="(180,3570)"/>
+    <wire from="(280,330)" to="(280,470)"/>
+    <wire from="(160,1810)" to="(160,1950)"/>
+    <wire from="(510,1550)" to="(550,1550)"/>
+    <wire from="(60,2520)" to="(550,2520)"/>
+    <wire from="(360,350)" to="(360,380)"/>
+    <wire from="(320,1360)" to="(360,1360)"/>
+    <wire from="(260,440)" to="(260,530)"/>
+    <wire from="(60,1390)" to="(60,1550)"/>
+    <wire from="(350,3000)" to="(380,3000)"/>
+    <wire from="(100,4810)" to="(580,4810)"/>
+    <wire from="(220,3150)" to="(220,3310)"/>
+    <wire from="(450,860)" to="(480,860)"/>
+    <wire from="(550,1930)" to="(570,1930)"/>
+    <wire from="(350,4280)" to="(380,4280)"/>
+    <wire from="(160,4750)" to="(500,4750)"/>
+    <wire from="(550,4800)" to="(580,4800)"/>
+    <wire from="(280,2940)" to="(300,2940)"/>
+    <wire from="(630,4560)" to="(660,4560)"/>
+    <wire from="(540,1590)" to="(570,1590)"/>
+    <wire from="(280,1100)" to="(280,1210)"/>
+    <wire from="(540,2550)" to="(570,2550)"/>
+    <wire from="(240,3170)" to="(240,3340)"/>
+    <wire from="(260,3190)" to="(260,3370)"/>
+    <wire from="(220,3910)" to="(300,3910)"/>
+    <wire from="(280,3970)" to="(360,3970)"/>
+    <wire from="(160,1950)" to="(550,1950)"/>
+    <wire from="(60,1840)" to="(60,1960)"/>
+    <wire from="(180,1000)" to="(180,1120)"/>
+    <wire from="(200,1020)" to="(200,1140)"/>
+    <wire from="(220,1040)" to="(220,1160)"/>
+    <wire from="(240,1060)" to="(240,1180)"/>
+    <wire from="(260,1080)" to="(260,1200)"/>
+    <wire from="(240,4270)" to="(300,4270)"/>
+    <wire from="(200,380)" to="(200,510)"/>
+    <wire from="(320,4030)" to="(380,4030)"/>
+    <wire from="(120,110)" to="(120,180)"/>
+    <wire from="(180,190)" to="(360,190)"/>
+    <wire from="(530,100)" to="(570,100)"/>
+    <wire from="(350,790)" to="(350,810)"/>
+    <wire from="(360,1120)" to="(360,1140)"/>
+    <wire from="(60,20)" to="(490,20)"/>
+    <wire from="(200,4000)" to="(300,4000)"/>
+    <wire from="(550,4510)" to="(550,4530)"/>
+    <wire from="(140,1650)" to="(490,1650)"/>
+    <wire from="(550,140)" to="(570,140)"/>
+    <wire from="(80,1980)" to="(490,1980)"/>
+    <wire from="(320,3740)" to="(350,3740)"/>
+    <wire from="(550,1420)" to="(570,1420)"/>
+    <wire from="(350,570)" to="(380,570)"/>
+    <wire from="(320,860)" to="(350,860)"/>
+    <wire from="(520,4580)" to="(550,4580)"/>
+    <wire from="(360,2830)" to="(380,2830)"/>
+    <wire from="(540,2040)" to="(570,2040)"/>
+    <wire from="(520,2660)" to="(550,2660)"/>
+    <wire from="(360,3470)" to="(380,3470)"/>
+    <wire from="(360,4110)" to="(380,4110)"/>
+    <wire from="(240,3170)" to="(380,3170)"/>
+    <wire from="(40,480)" to="(240,480)"/>
+    <wire from="(550,4640)" to="(550,4650)"/>
+    <wire from="(60,4620)" to="(500,4620)"/>
+    <wire from="(260,970)" to="(380,970)"/>
+    <wire from="(430,3630)" to="(490,3630)"/>
+    <wire from="(340,3790)" to="(340,3800)"/>
+    <wire from="(100,2010)" to="(100,2150)"/>
+    <wire from="(180,490)" to="(180,630)"/>
+    <wire from="(200,510)" to="(200,650)"/>
+    <wire from="(510,1810)" to="(550,1810)"/>
+    <wire from="(60,2390)" to="(490,2390)"/>
+    <wire from="(450,3670)" to="(490,3670)"/>
+    <wire from="(350,3800)" to="(350,3820)"/>
+    <wire from="(690,4550)" to="(730,4550)"/>
+    <wire from="(160,2070)" to="(160,2220)"/>
+    <wire from="(360,3810)" to="(360,3840)"/>
+    <wire from="(260,600)" to="(300,600)"/>
+    <wire from="(320,3220)" to="(360,3220)"/>
+    <wire from="(140,1780)" to="(490,1780)"/>
+    <wire from="(320,2910)" to="(350,2910)"/>
+    <wire from="(450,800)" to="(480,800)"/>
+    <wire from="(550,1870)" to="(570,1870)"/>
+    <wire from="(550,2190)" to="(570,2190)"/>
+    <wire from="(410,3320)" to="(440,3320)"/>
+    <wire from="(350,3900)" to="(380,3900)"/>
+    <wire from="(360,720)" to="(380,720)"/>
+    <wire from="(280,3840)" to="(300,3840)"/>
+    <wire from="(100,4380)" to="(500,4380)"/>
+    <wire from="(240,420)" to="(380,420)"/>
+    <wire from="(100,2150)" to="(490,2150)"/>
+    <wire from="(550,140)" to="(550,830)"/>
+    <wire from="(320,3010)" to="(380,3010)"/>
+    <wire from="(180,770)" to="(360,770)"/>
+    <wire from="(200,2980)" to="(300,2980)"/>
+    <wire from="(320,470)" to="(360,470)"/>
+    <wire from="(510,20)" to="(550,20)"/>
+    <wire from="(80,4790)" to="(500,4790)"/>
+    <wire from="(80,2120)" to="(80,2280)"/>
+    <wire from="(100,4380)" to="(100,4540)"/>
+    <wire from="(120,4400)" to="(120,4560)"/>
+    <wire from="(550,80)" to="(570,80)"/>
+    <wire from="(410,3780)" to="(430,3780)"/>
+    <wire from="(320,4000)" to="(350,4000)"/>
+    <wire from="(140,4420)" to="(140,4580)"/>
+    <wire from="(350,1150)" to="(380,1150)"/>
+    <wire from="(540,2300)" to="(570,2300)"/>
+    <wire from="(260,3070)" to="(260,3190)"/>
+    <wire from="(280,3090)" to="(280,3220)"/>
+    <wire from="(510,2390)" to="(550,2390)"/>
+    <wire from="(450,3610)" to="(490,3610)"/>
+    <wire from="(520,4320)" to="(560,4320)"/>
+    <wire from="(60,1690)" to="(490,1690)"/>
+    <wire from="(350,3740)" to="(350,3760)"/>
+    <wire from="(60,2630)" to="(60,4320)"/>
+    <wire from="(460,250)" to="(460,790)"/>
+    <wire from="(530,80)" to="(530,100)"/>
+    <wire from="(260,860)" to="(300,860)"/>
+    <wire from="(550,2660)" to="(550,2700)"/>
+    <wire from="(260,3820)" to="(350,3820)"/>
+    <wire from="(220,1280)" to="(380,1280)"/>
+    <wire from="(350,2880)" to="(380,2880)"/>
+    <wire from="(40,530)" to="(260,530)"/>
+    <wire from="(550,2130)" to="(570,2130)"/>
+    <wire from="(350,3520)" to="(380,3520)"/>
+    <wire from="(350,4160)" to="(380,4160)"/>
+    <wire from="(560,4700)" to="(580,4700)"/>
+    <wire from="(360,660)" to="(380,660)"/>
+    <wire from="(540,1470)" to="(570,1470)"/>
+    <wire from="(540,2430)" to="(570,2430)"/>
+    <wire from="(360,3430)" to="(360,3470)"/>
+    <wire from="(220,3150)" to="(300,3150)"/>
+    <wire from="(280,980)" to="(280,1100)"/>
+    <comp lib="1" loc="(600,2570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,530)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,4550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,580)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,250)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(690,4550)" name="OR Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4830)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+  </circuit>
+</project>

--- a/src/pipeline_cpu.circ
+++ b/src/pipeline_cpu.circ
@@ -97,6 +97,7 @@
   </lib>
   <lib desc="file#common/alu.circ" name="7"/>
   <lib desc="file#common/regfile.circ" name="8"/>
+  <lib desc="file#common/control.circ" name="9"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -586,41 +587,338 @@
     <wire from="(730,560)" to="(740,560)"/>
     <wire from="(550,220)" to="(560,220)"/>
     <wire from="(490,1280)" to="(500,1280)"/>
-    <comp lib="6" loc="(857,539)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(950,470)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(550,1270)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
+    <comp lib="0" loc="(1120,160)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+      <a name="label" val="IsCOP0"/>
     </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
+    <comp lib="0" loc="(1220,1290)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RsOutput"/>
+    </comp>
+    <comp lib="0" loc="(1490,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(620,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="5" loc="(590,180)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(760,130)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(280,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsEretEX"/>
     </comp>
-    <comp lib="0" loc="(980,920)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpSrc1"/>
+    <comp lib="1" loc="(750,1290)" name="NOT Gate">
+      <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(460,560)" name="Splitter">
+    <comp lib="0" loc="(950,470)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(650,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="6" loc="(1347,1084)" name="Text">
+      <a name="text" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(680,1290)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Load/Use"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="2" loc="(1950,770)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1700,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="0" loc="(840,550)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1380,1130)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1780,1120)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(400,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="6" loc="(1316,692)" name="Text">
+      <a name="text" val="WriteReg#"/>
+    </comp>
+    <comp lib="0" loc="(480,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="2" loc="(720,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(210,1330)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(1340,590)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1110,540)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="0" loc="(1040,920)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="2" loc="(1000,690)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1140,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="6" loc="(1175,1145)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="2" loc="(2410,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(1315,765)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="2" loc="(260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(840,700)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(870,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(1110,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="0" loc="(1040,1060)" name="Tunnel">
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(2100,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="0" loc="(1670,1110)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
+    </comp>
+    <comp lib="0" loc="(840,510)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1760,60)" name="Tunnel">
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="0" loc="(1320,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RsOutput"/>
+    </comp>
+    <comp lib="6" loc="(584,110)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp lib="4" loc="(530,1270)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp loc="(360,1330)" name="Hazard Unit"/>
+    <comp lib="0" loc="(1980,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp loc="(1670,590)" name="ALU_Wrapper"/>
+    <comp lib="3" loc="(1530,1160)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(840,850)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(550,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="6" loc="(1443,1265)" name="Text">
+      <a name="text" val="Memory Result"/>
+    </comp>
+    <comp lib="6" loc="(1437,1244)" name="Text">
+      <a name="text" val="ALU Result"/>
+    </comp>
+    <comp lib="0" loc="(950,450)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="0" loc="(1940,590)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -635,7 +933,7 @@
       <a name="bit8" val="0"/>
       <a name="bit9" val="0"/>
       <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
+      <a name="bit11" val="0"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
       <a name="bit14" val="none"/>
@@ -657,24 +955,182 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(510,1300)" name="Tunnel">
+    <comp lib="1" loc="(440,700)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1070,770)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="1"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+      <a name="bit11" val="1"/>
+      <a name="bit12" val="1"/>
+      <a name="bit13" val="1"/>
+      <a name="bit14" val="1"/>
+      <a name="bit15" val="1"/>
+      <a name="bit16" val="1"/>
+      <a name="bit17" val="1"/>
+      <a name="bit18" val="1"/>
+      <a name="bit19" val="1"/>
+      <a name="bit20" val="1"/>
+      <a name="bit21" val="1"/>
+      <a name="bit22" val="1"/>
+      <a name="bit23" val="1"/>
+      <a name="bit24" val="1"/>
+      <a name="bit25" val="1"/>
+      <a name="bit26" val="1"/>
+      <a name="bit27" val="1"/>
+      <a name="bit28" val="2"/>
+      <a name="bit29" val="2"/>
+      <a name="bit30" val="2"/>
+      <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1090,500)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rs"/>
+    </comp>
+    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(1600,630)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(1165,1186)" name="Text">
+      <a name="text" val="Branch Addr"/>
+    </comp>
+    <comp lib="5" loc="(550,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(760,130)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(450,560)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(420,760)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(2100,590)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="0" loc="(1520,350)" name="Tunnel">
+      <a name="label" val="JumpEX"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(550,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1030,710)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="5" loc="(600,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp loc="(1290,180)" name="RegWrite_Decider"/>
+    <comp lib="0" loc="(840,250)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="0" loc="(490,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="0" loc="(970,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(2220,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
     </comp>
     <comp lib="0" loc="(1520,290)" name="Tunnel">
       <a name="label" val="IsJREX"/>
     </comp>
-    <comp lib="0" loc="(1480,1170)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(1380,1130)" name="Constant">
+    <comp lib="0" loc="(230,1330)" name="Constant">
       <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="2" loc="(220,1280)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(930,920)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="4" loc="(540,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1630,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="0" loc="(2250,460)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="2" loc="(1960,1070)" name="Multiplexer">
       <a name="facing" val="south"/>
@@ -682,36 +1138,28 @@
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1280,150)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
+    <comp lib="2" loc="(160,520)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp loc="(2230,460)" name="Syscall_Decoder"/>
-    <comp lib="4" loc="(530,1270)" name="Counter">
+    <comp lib="0" loc="(1720,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(390,340)" name="Counter">
       <a name="width" val="32"/>
       <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
     </comp>
-    <comp lib="6" loc="(862,240)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="0" loc="(1640,1090)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="4" loc="(470,340)" name="Counter">
+    <comp lib="2" loc="(310,550)" name="Multiplexer">
       <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(600,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(1160,480)" name="Tunnel">
+    <comp loc="(2160,140)" name="MEM/WB"/>
+    <comp lib="0" loc="(1560,160)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="6" loc="(1316,692)" name="Text">
-      <a name="text" val="WriteReg#"/>
+      <a name="label" val="RegWriteEX"/>
     </comp>
     <comp lib="0" loc="(830,880)" name="Splitter">
       <a name="facing" val="north"/>
@@ -751,79 +1199,11 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="2" loc="(1340,590)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
+    <comp lib="2" loc="(480,560)" name="Demultiplexer">
+      <a name="width" val="9"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="4" loc="(610,310)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="2" loc="(2410,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2170,1110)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1220,1290)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp lib="1" loc="(1710,340)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(550,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1110,540)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="6" loc="(2439,1205)" name="Text">
-      <a name="text" val="WB_DATA"/>
-    </comp>
-    <comp lib="0" loc="(1030,760)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1760,60)" name="Tunnel">
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="0" loc="(970,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="6" loc="(1347,1084)" name="Text">
-      <a name="text" val="IsEret"/>
-    </comp>
-    <comp lib="2" loc="(1000,690)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(980,990)" name="CP0"/>
-    <comp loc="(1670,590)" name="ALU_Wrapper"/>
-    <comp lib="1" loc="(1740,280)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(840,630)" name="Splitter">
+    <comp lib="0" loc="(460,710)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -833,6 +1213,180 @@
       <a name="bit3" val="none"/>
       <a name="bit4" val="none"/>
       <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(1167,1164)" name="Text">
+      <a name="text" val="Jump Addr"/>
+    </comp>
+    <comp lib="2" loc="(430,650)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(840,770)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(2010,695)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="0" loc="(2030,630)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp loc="(1120,490)" name="Regfile_Wrapper"/>
+    <comp lib="4" loc="(470,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="2" loc="(360,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="6" loc="(682,877)" name="Text">
+      <a name="text" val="PCPlus4IF"/>
+    </comp>
+    <comp lib="2" loc="(220,1280)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(710,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(2010,1050)" name="Tunnel">
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="0" loc="(840,330)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(340,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="2" loc="(210,530)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2010,750)" name="Tunnel">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(580,860)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(460,560)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
       <a name="bit6" val="0"/>
       <a name="bit7" val="0"/>
       <a name="bit8" val="0"/>
@@ -860,83 +1414,160 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="1" loc="(440,700)" name="NOT Gate">
-      <a name="facing" val="north"/>
+    <comp loc="(1770,150)" name="EX/MEM"/>
+    <comp lib="6" loc="(862,240)" name="Text">
+      <a name="text" val="OP"/>
     </comp>
-    <comp lib="0" loc="(2030,630)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(1570,1060)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp lib="6" loc="(1317,872)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="6" loc="(2439,1205)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="0" loc="(700,370)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(890,1030)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
+    <comp lib="2" loc="(2360,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1870,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(1190,630)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="3" loc="(1590,1150)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="1" loc="(1180,490)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1610,1110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="JumpEX"/>
+    </comp>
+    <comp loc="(950,830)" name="Immediate_Extend"/>
+    <comp lib="0" loc="(2220,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(1640,1090)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(2220,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
+    <comp lib="6" loc="(1214,627)" name="Text">
+      <a name="text" val="Shamt"/>
     </comp>
-    <comp lib="0" loc="(650,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
+    <comp lib="0" loc="(220,1270)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="4" loc="(670,650)" name="ROM">
-      <a name="addrWidth" val="9"/>
-      <a name="dataWidth" val="32"/>
-      <a name="contents">addr/data: 9 32
-201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
-401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
-23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
-23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
-1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
-20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
-23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
-8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
-23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
-8fda0000 409a0000 201a0000 409a0800 42000018
-</a>
+    <comp lib="0" loc="(1670,1130)" name="Tunnel">
+      <a name="label" val="IsJALEX"/>
     </comp>
-    <comp lib="0" loc="(1320,640)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(1030,760)" name="Constant">
       <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
+      <a name="value" val="0x0"/>
     </comp>
     <comp lib="2" loc="(1080,700)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="5"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(1180,490)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp loc="(890,150)" name="Control">
-      <a name="labelfont" val="Dialog plain 16"/>
-    </comp>
-    <comp lib="6" loc="(2010,695)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="1" loc="(390,1290)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(930,920)" name="Tunnel">
+    <comp lib="0" loc="(350,1350)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(1090,500)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="0" loc="(1040,1060)" name="Tunnel">
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(220,1270)" name="Tunnel">
-      <a name="facing" val="south"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="1" loc="(750,1290)" name="NOT Gate">
+    <comp loc="(2230,460)" name="Syscall_Decoder"/>
+    <comp lib="0" loc="(920,540)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(1050,950)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp loc="(680,360)" name="Statistics"/>
+    <comp lib="2" loc="(1530,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(980,920)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="3" loc="(640,850)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(550,1270)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(600,770)" name="Tunnel">
       <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(320,520)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x800"/>
+    </comp>
+    <comp lib="0" loc="(980,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="6" loc="(860,688)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="0" loc="(1880,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="6" loc="(857,539)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(250,1300)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(1200,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="0" loc="(930,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(1280,150)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
     </comp>
     <comp lib="0" loc="(730,560)" name="Splitter">
       <a name="facing" val="north"/>
@@ -976,154 +1607,51 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(840,250)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(340,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp loc="(2160,140)" name="MEM/WB"/>
-    <comp lib="5" loc="(710,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="2" loc="(430,650)" name="Multiplexer">
-      <a name="facing" val="north"/>
+    <comp lib="2" loc="(1340,500)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(1640,1190)" name="OR Gate">
-      <a name="facing" val="south"/>
+    <comp lib="1" loc="(380,670)" name="OR Gate">
       <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1490,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="2" loc="(210,530)" name="Multiplexer">
+    <comp lib="2" loc="(1500,550)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1560,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(320,520)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x800"/>
-    </comp>
-    <comp lib="0" loc="(1120,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="6" loc="(1175,1145)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp lib="4" loc="(450,560)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp loc="(680,360)" name="Statistics"/>
-    <comp lib="4" loc="(540,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="6" loc="(1579,1326)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="0" loc="(840,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1690,1040)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="3" loc="(1590,1150)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(2010,750)" name="Tunnel">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(1630,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="0" loc="(550,450)" name="Probe">
+    <comp lib="0" loc="(2190,1110)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1490,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="0" loc="(1320,640)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="0" loc="(330,660)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="5" loc="(650,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="6" loc="(1314,841)" name="Text">
+      <a name="text" val="Immediate"/>
+    </comp>
+    <comp lib="1" loc="(1710,340)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1740,280)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="4" loc="(670,550)" name="ROM">
       <a name="addrWidth" val="9"/>
@@ -1173,15 +1701,56 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp loc="(1290,180)" name="RegWrite_Decider"/>
-    <comp lib="0" loc="(1700,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
+    <comp lib="0" loc="(1480,1170)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
     </comp>
-    <comp lib="0" loc="(250,1300)" name="Tunnel">
-      <a name="label" val="Halt"/>
+    <comp loc="(1370,140)" name="ID/EX"/>
+    <comp lib="2" loc="(2460,590)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(460,710)" name="Splitter">
+    <comp lib="0" loc="(920,520)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="1" loc="(290,690)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(2166,1226)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="6" loc="(1579,1326)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="0" loc="(920,1070)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(510,1300)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1800,1120)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(390,1290)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="6" loc="(863,316)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(2170,1110)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1690,1040)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="0" loc="(840,630)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -1191,12 +1760,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit3" val="none"/>
       <a name="bit4" val="none"/>
       <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
       <a name="bit14" val="none"/>
@@ -1218,228 +1787,62 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="6" loc="(859,501)" name="Text">
-      <a name="text" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(420,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(950,450)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="6" loc="(1437,1244)" name="Text">
-      <a name="text" val="ALU Result"/>
-    </comp>
-    <comp lib="2" loc="(1340,500)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(740,140)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
-    </comp>
-    <comp loc="(360,1330)" name="Hazard Unit"/>
-    <comp lib="0" loc="(1140,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="0" loc="(1190,630)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1670,1110)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
-    </comp>
-    <comp lib="1" loc="(290,690)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1870,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="4" loc="(670,650)" name="ROM">
+      <a name="addrWidth" val="9"/>
+      <a name="dataWidth" val="32"/>
+      <a name="contents">addr/data: 9 32
+201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
+401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
+23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
+23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
+1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
+20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
+23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
+8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
+23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
+8fda0000 409a0000 201a0000 409a0800 42000018
+</a>
     </comp>
     <comp lib="0" loc="(520,420)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp loc="(1370,140)" name="ID/EX"/>
-    <comp lib="6" loc="(860,688)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="0" loc="(490,1280)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="6" loc="(1214,627)" name="Text">
-      <a name="text" val="Shamt"/>
-    </comp>
-    <comp lib="0" loc="(280,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="0" loc="(1800,1120)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(840,770)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(920,540)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="6" loc="(863,316)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(650,760)" name="Button">
+    <comp lib="0" loc="(1160,480)" name="Tunnel">
       <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
     </comp>
-    <comp loc="(1120,490)" name="Regfile_Wrapper"/>
-    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
+    <comp lib="0" loc="(1090,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rs"/>
     </comp>
-    <comp lib="0" loc="(210,1330)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(2010,1050)" name="Tunnel">
-      <a name="label" val="IsCOP0MEM"/>
-    </comp>
-    <comp lib="6" loc="(584,110)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="0" loc="(920,520)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
+    <comp lib="9" loc="(890,150)" name="Control"/>
+    <comp lib="4" loc="(610,310)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
     <comp lib="0" loc="(2290,510)" name="Tunnel">
       <a name="label" val="Halt"/>
     </comp>
-    <comp lib="0" loc="(1070,770)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="1"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="1"/>
-      <a name="bit9" val="1"/>
-      <a name="bit10" val="1"/>
-      <a name="bit11" val="1"/>
-      <a name="bit12" val="1"/>
-      <a name="bit13" val="1"/>
-      <a name="bit14" val="1"/>
-      <a name="bit15" val="1"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="2"/>
-      <a name="bit29" val="2"/>
-      <a name="bit30" val="2"/>
-      <a name="bit31" val="2"/>
+    <comp lib="1" loc="(1640,1190)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
     </comp>
-    <comp lib="6" loc="(1314,841)" name="Text">
-      <a name="text" val="Immediate"/>
+    <comp loc="(980,990)" name="CP0"/>
+    <comp lib="6" loc="(859,501)" name="Text">
+      <a name="text" val="RS"/>
     </comp>
-    <comp lib="0" loc="(1040,920)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
+    <comp loc="(740,140)" name="IF/ID">
+      <a name="labelfont" val="Monaco bold 44"/>
     </comp>
-    <comp lib="2" loc="(2360,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(920,1070)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="2" loc="(480,560)" name="Demultiplexer">
-      <a name="width" val="9"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
+    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(980,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="2" loc="(1530,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(870,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
     <comp lib="6" loc="(1656,674)" name="Text">
       <a name="text" val="WriteDataEX"/>
-    </comp>
-    <comp lib="0" loc="(2100,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0MEM"/>
     </comp>
     <comp lib="0" loc="(570,280)" name="Splitter">
       <a name="facing" val="north"/>
@@ -1478,4877 +1881,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="7"/>
       <a name="bit31" val="7"/>
     </comp>
-    <comp lib="0" loc="(1940,590)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp loc="(1770,150)" name="EX/MEM"/>
-    <comp lib="0" loc="(1110,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="0" loc="(550,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(400,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="6" loc="(682,877)" name="Text">
-      <a name="text" val="PCPlus4IF"/>
-    </comp>
-    <comp lib="1" loc="(380,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(1530,1160)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(840,700)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1670,1130)" name="Tunnel">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(1780,1120)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(840,850)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(1500,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1880,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="2" loc="(310,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="3" loc="(640,850)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(1167,1164)" name="Text">
-      <a name="text" val="Jump Addr"/>
-    </comp>
-    <comp lib="0" loc="(1720,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(1980,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(2190,1110)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(230,1330)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(480,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="6" loc="(1317,872)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="6" loc="(1443,1265)" name="Text">
-      <a name="text" val="Memory Result"/>
-    </comp>
-    <comp lib="2" loc="(1600,630)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(580,860)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(2250,460)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1490,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(1200,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-    </comp>
-    <comp lib="2" loc="(1950,770)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,1290)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Load/Use"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1090,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="0" loc="(330,660)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="5" loc="(600,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(840,330)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(930,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="2" loc="(160,520)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1570,1060)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="0" loc="(890,1030)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(700,370)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp loc="(950,830)" name="Immediate_Extend"/>
-    <comp lib="0" loc="(350,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(2220,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="0" loc="(620,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="6" loc="(1165,1186)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="2" loc="(720,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(360,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1520,350)" name="Tunnel">
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="2" loc="(2460,590)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(2100,590)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="0" loc="(840,510)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(1315,765)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(1030,710)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="0" loc="(1320,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp lib="0" loc="(1610,1110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="4" loc="(390,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="6" loc="(2166,1226)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="0" loc="(1050,950)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-  </circuit>
-  <circuit name="Control">
-    <a name="circuit" val="Control"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#4b00ff" height="342" stroke="#ffffff" stroke-width="2" width="33" x="60" y="160"/>
-      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="74" y="300">Ctrl</text>
-      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="75" y="323">Unit</text>
-      <circ-port height="8" pin="240,130" width="8" x="56" y="256"/>
-      <circ-port height="8" pin="460,130" width="8" x="56" y="336"/>
-      <circ-port height="10" pin="980,360" width="10" x="85" y="375"/>
-      <circ-port height="10" pin="260,170" width="10" x="85" y="175"/>
-      <circ-port height="10" pin="260,210" width="10" x="85" y="415"/>
-      <circ-port height="10" pin="260,250" width="10" x="85" y="215"/>
-      <circ-port height="10" pin="260,290" width="10" x="85" y="195"/>
-      <circ-port height="10" pin="480,170" width="10" x="85" y="275"/>
-      <circ-port height="10" pin="480,210" width="10" x="85" y="255"/>
-      <circ-port height="10" pin="480,250" width="10" x="85" y="355"/>
-      <circ-port height="10" pin="480,290" width="10" x="85" y="315"/>
-      <circ-port height="10" pin="480,330" width="10" x="85" y="455"/>
-      <circ-port height="10" pin="260,330" width="10" x="85" y="335"/>
-      <circ-port height="10" pin="260,370" width="10" x="85" y="395"/>
-      <circ-port height="10" pin="480,370" width="10" x="85" y="295"/>
-      <circ-port height="10" pin="260,410" width="10" x="85" y="435"/>
-      <circ-port height="10" pin="480,410" width="10" x="85" y="235"/>
-      <circ-port height="10" pin="260,450" width="10" x="85" y="475"/>
-      <circ-port height="10" pin="480,440" width="10" x="65" y="495"/>
-      <circ-port height="10" pin="480,470" width="10" x="75" y="495"/>
-      <circ-anchor facing="east" height="6" width="6" x="57" y="157"/>
-    </appear>
-    <wire from="(910,470)" to="(910,480)"/>
-    <wire from="(820,740)" to="(820,750)"/>
-    <wire from="(840,720)" to="(840,730)"/>
-    <wire from="(140,50)" to="(580,50)"/>
-    <wire from="(140,850)" to="(580,850)"/>
-    <wire from="(140,490)" to="(580,490)"/>
-    <wire from="(750,220)" to="(750,310)"/>
-    <wire from="(930,170)" to="(930,190)"/>
-    <wire from="(820,370)" to="(820,450)"/>
-    <wire from="(830,740)" to="(850,740)"/>
-    <wire from="(230,170)" to="(260,170)"/>
-    <wire from="(910,300)" to="(930,300)"/>
-    <wire from="(1080,50)" to="(1080,550)"/>
-    <wire from="(460,250)" to="(480,250)"/>
-    <wire from="(460,130)" to="(480,130)"/>
-    <wire from="(460,170)" to="(480,170)"/>
-    <wire from="(460,210)" to="(480,210)"/>
-    <wire from="(460,290)" to="(480,290)"/>
-    <wire from="(460,330)" to="(480,330)"/>
-    <wire from="(460,370)" to="(480,370)"/>
-    <wire from="(460,410)" to="(480,410)"/>
-    <wire from="(950,130)" to="(980,130)"/>
-    <wire from="(950,210)" to="(980,210)"/>
-    <wire from="(900,440)" to="(930,440)"/>
-    <wire from="(430,670)" to="(440,670)"/>
-    <wire from="(250,250)" to="(260,250)"/>
-    <wire from="(250,290)" to="(260,290)"/>
-    <wire from="(250,330)" to="(260,330)"/>
-    <wire from="(230,710)" to="(240,710)"/>
-    <wire from="(710,430)" to="(720,430)"/>
-    <wire from="(710,470)" to="(720,470)"/>
-    <wire from="(600,50)" to="(600,550)"/>
-    <wire from="(930,300)" to="(930,310)"/>
-    <wire from="(800,350)" to="(920,350)"/>
-    <wire from="(1080,570)" to="(1080,850)"/>
-    <wire from="(730,140)" to="(920,140)"/>
-    <wire from="(600,570)" to="(600,850)"/>
-    <wire from="(750,220)" to="(920,220)"/>
-    <wire from="(860,460)" to="(880,460)"/>
-    <wire from="(900,460)" to="(920,460)"/>
-    <wire from="(270,750)" to="(290,750)"/>
-    <wire from="(660,450)" to="(690,450)"/>
-    <wire from="(270,710)" to="(290,710)"/>
-    <wire from="(270,670)" to="(290,670)"/>
-    <wire from="(270,790)" to="(290,790)"/>
-    <wire from="(270,630)" to="(290,630)"/>
-    <wire from="(600,50)" to="(1080,50)"/>
-    <wire from="(600,570)" to="(1080,570)"/>
-    <wire from="(600,850)" to="(1080,850)"/>
-    <wire from="(950,260)" to="(980,260)"/>
-    <wire from="(820,690)" to="(850,690)"/>
-    <wire from="(900,450)" to="(930,450)"/>
-    <wire from="(900,490)" to="(930,490)"/>
-    <wire from="(900,170)" to="(930,170)"/>
-    <wire from="(580,50)" to="(580,490)"/>
-    <wire from="(490,700)" to="(500,700)"/>
-    <wire from="(230,680)" to="(240,680)"/>
-    <wire from="(230,720)" to="(240,720)"/>
-    <wire from="(970,460)" to="(980,460)"/>
-    <wire from="(140,50)" to="(140,490)"/>
-    <wire from="(900,470)" to="(910,470)"/>
-    <wire from="(910,200)" to="(920,200)"/>
-    <wire from="(910,120)" to="(920,120)"/>
-    <wire from="(840,730)" to="(850,730)"/>
-    <wire from="(710,440)" to="(720,440)"/>
-    <wire from="(920,460)" to="(920,470)"/>
-    <wire from="(830,730)" to="(830,740)"/>
-    <wire from="(900,480)" to="(900,490)"/>
-    <wire from="(140,510)" to="(580,510)"/>
-    <wire from="(140,510)" to="(140,850)"/>
-    <wire from="(930,150)" to="(930,170)"/>
-    <wire from="(580,510)" to="(580,850)"/>
-    <wire from="(800,450)" to="(820,450)"/>
-    <wire from="(770,270)" to="(920,270)"/>
-    <wire from="(910,480)" to="(930,480)"/>
-    <wire from="(770,270)" to="(770,310)"/>
-    <wire from="(670,350)" to="(700,350)"/>
-    <wire from="(460,470)" to="(480,470)"/>
-    <wire from="(240,130)" to="(260,130)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(240,370)" to="(260,370)"/>
-    <wire from="(240,410)" to="(260,410)"/>
-    <wire from="(240,450)" to="(260,450)"/>
-    <wire from="(430,730)" to="(440,730)"/>
-    <wire from="(230,690)" to="(240,690)"/>
-    <wire from="(230,730)" to="(240,730)"/>
-    <wire from="(910,250)" to="(920,250)"/>
-    <wire from="(710,450)" to="(720,450)"/>
-    <wire from="(820,370)" to="(920,370)"/>
-    <wire from="(820,700)" to="(860,700)"/>
-    <wire from="(930,280)" to="(930,300)"/>
-    <wire from="(820,720)" to="(840,720)"/>
-    <wire from="(780,720)" to="(800,720)"/>
-    <wire from="(730,140)" to="(730,310)"/>
-    <wire from="(270,730)" to="(290,730)"/>
-    <wire from="(270,690)" to="(290,690)"/>
-    <wire from="(270,770)" to="(290,770)"/>
-    <wire from="(270,810)" to="(290,810)"/>
-    <wire from="(270,610)" to="(290,610)"/>
-    <wire from="(270,650)" to="(290,650)"/>
-    <wire from="(600,550)" to="(1080,550)"/>
-    <wire from="(460,440)" to="(480,440)"/>
-    <wire from="(950,360)" to="(980,360)"/>
-    <wire from="(820,710)" to="(850,710)"/>
-    <wire from="(820,750)" to="(850,750)"/>
-    <wire from="(900,430)" to="(930,430)"/>
-    <wire from="(490,680)" to="(500,680)"/>
-    <wire from="(230,700)" to="(240,700)"/>
-    <wire from="(200,710)" to="(210,710)"/>
-    <wire from="(920,470)" to="(930,470)"/>
-    <wire from="(820,730)" to="(830,730)"/>
-    <wire from="(890,720)" to="(900,720)"/>
-    <wire from="(710,420)" to="(720,420)"/>
-    <wire from="(710,460)" to="(720,460)"/>
-    <comp lib="0" loc="(480,130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(460,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(670,350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(250,250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="0" loc="(240,130)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(290,650)" name="Tunnel">
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(690,450)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(430,730)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(980,260)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(260,210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,370)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(290,750)" name="Tunnel">
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(290,730)" name="Tunnel">
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(460,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(980,210)" name="Tunnel">
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="0" loc="(240,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="2" loc="(950,260)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(460,130)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(260,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="6" loc="(371,553)" name="Text">
-      <a name="text" val="OP Decoding Area"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="1" loc="(970,460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate1" val="true"/>
-      <a name="negate2" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(230,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="0" loc="(260,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ZeroExtend"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(700,350)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(460,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(290,790)" name="Tunnel">
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp loc="(240,600)" name="Opcode_Decoder"/>
-    <comp lib="6" loc="(840,609)" name="Text">
-      <a name="text" val="Exception Handler"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(900,720)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(260,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrc"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(660,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(250,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="0" loc="(910,250)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(500,680)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(800,450)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="3"/>
-      <a name="bit1" val="2"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="0" loc="(290,630)" name="Tunnel">
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(480,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(200,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(480,210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(800,350)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="3"/>
-      <a name="bit1" val="2"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="0" loc="(480,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegDst"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(440,730)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(910,300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(480,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(460,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(290,770)" name="Tunnel">
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="0" loc="(500,700)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="2" loc="(950,130)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(800,720)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(210,710)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(460,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(260,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscall"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(980,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="2" loc="(950,360)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="4"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(440,670)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(290,810)" name="Tunnel">
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(290,670)" name="Tunnel">
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(780,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(260,130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="1" loc="(890,720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate2" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(460,370)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="6" loc="(851,85)" name="Text">
-      <a name="text" val="ALU Decoding Area"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(480,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsCOP0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(980,130)" name="Tunnel">
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="2" loc="(950,210)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(290,690)" name="Tunnel">
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp loc="(720,320)" name="Funct_Decoder"/>
-    <comp lib="0" loc="(260,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeq"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(980,460)" name="Tunnel">
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(900,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(290,710)" name="Tunnel">
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(480,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJR"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(910,120)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp loc="(770,430)" name="ALU_Decoder"/>
-    <comp lib="0" loc="(250,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(460,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(460,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(860,460)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(480,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Branch"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(260,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJAL"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp loc="(490,690)" name="RegisterRead_Detector"/>
-    <comp lib="0" loc="(880,460)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(240,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(480,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Jump"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(480,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemRead"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(930,340)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(460,250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(290,610)" name="Tunnel">
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(260,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoReg"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(910,200)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="6" loc="(353,93)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-  </circuit>
-  <circuit name="Funct_Decoder">
-    <a name="circuit" val="Funct_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="71" stroke="#000000" stroke-width="2" width="60" x="50" y="50"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="81" y="82">Funct</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="101">Decoder</text>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
-      <circ-port height="8" pin="40,140" width="8" x="46" y="76"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
-      <circ-port height="10" pin="390,240" width="10" x="105" y="65"/>
-      <circ-port height="8" pin="40,250" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="40,310" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="390,700" width="10" x="105" y="75"/>
-      <circ-port height="10" pin="390,1310" width="10" x="105" y="85"/>
-      <circ-port height="10" pin="390,1870" width="10" x="105" y="95"/>
-      <circ-port height="10" pin="390,2210" width="10" x="75" y="45"/>
-      <circ-port height="10" pin="390,2370" width="10" x="55" y="45"/>
-      <circ-port height="10" pin="390,2670" width="10" x="95" y="45"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
-    </appear>
-    <wire from="(160,700)" to="(160,830)"/>
-    <wire from="(100,640)" to="(100,770)"/>
-    <wire from="(200,910)" to="(260,910)"/>
-    <wire from="(230,870)" to="(230,880)"/>
-    <wire from="(220,1020)" to="(220,1030)"/>
-    <wire from="(60,2600)" to="(180,2600)"/>
-    <wire from="(60,2760)" to="(180,2760)"/>
-    <wire from="(60,590)" to="(240,590)"/>
-    <wire from="(210,770)" to="(260,770)"/>
-    <wire from="(60,1390)" to="(240,1390)"/>
-    <wire from="(230,2630)" to="(230,2650)"/>
-    <wire from="(230,2790)" to="(230,2810)"/>
-    <wire from="(240,240)" to="(240,260)"/>
-    <wire from="(230,1030)" to="(230,1050)"/>
-    <wire from="(60,1240)" to="(60,1390)"/>
-    <wire from="(290,2210)" to="(390,2210)"/>
-    <wire from="(290,2370)" to="(390,2370)"/>
-    <wire from="(240,1040)" to="(240,1070)"/>
-    <wire from="(240,720)" to="(240,750)"/>
-    <wire from="(80,1520)" to="(180,1520)"/>
-    <wire from="(230,170)" to="(260,170)"/>
-    <wire from="(230,650)" to="(260,650)"/>
-    <wire from="(140,2710)" to="(230,2710)"/>
-    <wire from="(290,70)" to="(320,70)"/>
-    <wire from="(310,250)" to="(340,250)"/>
-    <wire from="(230,1130)" to="(260,1130)"/>
-    <wire from="(230,1290)" to="(260,1290)"/>
-    <wire from="(230,1930)" to="(260,1930)"/>
-    <wire from="(230,2090)" to="(260,2090)"/>
-    <wire from="(240,1790)" to="(260,1790)"/>
-    <wire from="(200,2550)" to="(220,2550)"/>
-    <wire from="(310,2660)" to="(330,2660)"/>
-    <wire from="(160,830)" to="(160,940)"/>
-    <wire from="(160,1070)" to="(180,1070)"/>
-    <wire from="(210,480)" to="(230,480)"/>
-    <wire from="(210,800)" to="(230,800)"/>
-    <wire from="(100,2520)" to="(180,2520)"/>
-    <wire from="(160,2580)" to="(240,2580)"/>
-    <wire from="(100,770)" to="(100,890)"/>
-    <wire from="(120,2080)" to="(180,2080)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(40,310)" to="(160,310)"/>
-    <wire from="(60,240)" to="(240,240)"/>
-    <wire from="(60,720)" to="(240,720)"/>
-    <wire from="(120,2550)" to="(120,2690)"/>
-    <wire from="(140,2570)" to="(140,2710)"/>
-    <wire from="(240,850)" to="(240,870)"/>
-    <wire from="(140,2250)" to="(140,2400)"/>
-    <wire from="(160,2430)" to="(160,2580)"/>
-    <wire from="(230,520)" to="(230,540)"/>
-    <wire from="(220,2680)" to="(260,2680)"/>
-    <wire from="(220,2840)" to="(260,2840)"/>
-    <wire from="(230,780)" to="(260,780)"/>
-    <wire from="(100,2060)" to="(260,2060)"/>
-    <wire from="(140,440)" to="(230,440)"/>
-    <wire from="(360,2670)" to="(390,2670)"/>
-    <wire from="(240,2240)" to="(260,2240)"/>
-    <wire from="(240,1280)" to="(260,1280)"/>
-    <wire from="(240,1120)" to="(260,1120)"/>
-    <wire from="(240,1920)" to="(260,1920)"/>
-    <wire from="(240,2400)" to="(260,2400)"/>
-    <wire from="(240,2560)" to="(260,2560)"/>
-    <wire from="(320,720)" to="(340,720)"/>
-    <wire from="(290,1810)" to="(310,1810)"/>
-    <wire from="(240,530)" to="(240,570)"/>
-    <wire from="(240,160)" to="(260,160)"/>
-    <wire from="(240,320)" to="(260,320)"/>
-    <wire from="(320,510)" to="(320,680)"/>
-    <wire from="(210,610)" to="(230,610)"/>
-    <wire from="(200,1720)" to="(220,1720)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(100,1690)" to="(180,1690)"/>
-    <wire from="(160,1750)" to="(240,1750)"/>
-    <wire from="(120,1460)" to="(260,1460)"/>
-    <wire from="(310,1880)" to="(310,1940)"/>
-    <wire from="(120,1720)" to="(120,1840)"/>
-    <wire from="(140,1740)" to="(140,1870)"/>
-    <wire from="(60,1500)" to="(60,1630)"/>
-    <wire from="(120,2690)" to="(180,2690)"/>
-    <wire from="(120,2850)" to="(180,2850)"/>
-    <wire from="(140,800)" to="(190,800)"/>
-    <wire from="(60,850)" to="(240,850)"/>
-    <wire from="(80,1520)" to="(80,1660)"/>
-    <wire from="(230,2090)" to="(230,2100)"/>
-    <wire from="(60,2460)" to="(60,2600)"/>
-    <wire from="(240,2100)" to="(240,2120)"/>
-    <wire from="(100,1540)" to="(100,1690)"/>
-    <wire from="(160,1600)" to="(160,1750)"/>
-    <wire from="(230,650)" to="(230,670)"/>
-    <wire from="(230,970)" to="(230,990)"/>
-    <wire from="(140,2250)" to="(180,2250)"/>
-    <wire from="(200,2150)" to="(240,2150)"/>
-    <wire from="(200,2310)" to="(240,2310)"/>
-    <wire from="(230,270)" to="(260,270)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(210,570)" to="(240,570)"/>
-    <wire from="(200,1520)" to="(230,1520)"/>
-    <wire from="(100,2660)" to="(100,2820)"/>
-    <wire from="(120,1560)" to="(120,1720)"/>
-    <wire from="(140,1580)" to="(140,1740)"/>
-    <wire from="(140,1050)" to="(230,1050)"/>
-    <wire from="(100,1810)" to="(190,1810)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(230,2190)" to="(260,2190)"/>
-    <wire from="(230,2350)" to="(260,2350)"/>
-    <wire from="(230,2510)" to="(260,2510)"/>
-    <wire from="(140,1870)" to="(140,1970)"/>
-    <wire from="(240,930)" to="(260,930)"/>
-    <wire from="(240,1730)" to="(260,1730)"/>
-    <wire from="(320,1330)" to="(340,1330)"/>
-    <wire from="(290,1940)" to="(310,1940)"/>
-    <wire from="(240,660)" to="(240,700)"/>
-    <wire from="(310,250)" to="(310,290)"/>
-    <wire from="(210,740)" to="(230,740)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(60,1630)" to="(60,1760)"/>
-    <wire from="(120,420)" to="(180,420)"/>
-    <wire from="(200,180)" to="(260,180)"/>
-    <wire from="(200,1140)" to="(260,1140)"/>
-    <wire from="(200,1300)" to="(260,1300)"/>
-    <wire from="(140,1470)" to="(260,1470)"/>
-    <wire from="(120,190)" to="(120,200)"/>
-    <wire from="(310,2680)" to="(310,2830)"/>
-    <wire from="(230,780)" to="(230,800)"/>
-    <wire from="(240,950)" to="(240,980)"/>
-    <wire from="(220,1020)" to="(260,1020)"/>
-    <wire from="(200,2120)" to="(240,2120)"/>
-    <wire from="(200,2280)" to="(240,2280)"/>
-    <wire from="(200,2600)" to="(240,2600)"/>
-    <wire from="(200,2760)" to="(240,2760)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(80,1110)" to="(180,1110)"/>
-    <wire from="(80,1270)" to="(180,1270)"/>
-    <wire from="(100,400)" to="(260,400)"/>
-    <wire from="(210,700)" to="(240,700)"/>
-    <wire from="(230,880)" to="(260,880)"/>
-    <wire from="(100,1940)" to="(190,1940)"/>
-    <wire from="(230,1680)" to="(260,1680)"/>
-    <wire from="(240,2180)" to="(260,2180)"/>
-    <wire from="(240,2340)" to="(260,2340)"/>
-    <wire from="(240,2500)" to="(260,2500)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,790)" to="(240,830)"/>
-    <wire from="(160,340)" to="(180,340)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,260)" to="(260,260)"/>
-    <wire from="(320,1890)" to="(320,2070)"/>
-    <wire from="(120,540)" to="(190,540)"/>
-    <wire from="(80,1780)" to="(80,1910)"/>
-    <wire from="(120,540)" to="(120,670)"/>
-    <wire from="(60,1760)" to="(60,1890)"/>
-    <wire from="(120,1030)" to="(180,1030)"/>
-    <wire from="(230,430)" to="(230,440)"/>
-    <wire from="(240,440)" to="(240,450)"/>
-    <wire from="(60,950)" to="(240,950)"/>
-    <wire from="(100,1000)" to="(100,1140)"/>
-    <wire from="(320,260)" to="(320,410)"/>
-    <wire from="(320,1700)" to="(320,1850)"/>
-    <wire from="(200,2730)" to="(240,2730)"/>
-    <wire from="(80,2040)" to="(180,2040)"/>
-    <wire from="(160,1480)" to="(260,1480)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(210,830)" to="(240,830)"/>
-    <wire from="(230,1170)" to="(260,1170)"/>
-    <wire from="(230,1330)" to="(260,1330)"/>
-    <wire from="(290,1550)" to="(320,1550)"/>
-    <wire from="(240,870)" to="(260,870)"/>
-    <wire from="(240,1670)" to="(260,1670)"/>
-    <wire from="(240,1830)" to="(260,1830)"/>
-    <wire from="(100,140)" to="(100,180)"/>
-    <wire from="(310,190)" to="(310,230)"/>
-    <wire from="(240,1240)" to="(240,1280)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(80,150)" to="(80,260)"/>
-    <wire from="(100,1440)" to="(180,1440)"/>
-    <wire from="(120,670)" to="(190,670)"/>
-    <wire from="(160,450)" to="(160,700)"/>
-    <wire from="(200,2520)" to="(260,2520)"/>
-    <wire from="(80,1910)" to="(80,2040)"/>
-    <wire from="(140,1970)" to="(140,2100)"/>
-    <wire from="(60,1890)" to="(60,2020)"/>
-    <wire from="(200,1560)" to="(260,1560)"/>
-    <wire from="(80,1270)" to="(80,1410)"/>
-    <wire from="(230,1520)" to="(230,1530)"/>
-    <wire from="(320,70)" to="(320,220)"/>
-    <wire from="(60,1090)" to="(60,1240)"/>
-    <wire from="(80,2490)" to="(180,2490)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(230,500)" to="(260,500)"/>
-    <wire from="(200,1110)" to="(230,1110)"/>
-    <wire from="(200,1270)" to="(230,1270)"/>
-    <wire from="(80,1110)" to="(80,1270)"/>
-    <wire from="(140,320)" to="(230,320)"/>
-    <wire from="(310,1860)" to="(340,1860)"/>
-    <wire from="(240,1960)" to="(260,1960)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(310,640)" to="(310,690)"/>
-    <wire from="(160,1480)" to="(160,1600)"/>
-    <wire from="(60,2020)" to="(60,2150)"/>
-    <wire from="(200,1690)" to="(260,1690)"/>
-    <wire from="(220,1320)" to="(220,1330)"/>
-    <wire from="(290,1310)" to="(340,1310)"/>
-    <wire from="(230,1170)" to="(230,1180)"/>
-    <wire from="(80,2040)" to="(80,2180)"/>
-    <wire from="(100,2060)" to="(100,2200)"/>
-    <wire from="(120,2080)" to="(120,2220)"/>
-    <wire from="(230,1330)" to="(230,1350)"/>
-    <wire from="(240,1500)" to="(240,1520)"/>
-    <wire from="(310,1150)" to="(310,1300)"/>
-    <wire from="(140,2100)" to="(140,2250)"/>
-    <wire from="(160,2280)" to="(160,2430)"/>
-    <wire from="(240,1180)" to="(240,1210)"/>
-    <wire from="(240,1340)" to="(240,1370)"/>
-    <wire from="(200,1070)" to="(240,1070)"/>
-    <wire from="(80,380)" to="(180,380)"/>
-    <wire from="(80,1660)" to="(180,1660)"/>
-    <wire from="(230,310)" to="(260,310)"/>
-    <wire from="(230,630)" to="(260,630)"/>
-    <wire from="(160,2000)" to="(190,2000)"/>
-    <wire from="(160,2120)" to="(160,2280)"/>
-    <wire from="(140,930)" to="(230,930)"/>
-    <wire from="(310,230)" to="(340,230)"/>
-    <wire from="(290,1010)" to="(320,1010)"/>
-    <wire from="(230,1430)" to="(260,1430)"/>
-    <wire from="(200,2040)" to="(230,2040)"/>
-    <wire from="(230,2230)" to="(260,2230)"/>
-    <wire from="(230,2390)" to="(260,2390)"/>
-    <wire from="(230,2550)" to="(260,2550)"/>
-    <wire from="(310,710)" to="(340,710)"/>
-    <wire from="(200,2690)" to="(220,2690)"/>
-    <wire from="(200,2850)" to="(220,2850)"/>
-    <wire from="(320,1850)" to="(340,1850)"/>
-    <wire from="(240,2460)" to="(240,2500)"/>
-    <wire from="(240,490)" to="(260,490)"/>
-    <wire from="(160,1210)" to="(180,1210)"/>
-    <wire from="(160,1370)" to="(180,1370)"/>
-    <wire from="(100,2660)" to="(180,2660)"/>
-    <wire from="(100,2820)" to="(180,2820)"/>
-    <wire from="(120,670)" to="(120,910)"/>
-    <wire from="(120,300)" to="(180,300)"/>
-    <wire from="(120,2220)" to="(180,2220)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(60,1500)" to="(240,1500)"/>
-    <wire from="(80,2490)" to="(80,2630)"/>
-    <wire from="(230,1780)" to="(230,1800)"/>
-    <wire from="(80,1780)" to="(190,1780)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(60,2310)" to="(60,2460)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(100,280)" to="(260,280)"/>
-    <wire from="(230,760)" to="(260,760)"/>
-    <wire from="(230,920)" to="(260,920)"/>
-    <wire from="(60,2150)" to="(60,2310)"/>
-    <wire from="(100,2200)" to="(260,2200)"/>
-    <wire from="(100,2360)" to="(260,2360)"/>
-    <wire from="(120,2690)" to="(120,2850)"/>
-    <wire from="(60,360)" to="(60,460)"/>
-    <wire from="(80,380)" to="(80,480)"/>
-    <wire from="(230,1720)" to="(260,1720)"/>
-    <wire from="(200,2490)" to="(230,2490)"/>
-    <wire from="(310,1320)" to="(340,1320)"/>
-    <wire from="(320,220)" to="(340,220)"/>
-    <wire from="(290,190)" to="(310,190)"/>
-    <wire from="(290,1150)" to="(310,1150)"/>
-    <wire from="(240,1420)" to="(260,1420)"/>
-    <wire from="(240,1580)" to="(260,1580)"/>
-    <wire from="(240,2700)" to="(260,2700)"/>
-    <wire from="(240,2860)" to="(260,2860)"/>
-    <wire from="(140,2710)" to="(140,2880)"/>
-    <wire from="(370,1870)" to="(390,1870)"/>
-    <wire from="(240,1630)" to="(240,1670)"/>
-    <wire from="(240,620)" to="(260,620)"/>
-    <wire from="(100,400)" to="(100,510)"/>
-    <wire from="(160,450)" to="(240,450)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(160,2730)" to="(160,2910)"/>
-    <wire from="(80,1660)" to="(80,1780)"/>
-    <wire from="(120,420)" to="(120,540)"/>
-    <wire from="(140,440)" to="(140,570)"/>
-    <wire from="(160,940)" to="(160,1070)"/>
-    <wire from="(140,250)" to="(140,320)"/>
-    <wire from="(120,910)" to="(180,910)"/>
-    <wire from="(310,2530)" to="(310,2660)"/>
-    <wire from="(230,310)" to="(230,320)"/>
-    <wire from="(60,1240)" to="(180,1240)"/>
-    <wire from="(210,1810)" to="(260,1810)"/>
-    <wire from="(230,2390)" to="(230,2400)"/>
-    <wire from="(220,2540)" to="(220,2550)"/>
-    <wire from="(230,1270)" to="(230,1290)"/>
-    <wire from="(230,1110)" to="(230,1130)"/>
-    <wire from="(230,1910)" to="(230,1930)"/>
-    <wire from="(80,1910)" to="(190,1910)"/>
-    <wire from="(230,2230)" to="(230,2250)"/>
-    <wire from="(230,2550)" to="(230,2570)"/>
-    <wire from="(240,2560)" to="(240,2580)"/>
-    <wire from="(230,150)" to="(230,170)"/>
-    <wire from="(240,320)" to="(240,340)"/>
-    <wire from="(240,1760)" to="(240,1790)"/>
-    <wire from="(240,2400)" to="(240,2430)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(200,380)" to="(230,380)"/>
-    <wire from="(200,1180)" to="(230,1180)"/>
-    <wire from="(200,1660)" to="(230,1660)"/>
-    <wire from="(100,890)" to="(260,890)"/>
-    <wire from="(60,2600)" to="(60,2760)"/>
-    <wire from="(140,1350)" to="(230,1350)"/>
-    <wire from="(230,1530)" to="(260,1530)"/>
-    <wire from="(230,2650)" to="(260,2650)"/>
-    <wire from="(230,2810)" to="(260,2810)"/>
-    <wire from="(100,510)" to="(190,510)"/>
-    <wire from="(290,2070)" to="(320,2070)"/>
-    <wire from="(290,640)" to="(310,640)"/>
-    <wire from="(240,750)" to="(260,750)"/>
-    <wire from="(210,1840)" to="(230,1840)"/>
-    <wire from="(370,240)" to="(390,240)"/>
-    <wire from="(240,2240)" to="(240,2280)"/>
-    <wire from="(200,1030)" to="(220,1030)"/>
-    <wire from="(160,2430)" to="(180,2430)"/>
-    <wire from="(160,2910)" to="(180,2910)"/>
-    <wire from="(100,1000)" to="(180,1000)"/>
-    <wire from="(310,710)" to="(310,770)"/>
-    <wire from="(200,2080)" to="(260,2080)"/>
-    <wire from="(100,1810)" to="(100,1940)"/>
-    <wire from="(120,1030)" to="(120,1160)"/>
-    <wire from="(140,1050)" to="(140,1180)"/>
-    <wire from="(200,1440)" to="(260,1440)"/>
-    <wire from="(230,920)" to="(230,930)"/>
-    <wire from="(210,1940)" to="(260,1940)"/>
-    <wire from="(60,1760)" to="(240,1760)"/>
-    <wire from="(140,1870)" to="(190,1870)"/>
-    <wire from="(240,930)" to="(240,940)"/>
-    <wire from="(220,1710)" to="(220,1720)"/>
-    <wire from="(230,2040)" to="(230,2050)"/>
-    <wire from="(160,1070)" to="(160,1210)"/>
-    <wire from="(230,1720)" to="(230,1740)"/>
-    <wire from="(240,1730)" to="(240,1750)"/>
-    <wire from="(240,1090)" to="(240,1120)"/>
-    <wire from="(240,1890)" to="(240,1920)"/>
-    <wire from="(200,340)" to="(240,340)"/>
-    <wire from="(220,1320)" to="(260,1320)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(240,130)" to="(240,160)"/>
-    <wire from="(80,1410)" to="(180,1410)"/>
-    <wire from="(290,2670)" to="(330,2670)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(100,180)" to="(100,280)"/>
-    <wire from="(120,200)" to="(120,300)"/>
-    <wire from="(230,1820)" to="(260,1820)"/>
-    <wire from="(100,640)" to="(190,640)"/>
-    <wire from="(290,290)" to="(310,290)"/>
-    <wire from="(240,1520)" to="(260,1520)"/>
-    <wire from="(240,2640)" to="(260,2640)"/>
-    <wire from="(240,1040)" to="(260,1040)"/>
-    <wire from="(210,1970)" to="(230,1970)"/>
-    <wire from="(290,770)" to="(310,770)"/>
-    <wire from="(290,2530)" to="(310,2530)"/>
-    <wire from="(240,2800)" to="(260,2800)"/>
-    <wire from="(160,1600)" to="(180,1600)"/>
-    <wire from="(100,1940)" to="(100,2060)"/>
-    <wire from="(160,2000)" to="(160,2120)"/>
-    <wire from="(60,460)" to="(60,590)"/>
-    <wire from="(80,480)" to="(80,610)"/>
-    <wire from="(120,1330)" to="(180,1330)"/>
-    <wire from="(230,90)" to="(230,100)"/>
-    <wire from="(60,2460)" to="(180,2460)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(60,1090)" to="(240,1090)"/>
-    <wire from="(60,1890)" to="(240,1890)"/>
-    <wire from="(100,1300)" to="(100,1440)"/>
-    <wire from="(240,2020)" to="(240,2040)"/>
-    <wire from="(230,2490)" to="(230,2510)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(80,260)" to="(180,260)"/>
-    <wire from="(80,2180)" to="(180,2180)"/>
-    <wire from="(80,2340)" to="(180,2340)"/>
-    <wire from="(230,990)" to="(260,990)"/>
-    <wire from="(100,1140)" to="(100,1300)"/>
-    <wire from="(140,570)" to="(140,800)"/>
-    <wire from="(140,2570)" to="(230,2570)"/>
-    <wire from="(290,410)" to="(320,410)"/>
-    <wire from="(230,1950)" to="(260,1950)"/>
-    <wire from="(200,2400)" to="(230,2400)"/>
-    <wire from="(200,2880)" to="(230,2880)"/>
-    <wire from="(100,770)" to="(190,770)"/>
-    <wire from="(210,1780)" to="(230,1780)"/>
-    <wire from="(120,1160)" to="(120,1330)"/>
-    <wire from="(140,1180)" to="(140,1350)"/>
-    <wire from="(320,1890)" to="(340,1890)"/>
-    <wire from="(310,2680)" to="(330,2680)"/>
-    <wire from="(140,1470)" to="(140,1580)"/>
-    <wire from="(240,530)" to="(260,530)"/>
-    <wire from="(60,1390)" to="(60,1500)"/>
-    <wire from="(80,1410)" to="(80,1520)"/>
-    <wire from="(320,720)" to="(320,900)"/>
-    <wire from="(200,2660)" to="(260,2660)"/>
-    <wire from="(200,2820)" to="(260,2820)"/>
-    <wire from="(60,590)" to="(60,720)"/>
-    <wire from="(80,610)" to="(80,740)"/>
-    <wire from="(200,420)" to="(260,420)"/>
-    <wire from="(310,1320)" to="(310,1450)"/>
-    <wire from="(230,380)" to="(230,390)"/>
-    <wire from="(60,1630)" to="(180,1630)"/>
-    <wire from="(140,1970)" to="(190,1970)"/>
-    <wire from="(60,2020)" to="(240,2020)"/>
-    <wire from="(230,1660)" to="(230,1680)"/>
-    <wire from="(230,1820)" to="(230,1840)"/>
-    <wire from="(140,1180)" to="(180,1180)"/>
-    <wire from="(240,2150)" to="(240,2180)"/>
-    <wire from="(240,2310)" to="(240,2340)"/>
-    <wire from="(200,1240)" to="(240,1240)"/>
-    <wire from="(220,2540)" to="(260,2540)"/>
-    <wire from="(160,310)" to="(160,340)"/>
-    <wire from="(80,870)" to="(180,870)"/>
-    <wire from="(80,2630)" to="(180,2630)"/>
-    <wire from="(80,2790)" to="(180,2790)"/>
-    <wire from="(200,1410)" to="(230,1410)"/>
-    <wire from="(140,1580)" to="(230,1580)"/>
-    <wire from="(140,1740)" to="(230,1740)"/>
-    <wire from="(320,260)" to="(340,260)"/>
-    <wire from="(240,980)" to="(260,980)"/>
-    <wire from="(210,1910)" to="(230,1910)"/>
-    <wire from="(240,2100)" to="(260,2100)"/>
-    <wire from="(240,1830)" to="(240,1870)"/>
-    <wire from="(160,340)" to="(160,450)"/>
-    <wire from="(240,660)" to="(260,660)"/>
-    <wire from="(120,200)" to="(260,200)"/>
-    <wire from="(120,1160)" to="(260,1160)"/>
-    <wire from="(60,240)" to="(60,360)"/>
-    <wire from="(80,260)" to="(80,380)"/>
-    <wire from="(100,280)" to="(100,400)"/>
-    <wire from="(120,300)" to="(120,420)"/>
-    <wire from="(140,320)" to="(140,440)"/>
-    <wire from="(140,800)" to="(140,930)"/>
-    <wire from="(60,720)" to="(60,850)"/>
-    <wire from="(80,740)" to="(80,870)"/>
-    <wire from="(120,2550)" to="(180,2550)"/>
-    <wire from="(100,2520)" to="(100,2660)"/>
-    <wire from="(230,1950)" to="(230,1970)"/>
-    <wire from="(80,2340)" to="(80,2490)"/>
-    <wire from="(160,2580)" to="(160,2730)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(240,360)" to="(240,380)"/>
-    <wire from="(320,1330)" to="(320,1550)"/>
-    <wire from="(200,1210)" to="(240,1210)"/>
-    <wire from="(200,1370)" to="(240,1370)"/>
-    <wire from="(220,1710)" to="(260,1710)"/>
-    <wire from="(160,700)" to="(190,700)"/>
-    <wire from="(200,100)" to="(230,100)"/>
-    <wire from="(200,260)" to="(230,260)"/>
-    <wire from="(80,2180)" to="(80,2340)"/>
-    <wire from="(100,2200)" to="(100,2360)"/>
-    <wire from="(100,2360)" to="(100,2520)"/>
-    <wire from="(120,2220)" to="(120,2380)"/>
-    <wire from="(60,850)" to="(60,950)"/>
-    <wire from="(80,870)" to="(80,970)"/>
-    <wire from="(230,1570)" to="(260,1570)"/>
-    <wire from="(290,510)" to="(320,510)"/>
-    <wire from="(210,1870)" to="(240,1870)"/>
-    <wire from="(230,2050)" to="(260,2050)"/>
-    <wire from="(200,2180)" to="(230,2180)"/>
-    <wire from="(200,2340)" to="(230,2340)"/>
-    <wire from="(230,2690)" to="(260,2690)"/>
-    <wire from="(230,2850)" to="(260,2850)"/>
-    <wire from="(310,690)" to="(340,690)"/>
-    <wire from="(240,790)" to="(260,790)"/>
-    <wire from="(120,2380)" to="(120,2550)"/>
-    <wire from="(140,2400)" to="(140,2570)"/>
-    <wire from="(240,1960)" to="(240,2000)"/>
-    <wire from="(240,2600)" to="(240,2640)"/>
-    <wire from="(240,2760)" to="(240,2800)"/>
-    <wire from="(100,890)" to="(100,1000)"/>
-    <wire from="(160,940)" to="(240,940)"/>
-    <wire from="(100,1690)" to="(100,1810)"/>
-    <wire from="(120,910)" to="(120,1030)"/>
-    <wire from="(140,930)" to="(140,1050)"/>
-    <wire from="(120,1560)" to="(180,1560)"/>
-    <wire from="(120,1720)" to="(180,1720)"/>
-    <wire from="(200,1000)" to="(260,1000)"/>
-    <wire from="(140,210)" to="(260,210)"/>
-    <wire from="(60,360)" to="(240,360)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(80,480)" to="(190,480)"/>
-    <wire from="(230,480)" to="(230,500)"/>
-    <wire from="(140,2400)" to="(180,2400)"/>
-    <wire from="(140,2880)" to="(180,2880)"/>
-    <wire from="(200,2460)" to="(240,2460)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(320,1010)" to="(320,1290)"/>
-    <wire from="(80,970)" to="(180,970)"/>
-    <wire from="(160,830)" to="(190,830)"/>
-    <wire from="(200,870)" to="(230,870)"/>
-    <wire from="(100,1540)" to="(260,1540)"/>
-    <wire from="(80,2630)" to="(80,2790)"/>
-    <wire from="(210,2000)" to="(240,2000)"/>
-    <wire from="(200,2630)" to="(230,2630)"/>
-    <wire from="(200,2790)" to="(230,2790)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(310,1300)" to="(340,1300)"/>
-    <wire from="(240,2040)" to="(260,2040)"/>
-    <wire from="(320,680)" to="(340,680)"/>
-    <wire from="(290,1450)" to="(310,1450)"/>
-    <wire from="(140,100)" to="(140,210)"/>
-    <wire from="(240,440)" to="(260,440)"/>
-    <wire from="(160,2120)" to="(180,2120)"/>
-    <wire from="(160,2280)" to="(180,2280)"/>
-    <wire from="(120,80)" to="(120,190)"/>
-    <wire from="(120,2380)" to="(260,2380)"/>
-    <wire from="(120,1840)" to="(190,1840)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(210,510)" to="(260,510)"/>
-    <wire from="(230,1570)" to="(230,1580)"/>
-    <wire from="(220,2680)" to="(220,2690)"/>
-    <wire from="(220,2840)" to="(220,2850)"/>
-    <wire from="(230,1410)" to="(230,1430)"/>
-    <wire from="(240,1580)" to="(240,1600)"/>
-    <wire from="(230,2690)" to="(230,2710)"/>
-    <wire from="(80,610)" to="(190,610)"/>
-    <wire from="(230,610)" to="(230,630)"/>
-    <wire from="(240,2700)" to="(240,2730)"/>
-    <wire from="(230,2850)" to="(230,2880)"/>
-    <wire from="(200,1630)" to="(240,1630)"/>
-    <wire from="(200,2430)" to="(240,2430)"/>
-    <wire from="(200,2910)" to="(240,2910)"/>
-    <wire from="(240,460)" to="(240,490)"/>
-    <wire from="(160,220)" to="(260,220)"/>
-    <wire from="(230,390)" to="(260,390)"/>
-    <wire from="(230,1030)" to="(260,1030)"/>
-    <wire from="(370,700)" to="(390,700)"/>
-    <wire from="(320,1290)" to="(340,1290)"/>
-    <wire from="(160,1370)" to="(160,1480)"/>
-    <wire from="(210,540)" to="(230,540)"/>
-    <wire from="(200,1330)" to="(220,1330)"/>
-    <wire from="(160,2730)" to="(180,2730)"/>
-    <wire from="(100,180)" to="(180,180)"/>
-    <wire from="(100,1140)" to="(180,1140)"/>
-    <wire from="(100,1300)" to="(180,1300)"/>
-    <wire from="(310,1810)" to="(310,1860)"/>
-    <wire from="(240,2860)" to="(240,2910)"/>
-    <wire from="(160,1750)" to="(160,2000)"/>
-    <wire from="(140,1350)" to="(140,1470)"/>
-    <wire from="(200,2220)" to="(260,2220)"/>
-    <wire from="(120,1330)" to="(120,1460)"/>
-    <wire from="(100,510)" to="(100,640)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(200,300)" to="(260,300)"/>
-    <wire from="(230,260)" to="(230,270)"/>
-    <wire from="(60,2150)" to="(180,2150)"/>
-    <wire from="(60,2310)" to="(180,2310)"/>
-    <wire from="(140,570)" to="(190,570)"/>
-    <wire from="(60,460)" to="(240,460)"/>
-    <wire from="(210,640)" to="(260,640)"/>
-    <wire from="(60,950)" to="(60,1090)"/>
-    <wire from="(80,970)" to="(80,1110)"/>
-    <wire from="(230,2180)" to="(230,2190)"/>
-    <wire from="(230,2340)" to="(230,2350)"/>
-    <wire from="(80,740)" to="(190,740)"/>
-    <wire from="(230,740)" to="(230,760)"/>
-    <wire from="(160,220)" to="(160,310)"/>
-    <wire from="(140,100)" to="(180,100)"/>
-    <wire from="(240,1390)" to="(240,1420)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(240,590)" to="(240,620)"/>
-    <wire from="(230,520)" to="(260,520)"/>
-    <wire from="(200,970)" to="(230,970)"/>
-    <wire from="(160,1210)" to="(160,1370)"/>
-    <wire from="(140,2100)" to="(230,2100)"/>
-    <wire from="(290,900)" to="(320,900)"/>
-    <wire from="(230,1800)" to="(260,1800)"/>
-    <wire from="(200,2250)" to="(230,2250)"/>
-    <wire from="(100,1440)" to="(100,1540)"/>
-    <wire from="(120,1460)" to="(120,1560)"/>
-    <wire from="(290,1700)" to="(320,1700)"/>
-    <wire from="(310,1880)" to="(340,1880)"/>
-    <wire from="(240,1180)" to="(260,1180)"/>
-    <wire from="(240,1340)" to="(260,1340)"/>
-    <wire from="(290,2830)" to="(310,2830)"/>
-    <wire from="(370,1310)" to="(390,1310)"/>
-    <wire from="(240,380)" to="(260,380)"/>
-    <wire from="(210,670)" to="(230,670)"/>
-    <wire from="(120,1840)" to="(120,2080)"/>
-    <wire from="(120,80)" to="(260,80)"/>
-    <comp lib="1" loc="(290,2670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,2210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJR"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1810)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,2670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,2370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscall"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,290)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,1910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,700)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(200,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2070)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2080)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,640)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1940)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,1560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,1310)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1010)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,610)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,1870)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,1310)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,510)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(290,2830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,190)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,2670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,770)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(210,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,240)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(290,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2370)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,1870)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-  </circuit>
-  <circuit name="ALU_Decoder">
-    <a name="circuit" val="ALU_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="66" stroke="#000000" stroke-width="2" width="60" x="50" y="55"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="88">ALU</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="104">Decoder</text>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
-      <circ-port height="8" pin="40,130" width="8" x="46" y="76"/>
-      <circ-port height="10" pin="430,140" width="10" x="105" y="65"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
-      <circ-port height="8" pin="40,240" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="40,300" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="430,1130" width="10" x="105" y="75"/>
-      <circ-port height="10" pin="430,2190" width="10" x="105" y="85"/>
-      <circ-port height="10" pin="430,3270" width="10" x="105" y="95"/>
-      <circ-anchor facing="east" height="6" width="6" x="97" y="67"/>
-    </appear>
-    <wire from="(310,1140)" to="(310,1210)"/>
-    <wire from="(200,910)" to="(260,910)"/>
-    <wire from="(120,3710)" to="(180,3710)"/>
-    <wire from="(230,230)" to="(230,240)"/>
-    <wire from="(60,3960)" to="(60,4100)"/>
-    <wire from="(240,2800)" to="(240,2820)"/>
-    <wire from="(240,240)" to="(240,260)"/>
-    <wire from="(230,550)" to="(230,570)"/>
-    <wire from="(200,290)" to="(240,290)"/>
-    <wire from="(200,1570)" to="(240,1570)"/>
-    <wire from="(140,2150)" to="(180,2150)"/>
-    <wire from="(140,2470)" to="(180,2470)"/>
-    <wire from="(200,2210)" to="(240,2210)"/>
-    <wire from="(200,2530)" to="(240,2530)"/>
-    <wire from="(80,880)" to="(180,880)"/>
-    <wire from="(340,3310)" to="(380,3310)"/>
-    <wire from="(60,3640)" to="(60,3800)"/>
-    <wire from="(230,1930)" to="(260,1930)"/>
-    <wire from="(230,2250)" to="(260,2250)"/>
-    <wire from="(230,2570)" to="(260,2570)"/>
-    <wire from="(230,3850)" to="(260,3850)"/>
-    <wire from="(230,4170)" to="(260,4170)"/>
-    <wire from="(290,80)" to="(310,80)"/>
-    <wire from="(80,1920)" to="(230,1920)"/>
-    <wire from="(160,3470)" to="(180,3470)"/>
-    <wire from="(240,560)" to="(240,600)"/>
-    <wire from="(80,2380)" to="(80,2560)"/>
-    <wire from="(310,1140)" to="(380,1140)"/>
-    <wire from="(60,3210)" to="(180,3210)"/>
-    <wire from="(290,2740)" to="(340,2740)"/>
-    <wire from="(230,3240)" to="(230,3250)"/>
-    <wire from="(200,2660)" to="(240,2660)"/>
-    <wire from="(140,4200)" to="(180,4200)"/>
-    <wire from="(80,50)" to="(180,50)"/>
-    <wire from="(80,1330)" to="(180,1330)"/>
-    <wire from="(200,110)" to="(230,110)"/>
-    <wire from="(100,780)" to="(260,780)"/>
-    <wire from="(80,80)" to="(80,180)"/>
-    <wire from="(290,210)" to="(310,210)"/>
-    <wire from="(240,4000)" to="(260,4000)"/>
-    <wire from="(160,2320)" to="(180,2320)"/>
-    <wire from="(100,1050)" to="(180,1050)"/>
-    <wire from="(100,2970)" to="(180,2970)"/>
-    <wire from="(160,3030)" to="(240,3030)"/>
-    <wire from="(230,810)" to="(230,820)"/>
-    <wire from="(60,2060)" to="(180,2060)"/>
-    <wire from="(240,820)" to="(240,830)"/>
-    <wire from="(230,2090)" to="(230,2100)"/>
-    <wire from="(160,1120)" to="(160,1270)"/>
-    <wire from="(320,1150)" to="(320,1360)"/>
-    <wire from="(80,180)" to="(180,180)"/>
-    <wire from="(80,500)" to="(180,500)"/>
-    <wire from="(200,880)" to="(230,880)"/>
-    <wire from="(350,530)" to="(350,1080)"/>
-    <wire from="(140,3450)" to="(230,3450)"/>
-    <wire from="(230,1230)" to="(260,1230)"/>
-    <wire from="(230,2830)" to="(260,2830)"/>
-    <wire from="(200,1850)" to="(220,1850)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(120,1850)" to="(120,1970)"/>
-    <wire from="(200,1940)" to="(260,1940)"/>
-    <wire from="(200,3860)" to="(260,3860)"/>
-    <wire from="(140,1870)" to="(140,2000)"/>
-    <wire from="(230,940)" to="(230,950)"/>
-    <wire from="(240,950)" to="(240,970)"/>
-    <wire from="(100,3110)" to="(100,3260)"/>
-    <wire from="(120,3130)" to="(120,3280)"/>
-    <wire from="(140,3150)" to="(140,3300)"/>
-    <wire from="(60,1150)" to="(60,1300)"/>
-    <wire from="(80,3830)" to="(180,3830)"/>
-    <wire from="(120,190)" to="(120,220)"/>
-    <wire from="(200,50)" to="(230,50)"/>
-    <wire from="(200,1330)" to="(230,1330)"/>
-    <wire from="(160,1570)" to="(160,1730)"/>
-    <wire from="(140,2300)" to="(230,2300)"/>
-    <wire from="(230,1040)" to="(260,1040)"/>
-    <wire from="(230,2960)" to="(260,2960)"/>
-    <wire from="(120,700)" to="(120,800)"/>
-    <wire from="(140,720)" to="(140,820)"/>
-    <wire from="(240,1700)" to="(260,1700)"/>
-    <wire from="(240,3300)" to="(260,3300)"/>
-    <wire from="(200,380)" to="(220,380)"/>
-    <wire from="(200,700)" to="(220,700)"/>
-    <wire from="(100,350)" to="(180,350)"/>
-    <wire from="(100,670)" to="(180,670)"/>
-    <wire from="(160,730)" to="(240,730)"/>
-    <wire from="(160,2660)" to="(160,2790)"/>
-    <wire from="(140,3600)" to="(140,3740)"/>
-    <wire from="(330,1160)" to="(330,1500)"/>
-    <wire from="(160,3620)" to="(160,3770)"/>
-    <wire from="(140,2000)" to="(140,2150)"/>
-    <wire from="(140,110)" to="(180,110)"/>
-    <wire from="(240,2680)" to="(240,2710)"/>
-    <wire from="(240,3640)" to="(240,3670)"/>
-    <wire from="(220,2430)" to="(260,2430)"/>
-    <wire from="(220,2750)" to="(260,2750)"/>
-    <wire from="(200,3050)" to="(240,3050)"/>
-    <wire from="(80,760)" to="(180,760)"/>
-    <wire from="(200,180)" to="(230,180)"/>
-    <wire from="(200,500)" to="(230,500)"/>
-    <wire from="(60,1600)" to="(60,1760)"/>
-    <wire from="(100,1490)" to="(260,1490)"/>
-    <wire from="(120,380)" to="(120,540)"/>
-    <wire from="(100,3410)" to="(260,3410)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(230,4050)" to="(260,4050)"/>
-    <wire from="(160,2790)" to="(160,2890)"/>
-    <wire from="(240,2150)" to="(260,2150)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(100,2730)" to="(100,2840)"/>
-    <wire from="(240,3960)" to="(240,4000)"/>
-    <wire from="(120,3130)" to="(260,3130)"/>
-    <wire from="(310,3260)" to="(380,3260)"/>
-    <wire from="(290,360)" to="(360,360)"/>
-    <wire from="(80,3990)" to="(80,4120)"/>
-    <wire from="(120,2440)" to="(180,2440)"/>
-    <wire from="(120,2760)" to="(180,2760)"/>
-    <wire from="(330,3300)" to="(380,3300)"/>
-    <wire from="(60,850)" to="(180,850)"/>
-    <wire from="(230,3440)" to="(230,3450)"/>
-    <wire from="(230,1520)" to="(230,1540)"/>
-    <wire from="(240,3450)" to="(240,3470)"/>
-    <wire from="(230,880)" to="(230,900)"/>
-    <wire from="(200,1900)" to="(240,1900)"/>
-    <wire from="(200,3180)" to="(240,3180)"/>
-    <wire from="(200,3500)" to="(240,3500)"/>
-    <wire from="(220,4160)" to="(260,4160)"/>
-    <wire from="(230,340)" to="(260,340)"/>
-    <wire from="(200,950)" to="(230,950)"/>
-    <wire from="(230,660)" to="(260,660)"/>
-    <wire from="(100,2260)" to="(260,2260)"/>
-    <wire from="(100,2580)" to="(260,2580)"/>
-    <wire from="(80,3670)" to="(80,3830)"/>
-    <wire from="(140,2880)" to="(230,2880)"/>
-    <wire from="(200,3830)" to="(230,3830)"/>
-    <wire from="(290,1360)" to="(320,1360)"/>
-    <wire from="(230,3540)" to="(260,3540)"/>
-    <wire from="(240,1640)" to="(260,1640)"/>
-    <wire from="(100,2410)" to="(100,2580)"/>
-    <wire from="(240,3240)" to="(260,3240)"/>
-    <wire from="(100,3690)" to="(100,3860)"/>
-    <wire from="(240,1530)" to="(240,1570)"/>
-    <wire from="(160,600)" to="(180,600)"/>
-    <wire from="(120,3710)" to="(120,3890)"/>
-    <wire from="(200,2970)" to="(260,2970)"/>
-    <wire from="(200,1050)" to="(260,1050)"/>
-    <wire from="(200,1370)" to="(260,1370)"/>
-    <wire from="(120,4170)" to="(180,4170)"/>
-    <wire from="(60,20)" to="(180,20)"/>
-    <wire from="(230,50)" to="(230,60)"/>
-    <wire from="(60,1300)" to="(180,1300)"/>
-    <wire from="(230,1330)" to="(230,1340)"/>
-    <wire from="(220,1960)" to="(220,1970)"/>
-    <wire from="(230,2290)" to="(230,2300)"/>
-    <wire from="(220,3880)" to="(220,3890)"/>
-    <wire from="(240,2300)" to="(240,2320)"/>
-    <wire from="(230,2610)" to="(230,2630)"/>
-    <wire from="(230,3890)" to="(230,3910)"/>
-    <wire from="(230,1970)" to="(230,2000)"/>
-    <wire from="(240,3900)" to="(240,3930)"/>
-    <wire from="(200,2030)" to="(240,2030)"/>
-    <wire from="(200,2350)" to="(240,2350)"/>
-    <wire from="(80,1020)" to="(180,1020)"/>
-    <wire from="(80,2940)" to="(180,2940)"/>
-    <wire from="(200,760)" to="(230,760)"/>
-    <wire from="(200,1400)" to="(230,1400)"/>
-    <wire from="(240,2090)" to="(260,2090)"/>
-    <wire from="(160,3930)" to="(180,3930)"/>
-    <wire from="(290,3420)" to="(310,3420)"/>
-    <wire from="(240,2620)" to="(240,2660)"/>
-    <wire from="(340,1170)" to="(340,1670)"/>
-    <wire from="(240,1980)" to="(240,2030)"/>
-    <wire from="(200,220)" to="(260,220)"/>
-    <wire from="(200,540)" to="(260,540)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(330,3240)" to="(380,3240)"/>
-    <wire from="(60,150)" to="(180,150)"/>
-    <wire from="(230,180)" to="(230,190)"/>
-    <wire from="(60,470)" to="(180,470)"/>
-    <wire from="(230,500)" to="(230,510)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(240,1150)" to="(240,1180)"/>
-    <wire from="(80,1470)" to="(180,1470)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(80,3390)" to="(180,3390)"/>
-    <wire from="(200,570)" to="(230,570)"/>
-    <wire from="(100,2840)" to="(260,2840)"/>
-    <wire from="(290,2270)" to="(310,2270)"/>
-    <wire from="(100,3110)" to="(180,3110)"/>
-    <wire from="(320,1110)" to="(380,1110)"/>
-    <wire from="(200,350)" to="(260,350)"/>
-    <wire from="(200,670)" to="(260,670)"/>
-    <wire from="(60,3800)" to="(180,3800)"/>
-    <wire from="(230,2870)" to="(230,2880)"/>
-    <wire from="(160,300)" to="(160,440)"/>
-    <wire from="(240,2880)" to="(240,2890)"/>
-    <wire from="(230,3830)" to="(230,3850)"/>
-    <wire from="(100,1200)" to="(100,1350)"/>
-    <wire from="(120,1220)" to="(120,1370)"/>
-    <wire from="(160,3180)" to="(160,3330)"/>
-    <wire from="(80,1180)" to="(80,1330)"/>
-    <wire from="(140,950)" to="(180,950)"/>
-    <wire from="(80,320)" to="(180,320)"/>
-    <wire from="(80,640)" to="(180,640)"/>
-    <wire from="(80,2240)" to="(180,2240)"/>
-    <wire from="(80,2560)" to="(180,2560)"/>
-    <wire from="(200,1020)" to="(230,1020)"/>
-    <wire from="(140,3910)" to="(230,3910)"/>
-    <wire from="(140,1240)" to="(140,1400)"/>
-    <wire from="(230,1690)" to="(260,1690)"/>
-    <wire from="(200,2940)" to="(230,2940)"/>
-    <wire from="(230,3290)" to="(260,3290)"/>
-    <wire from="(240,1390)" to="(260,1390)"/>
-    <wire from="(360,1190)" to="(380,1190)"/>
-    <wire from="(240,1600)" to="(240,1640)"/>
-    <wire from="(240,110)" to="(260,110)"/>
-    <wire from="(160,3620)" to="(240,3620)"/>
-    <wire from="(200,800)" to="(260,800)"/>
-    <wire from="(230,760)" to="(230,770)"/>
-    <wire from="(230,1080)" to="(230,1090)"/>
-    <wire from="(230,3000)" to="(230,3010)"/>
-    <wire from="(350,1180)" to="(350,1830)"/>
-    <wire from="(240,3010)" to="(240,3030)"/>
-    <wire from="(60,3210)" to="(60,3360)"/>
-    <wire from="(160,2030)" to="(160,2180)"/>
-    <wire from="(240,1090)" to="(240,1120)"/>
-    <wire from="(140,1400)" to="(180,1400)"/>
-    <wire from="(220,4040)" to="(260,4040)"/>
-    <wire from="(200,1470)" to="(230,1470)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(80,1630)" to="(80,1790)"/>
-    <wire from="(140,410)" to="(140,570)"/>
-    <wire from="(350,3220)" to="(380,3220)"/>
-    <wire from="(290,920)" to="(320,920)"/>
-    <wire from="(230,2140)" to="(260,2140)"/>
-    <wire from="(200,3390)" to="(230,3390)"/>
-    <wire from="(230,3100)" to="(260,3100)"/>
-    <wire from="(120,2760)" to="(120,2860)"/>
-    <wire from="(140,2780)" to="(140,2880)"/>
-    <wire from="(200,2440)" to="(220,2440)"/>
-    <wire from="(200,2760)" to="(220,2760)"/>
-    <wire from="(160,1120)" to="(180,1120)"/>
-    <wire from="(240,240)" to="(260,240)"/>
-    <wire from="(240,560)" to="(260,560)"/>
-    <wire from="(350,2590)" to="(350,3220)"/>
-    <wire from="(100,2410)" to="(180,2410)"/>
-    <wire from="(100,2730)" to="(180,2730)"/>
-    <wire from="(160,2790)" to="(240,2790)"/>
-    <wire from="(120,1220)" to="(260,1220)"/>
-    <wire from="(310,2120)" to="(310,2180)"/>
-    <wire from="(100,4020)" to="(100,4140)"/>
-    <wire from="(320,3290)" to="(380,3290)"/>
-    <wire from="(40,130)" to="(100,130)"/>
-    <wire from="(120,4050)" to="(180,4050)"/>
-    <wire from="(290,1670)" to="(340,1670)"/>
-    <wire from="(220,1840)" to="(220,1850)"/>
-    <wire from="(230,1850)" to="(230,1870)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(240,4100)" to="(240,4120)"/>
-    <wire from="(160,4080)" to="(160,4230)"/>
-    <wire from="(60,2060)" to="(60,2210)"/>
-    <wire from="(140,570)" to="(180,570)"/>
-    <wire from="(200,1270)" to="(240,1270)"/>
-    <wire from="(340,1090)" to="(380,1090)"/>
-    <wire from="(80,2820)" to="(180,2820)"/>
-    <wire from="(200,320)" to="(230,320)"/>
-    <wire from="(200,640)" to="(230,640)"/>
-    <wire from="(100,3550)" to="(260,3550)"/>
-    <wire from="(120,2440)" to="(120,2600)"/>
-    <wire from="(200,2240)" to="(230,2240)"/>
-    <wire from="(200,2560)" to="(230,2560)"/>
-    <wire from="(290,1060)" to="(310,1060)"/>
-    <wire from="(240,1330)" to="(260,1330)"/>
-    <wire from="(200,4170)" to="(220,4170)"/>
-    <wire from="(140,3740)" to="(140,3910)"/>
-    <wire from="(240,50)" to="(260,50)"/>
-    <wire from="(160,1570)" to="(180,1570)"/>
-    <wire from="(330,790)" to="(330,1100)"/>
-    <wire from="(100,4140)" to="(180,4140)"/>
-    <wire from="(360,1190)" to="(360,1950)"/>
-    <wire from="(290,2420)" to="(360,2420)"/>
-    <wire from="(290,4030)" to="(350,4030)"/>
-    <wire from="(360,360)" to="(360,1070)"/>
-    <wire from="(220,370)" to="(220,380)"/>
-    <wire from="(220,690)" to="(220,700)"/>
-    <wire from="(60,990)" to="(180,990)"/>
-    <wire from="(60,2910)" to="(180,2910)"/>
-    <wire from="(60,740)" to="(240,740)"/>
-    <wire from="(230,2940)" to="(230,2960)"/>
-    <wire from="(230,3580)" to="(230,3600)"/>
-    <wire from="(230,700)" to="(230,720)"/>
-    <wire from="(240,710)" to="(240,730)"/>
-    <wire from="(230,1020)" to="(230,1040)"/>
-    <wire from="(200,440)" to="(240,440)"/>
-    <wire from="(240,3590)" to="(240,3620)"/>
-    <wire from="(200,3640)" to="(240,3640)"/>
-    <wire from="(200,3960)" to="(240,3960)"/>
-    <wire from="(230,380)" to="(230,410)"/>
-    <wire from="(200,1090)" to="(230,1090)"/>
-    <wire from="(230,2400)" to="(260,2400)"/>
-    <wire from="(230,2720)" to="(260,2720)"/>
-    <wire from="(200,3010)" to="(230,3010)"/>
-    <wire from="(230,3680)" to="(260,3680)"/>
-    <wire from="(240,820)" to="(260,820)"/>
-    <wire from="(240,180)" to="(260,180)"/>
-    <wire from="(240,500)" to="(260,500)"/>
-    <wire from="(160,2660)" to="(180,2660)"/>
-    <wire from="(240,390)" to="(240,440)"/>
-    <wire from="(290,4150)" to="(360,4150)"/>
-    <wire from="(200,3110)" to="(260,3110)"/>
-    <wire from="(200,3430)" to="(260,3430)"/>
-    <wire from="(200,1510)" to="(260,1510)"/>
-    <wire from="(60,1440)" to="(180,1440)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(60,3360)" to="(180,3360)"/>
-    <wire from="(60,20)" to="(60,30)"/>
-    <wire from="(230,1470)" to="(230,1480)"/>
-    <wire from="(230,3390)" to="(230,3400)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(200,3770)" to="(240,3770)"/>
-    <wire from="(80,3080)" to="(180,3080)"/>
-    <wire from="(200,1540)" to="(230,1540)"/>
-    <wire from="(140,1870)" to="(230,1870)"/>
-    <wire from="(200,2820)" to="(230,2820)"/>
-    <wire from="(230,4130)" to="(260,4130)"/>
-    <wire from="(240,950)" to="(260,950)"/>
-    <wire from="(360,1070)" to="(380,1070)"/>
-    <wire from="(80,4120)" to="(230,4120)"/>
-    <wire from="(200,2280)" to="(260,2280)"/>
-    <wire from="(200,2600)" to="(260,2600)"/>
-    <wire from="(60,290)" to="(180,290)"/>
-    <wire from="(60,2210)" to="(180,2210)"/>
-    <wire from="(60,2530)" to="(180,2530)"/>
-    <wire from="(60,850)" to="(60,990)"/>
-    <wire from="(230,1920)" to="(230,1930)"/>
-    <wire from="(230,2240)" to="(230,2250)"/>
-    <wire from="(230,2560)" to="(230,2570)"/>
-    <wire from="(160,1270)" to="(160,1420)"/>
-    <wire from="(230,320)" to="(230,340)"/>
-    <wire from="(230,640)" to="(230,660)"/>
-    <wire from="(240,3210)" to="(240,3240)"/>
-    <wire from="(290,790)" to="(330,790)"/>
-    <wire from="(220,1680)" to="(260,1680)"/>
-    <wire from="(80,3530)" to="(180,3530)"/>
-    <wire from="(230,100)" to="(260,100)"/>
-    <wire from="(140,720)" to="(230,720)"/>
-    <wire from="(230,1380)" to="(260,1380)"/>
-    <wire from="(200,2630)" to="(230,2630)"/>
-    <wire from="(350,1180)" to="(380,1180)"/>
-    <wire from="(240,760)" to="(260,760)"/>
-    <wire from="(310,80)" to="(310,130)"/>
-    <wire from="(200,2410)" to="(260,2410)"/>
-    <wire from="(200,2730)" to="(260,2730)"/>
-    <wire from="(120,1370)" to="(180,1370)"/>
-    <wire from="(120,1690)" to="(180,1690)"/>
-    <wire from="(60,1300)" to="(60,1440)"/>
-    <wire from="(80,3240)" to="(80,3390)"/>
-    <wire from="(100,3260)" to="(100,3410)"/>
-    <wire from="(120,3280)" to="(120,3430)"/>
-    <wire from="(140,3300)" to="(140,3450)"/>
-    <wire from="(140,1090)" to="(180,1090)"/>
-    <wire from="(240,2060)" to="(240,2090)"/>
-    <wire from="(200,1150)" to="(240,1150)"/>
-    <wire from="(140,3010)" to="(180,3010)"/>
-    <wire from="(80,2380)" to="(180,2380)"/>
-    <wire from="(80,2700)" to="(180,2700)"/>
-    <wire from="(230,230)" to="(260,230)"/>
-    <wire from="(230,550)" to="(260,550)"/>
-    <wire from="(100,1660)" to="(100,1820)"/>
-    <wire from="(160,440)" to="(160,600)"/>
-    <wire from="(230,1190)" to="(260,1190)"/>
-    <wire from="(200,3080)" to="(230,3080)"/>
-    <wire from="(240,890)" to="(260,890)"/>
-    <wire from="(240,1530)" to="(260,1530)"/>
-    <wire from="(240,3450)" to="(260,3450)"/>
-    <wire from="(200,4050)" to="(220,4050)"/>
-    <wire from="(100,4020)" to="(180,4020)"/>
-    <wire from="(160,4080)" to="(240,4080)"/>
-    <wire from="(320,920)" to="(320,1110)"/>
-    <wire from="(120,4050)" to="(120,4170)"/>
-    <wire from="(310,3280)" to="(380,3280)"/>
-    <wire from="(200,2860)" to="(260,2860)"/>
-    <wire from="(200,4140)" to="(260,4140)"/>
-    <wire from="(120,220)" to="(180,220)"/>
-    <wire from="(120,540)" to="(180,540)"/>
-    <wire from="(140,4070)" to="(140,4200)"/>
-    <wire from="(310,3280)" to="(310,3420)"/>
-    <wire from="(60,150)" to="(60,290)"/>
-    <wire from="(60,620)" to="(240,620)"/>
-    <wire from="(230,2820)" to="(230,2830)"/>
-    <wire from="(230,3140)" to="(230,3150)"/>
-    <wire from="(80,2090)" to="(80,2240)"/>
-    <wire from="(100,2110)" to="(100,2260)"/>
-    <wire from="(120,2130)" to="(120,2280)"/>
-    <wire from="(140,2150)" to="(140,2300)"/>
-    <wire from="(60,470)" to="(60,620)"/>
-    <wire from="(140,1540)" to="(180,1540)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(240,3150)" to="(240,3180)"/>
-    <wire from="(140,2470)" to="(140,2630)"/>
-    <wire from="(160,3770)" to="(160,3930)"/>
-    <wire from="(200,3530)" to="(230,3530)"/>
-    <wire from="(290,2980)" to="(320,2980)"/>
-    <wire from="(310,130)" to="(330,130)"/>
-    <wire from="(240,1980)" to="(260,1980)"/>
-    <wire from="(240,2300)" to="(260,2300)"/>
-    <wire from="(240,2620)" to="(260,2620)"/>
-    <wire from="(240,3900)" to="(260,3900)"/>
-    <wire from="(160,3180)" to="(180,3180)"/>
-    <wire from="(120,3280)" to="(260,3280)"/>
-    <wire from="(100,130)" to="(100,200)"/>
-    <wire from="(200,1730)" to="(240,1730)"/>
-    <wire from="(140,2630)" to="(180,2630)"/>
-    <wire from="(200,3330)" to="(240,3330)"/>
-    <wire from="(290,1500)" to="(330,1500)"/>
-    <wire from="(340,680)" to="(340,1090)"/>
-    <wire from="(230,810)" to="(260,810)"/>
-    <wire from="(60,3800)" to="(60,3960)"/>
-    <wire from="(100,3690)" to="(260,3690)"/>
-    <wire from="(200,2380)" to="(230,2380)"/>
-    <wire from="(200,2700)" to="(230,2700)"/>
-    <wire from="(230,4010)" to="(260,4010)"/>
-    <wire from="(240,1470)" to="(260,1470)"/>
-    <wire from="(310,2180)" to="(330,2180)"/>
-    <wire from="(290,3120)" to="(310,3120)"/>
-    <wire from="(240,3390)" to="(260,3390)"/>
-    <wire from="(160,2030)" to="(180,2030)"/>
-    <wire from="(120,2130)" to="(260,2130)"/>
-    <wire from="(310,150)" to="(310,210)"/>
-    <wire from="(120,800)" to="(180,800)"/>
-    <wire from="(320,3290)" to="(320,3560)"/>
-    <wire from="(60,3050)" to="(180,3050)"/>
-    <wire from="(220,2430)" to="(220,2440)"/>
-    <wire from="(220,2750)" to="(220,2760)"/>
-    <wire from="(60,2800)" to="(240,2800)"/>
-    <wire from="(160,830)" to="(160,970)"/>
-    <wire from="(230,2760)" to="(230,2780)"/>
-    <wire from="(240,2770)" to="(240,2790)"/>
-    <wire from="(230,3080)" to="(230,3100)"/>
-    <wire from="(230,3720)" to="(230,3740)"/>
-    <wire from="(230,2440)" to="(230,2470)"/>
-    <wire from="(200,260)" to="(240,260)"/>
-    <wire from="(200,2180)" to="(240,2180)"/>
-    <wire from="(200,2500)" to="(240,2500)"/>
-    <wire from="(200,4100)" to="(240,4100)"/>
-    <wire from="(80,50)" to="(80,80)"/>
-    <wire from="(230,940)" to="(260,940)"/>
-    <wire from="(290,3560)" to="(320,3560)"/>
-    <wire from="(200,3150)" to="(230,3150)"/>
-    <wire from="(240,1920)" to="(260,1920)"/>
-    <wire from="(240,2240)" to="(260,2240)"/>
-    <wire from="(240,2560)" to="(260,2560)"/>
-    <wire from="(240,2880)" to="(260,2880)"/>
-    <wire from="(240,3840)" to="(260,3840)"/>
-    <wire from="(410,1130)" to="(430,1130)"/>
-    <wire from="(240,850)" to="(240,890)"/>
-    <wire from="(240,3730)" to="(240,3770)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(240,2450)" to="(240,2500)"/>
-    <wire from="(100,70)" to="(100,130)"/>
-    <wire from="(330,2850)" to="(330,3240)"/>
-    <wire from="(200,3570)" to="(260,3570)"/>
-    <wire from="(310,2200)" to="(310,2270)"/>
-    <wire from="(60,1900)" to="(180,1900)"/>
-    <wire from="(60,3500)" to="(180,3500)"/>
-    <wire from="(80,880)" to="(80,1020)"/>
-    <wire from="(230,3530)" to="(230,3540)"/>
-    <wire from="(220,4160)" to="(220,4170)"/>
-    <wire from="(360,2420)" to="(360,3210)"/>
-    <wire from="(240,1300)" to="(240,1330)"/>
-    <wire from="(230,4170)" to="(230,4200)"/>
-    <wire from="(240,20)" to="(240,50)"/>
-    <wire from="(340,1170)" to="(380,1170)"/>
-    <wire from="(200,4230)" to="(240,4230)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(200,2000)" to="(230,2000)"/>
-    <wire from="(200,3600)" to="(230,3600)"/>
-    <wire from="(240,1090)" to="(260,1090)"/>
-    <wire from="(240,3010)" to="(260,3010)"/>
-    <wire from="(160,260)" to="(160,300)"/>
-    <wire from="(200,1690)" to="(220,1690)"/>
-    <wire from="(100,1660)" to="(180,1660)"/>
-    <wire from="(240,4180)" to="(240,4230)"/>
-    <wire from="(60,30)" to="(60,150)"/>
-    <wire from="(140,110)" to="(140,240)"/>
-    <wire from="(160,130)" to="(160,260)"/>
-    <wire from="(200,4020)" to="(260,4020)"/>
-    <wire from="(160,3330)" to="(160,3470)"/>
-    <wire from="(60,2350)" to="(180,2350)"/>
-    <wire from="(80,1330)" to="(80,1470)"/>
-    <wire from="(60,2910)" to="(60,3050)"/>
-    <wire from="(100,1350)" to="(100,1490)"/>
-    <wire from="(120,1370)" to="(120,1510)"/>
-    <wire from="(230,2380)" to="(230,2400)"/>
-    <wire from="(230,2700)" to="(230,2720)"/>
-    <wire from="(160,1730)" to="(160,1880)"/>
-    <wire from="(330,3300)" to="(330,3700)"/>
-    <wire from="(240,150)" to="(240,180)"/>
-    <wire from="(240,470)" to="(240,500)"/>
-    <wire from="(290,2850)" to="(330,2850)"/>
-    <wire from="(80,3670)" to="(180,3670)"/>
-    <wire from="(80,3990)" to="(180,3990)"/>
-    <wire from="(60,990)" to="(60,1150)"/>
-    <wire from="(100,1200)" to="(260,1200)"/>
-    <wire from="(120,1690)" to="(120,1850)"/>
-    <wire from="(140,1710)" to="(140,1870)"/>
-    <wire from="(140,2780)" to="(230,2780)"/>
-    <wire from="(230,1520)" to="(260,1520)"/>
-    <wire from="(230,3440)" to="(260,3440)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,2820)" to="(260,2820)"/>
-    <wire from="(360,140)" to="(430,140)"/>
-    <wire from="(120,1510)" to="(180,1510)"/>
-    <wire from="(120,3430)" to="(180,3430)"/>
-    <wire from="(60,1760)" to="(60,1900)"/>
-    <wire from="(80,180)" to="(80,320)"/>
-    <wire from="(80,500)" to="(80,640)"/>
-    <wire from="(230,1230)" to="(230,1240)"/>
-    <wire from="(60,3360)" to="(60,3500)"/>
-    <wire from="(160,2180)" to="(160,2320)"/>
-    <wire from="(100,200)" to="(100,350)"/>
-    <wire from="(100,520)" to="(100,670)"/>
-    <wire from="(240,1240)" to="(240,1270)"/>
-    <wire from="(140,3150)" to="(180,3150)"/>
-    <wire from="(200,3210)" to="(240,3210)"/>
-    <wire from="(40,240)" to="(140,240)"/>
-    <wire from="(60,1440)" to="(60,1600)"/>
-    <wire from="(120,220)" to="(120,380)"/>
-    <wire from="(120,540)" to="(120,700)"/>
-    <wire from="(160,2500)" to="(160,2660)"/>
-    <wire from="(230,1650)" to="(260,1650)"/>
-    <wire from="(230,1970)" to="(260,1970)"/>
-    <wire from="(230,2290)" to="(260,2290)"/>
-    <wire from="(230,2610)" to="(260,2610)"/>
-    <wire from="(230,3250)" to="(260,3250)"/>
-    <wire from="(230,3890)" to="(260,3890)"/>
-    <wire from="(240,1030)" to="(260,1030)"/>
-    <wire from="(140,240)" to="(140,410)"/>
-    <wire from="(240,2950)" to="(260,2950)"/>
-    <wire from="(240,3590)" to="(260,3590)"/>
-    <wire from="(240,3800)" to="(240,3840)"/>
-    <wire from="(240,390)" to="(260,390)"/>
-    <wire from="(240,710)" to="(260,710)"/>
-    <wire from="(160,1270)" to="(180,1270)"/>
-    <wire from="(120,90)" to="(260,90)"/>
-    <wire from="(360,2190)" to="(430,2190)"/>
-    <wire from="(290,530)" to="(350,530)"/>
-    <wire from="(120,2280)" to="(180,2280)"/>
-    <wire from="(120,2600)" to="(180,2600)"/>
-    <wire from="(60,2210)" to="(60,2350)"/>
-    <wire from="(60,2680)" to="(240,2680)"/>
-    <wire from="(60,2530)" to="(60,2680)"/>
-    <wire from="(140,2000)" to="(180,2000)"/>
-    <wire from="(140,3600)" to="(180,3600)"/>
-    <wire from="(200,2060)" to="(240,2060)"/>
-    <wire from="(80,3830)" to="(80,3990)"/>
-    <wire from="(230,2100)" to="(260,2100)"/>
-    <wire from="(200,3670)" to="(230,3670)"/>
-    <wire from="(200,3990)" to="(230,3990)"/>
-    <wire from="(290,1210)" to="(310,1210)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(160,440)" to="(180,440)"/>
-    <wire from="(60,740)" to="(60,850)"/>
-    <wire from="(160,830)" to="(240,830)"/>
-    <wire from="(60,290)" to="(60,470)"/>
-    <wire from="(340,3310)" to="(340,3870)"/>
-    <wire from="(80,760)" to="(80,880)"/>
-    <wire from="(120,800)" to="(120,930)"/>
-    <wire from="(140,820)" to="(140,950)"/>
-    <wire from="(320,3250)" to="(380,3250)"/>
-    <wire from="(100,780)" to="(100,910)"/>
-    <wire from="(320,2980)" to="(320,3250)"/>
-    <wire from="(290,3870)" to="(340,3870)"/>
-    <wire from="(220,4040)" to="(220,4050)"/>
-    <wire from="(230,4050)" to="(230,4070)"/>
-    <wire from="(240,4060)" to="(240,4080)"/>
-    <wire from="(200,3470)" to="(240,3470)"/>
-    <wire from="(80,1180)" to="(180,1180)"/>
-    <wire from="(200,1240)" to="(230,1240)"/>
-    <wire from="(230,2870)" to="(260,2870)"/>
-    <wire from="(160,3770)" to="(180,3770)"/>
-    <wire from="(240,3530)" to="(260,3530)"/>
-    <wire from="(360,3330)" to="(380,3330)"/>
-    <wire from="(240,330)" to="(260,330)"/>
-    <wire from="(240,650)" to="(260,650)"/>
-    <wire from="(310,1120)" to="(380,1120)"/>
-    <wire from="(200,1660)" to="(260,1660)"/>
-    <wire from="(120,2860)" to="(180,2860)"/>
-    <wire from="(330,1160)" to="(380,1160)"/>
-    <wire from="(100,910)" to="(100,1050)"/>
-    <wire from="(120,930)" to="(120,1070)"/>
-    <wire from="(140,950)" to="(140,1090)"/>
-    <wire from="(160,2890)" to="(160,3030)"/>
-    <wire from="(160,970)" to="(160,1120)"/>
-    <wire from="(200,2320)" to="(240,2320)"/>
-    <wire from="(80,1630)" to="(180,1630)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(230,1080)" to="(260,1080)"/>
-    <wire from="(230,3000)" to="(260,3000)"/>
-    <wire from="(240,990)" to="(240,1030)"/>
-    <wire from="(340,2740)" to="(340,3230)"/>
-    <wire from="(240,2910)" to="(240,2950)"/>
-    <wire from="(160,130)" to="(240,130)"/>
-    <wire from="(310,1060)" to="(310,1120)"/>
-    <wire from="(200,3710)" to="(260,3710)"/>
-    <wire from="(350,3320)" to="(350,4030)"/>
-    <wire from="(60,3640)" to="(180,3640)"/>
-    <wire from="(60,3960)" to="(180,3960)"/>
-    <wire from="(80,2940)" to="(80,3080)"/>
-    <wire from="(140,1400)" to="(140,1540)"/>
-    <wire from="(230,3670)" to="(230,3680)"/>
-    <wire from="(230,3990)" to="(230,4010)"/>
-    <wire from="(160,1420)" to="(160,1570)"/>
-    <wire from="(240,1440)" to="(240,1470)"/>
-    <wire from="(200,850)" to="(240,850)"/>
-    <wire from="(240,3360)" to="(240,3390)"/>
-    <wire from="(340,3230)" to="(380,3230)"/>
-    <wire from="(200,1180)" to="(230,1180)"/>
-    <wire from="(80,1020)" to="(80,1180)"/>
-    <wire from="(140,4070)" to="(230,4070)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(200,3740)" to="(230,3740)"/>
-    <wire from="(240,3150)" to="(260,3150)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(120,930)" to="(260,930)"/>
-    <wire from="(80,1790)" to="(80,1920)"/>
-    <wire from="(330,1100)" to="(380,1100)"/>
-    <wire from="(80,3390)" to="(80,3530)"/>
-    <wire from="(230,4120)" to="(230,4130)"/>
-    <wire from="(100,3410)" to="(100,3550)"/>
-    <wire from="(120,3430)" to="(120,3570)"/>
-    <wire from="(160,3470)" to="(160,3620)"/>
-    <wire from="(140,570)" to="(140,720)"/>
-    <wire from="(140,3450)" to="(140,3600)"/>
-    <wire from="(140,1240)" to="(180,1240)"/>
-    <wire from="(240,2210)" to="(240,2240)"/>
-    <wire from="(240,2530)" to="(240,2560)"/>
-    <wire from="(200,20)" to="(240,20)"/>
-    <wire from="(200,1300)" to="(240,1300)"/>
-    <wire from="(220,1960)" to="(260,1960)"/>
-    <wire from="(220,3880)" to="(260,3880)"/>
-    <wire from="(230,60)" to="(260,60)"/>
-    <wire from="(230,380)" to="(260,380)"/>
-    <wire from="(230,700)" to="(260,700)"/>
-    <wire from="(200,1630)" to="(230,1630)"/>
-    <wire from="(80,1470)" to="(80,1630)"/>
-    <wire from="(60,3050)" to="(60,3210)"/>
-    <wire from="(100,3260)" to="(260,3260)"/>
-    <wire from="(230,1340)" to="(260,1340)"/>
-    <wire from="(230,3580)" to="(260,3580)"/>
-    <wire from="(310,150)" to="(330,150)"/>
-    <wire from="(100,1490)" to="(100,1660)"/>
-    <wire from="(240,290)" to="(240,330)"/>
-    <wire from="(360,3330)" to="(360,4150)"/>
-    <wire from="(120,1510)" to="(120,1690)"/>
-    <wire from="(60,620)" to="(60,740)"/>
-    <wire from="(80,640)" to="(80,760)"/>
-    <wire from="(120,1970)" to="(180,1970)"/>
-    <wire from="(120,3570)" to="(180,3570)"/>
-    <wire from="(120,3890)" to="(180,3890)"/>
-    <wire from="(220,1680)" to="(220,1690)"/>
-    <wire from="(60,3500)" to="(60,3640)"/>
-    <wire from="(80,2240)" to="(80,2380)"/>
-    <wire from="(80,2560)" to="(80,2700)"/>
-    <wire from="(230,3290)" to="(230,3300)"/>
-    <wire from="(230,1690)" to="(230,1710)"/>
-    <wire from="(100,2260)" to="(100,2410)"/>
-    <wire from="(100,2580)" to="(100,2730)"/>
-    <wire from="(240,740)" to="(240,760)"/>
-    <wire from="(140,410)" to="(180,410)"/>
-    <wire from="(240,1700)" to="(240,1730)"/>
-    <wire from="(200,150)" to="(240,150)"/>
-    <wire from="(200,470)" to="(240,470)"/>
-    <wire from="(240,3300)" to="(240,3330)"/>
-    <wire from="(230,190)" to="(260,190)"/>
-    <wire from="(230,510)" to="(260,510)"/>
-    <wire from="(60,1900)" to="(60,2060)"/>
-    <wire from="(100,2110)" to="(260,2110)"/>
-    <wire from="(120,2280)" to="(120,2440)"/>
-    <wire from="(100,3860)" to="(100,4020)"/>
-    <wire from="(120,2600)" to="(120,2760)"/>
-    <wire from="(240,2450)" to="(260,2450)"/>
-    <wire from="(240,2770)" to="(260,2770)"/>
-    <wire from="(160,3330)" to="(180,3330)"/>
-    <wire from="(80,1920)" to="(80,2090)"/>
-    <wire from="(100,1940)" to="(100,2110)"/>
-    <wire from="(310,2200)" to="(330,2200)"/>
-    <wire from="(240,3090)" to="(260,3090)"/>
-    <wire from="(240,3730)" to="(260,3730)"/>
-    <wire from="(140,2300)" to="(140,2470)"/>
-    <wire from="(360,3210)" to="(380,3210)"/>
-    <wire from="(160,1730)" to="(180,1730)"/>
-    <wire from="(80,320)" to="(80,500)"/>
-    <wire from="(160,2320)" to="(160,2500)"/>
-    <wire from="(290,2590)" to="(350,2590)"/>
-    <wire from="(60,1150)" to="(180,1150)"/>
-    <wire from="(290,680)" to="(340,680)"/>
-    <wire from="(230,1180)" to="(230,1190)"/>
-    <wire from="(230,2140)" to="(230,2150)"/>
-    <wire from="(240,2150)" to="(240,2180)"/>
-    <wire from="(200,600)" to="(240,600)"/>
-    <wire from="(140,3740)" to="(180,3740)"/>
-    <wire from="(200,3800)" to="(240,3800)"/>
-    <wire from="(350,3320)" to="(380,3320)"/>
-    <wire from="(350,1080)" to="(380,1080)"/>
-    <wire from="(240,4180)" to="(260,4180)"/>
-    <wire from="(60,2800)" to="(60,2910)"/>
-    <wire from="(160,260)" to="(180,260)"/>
-    <wire from="(160,2180)" to="(180,2180)"/>
-    <wire from="(160,2500)" to="(180,2500)"/>
-    <wire from="(100,910)" to="(180,910)"/>
-    <wire from="(160,970)" to="(240,970)"/>
-    <wire from="(160,2890)" to="(240,2890)"/>
-    <wire from="(60,2350)" to="(60,2530)"/>
-    <wire from="(80,2820)" to="(80,2940)"/>
-    <wire from="(100,2840)" to="(100,2970)"/>
-    <wire from="(320,1150)" to="(380,1150)"/>
-    <wire from="(120,2860)" to="(120,2990)"/>
-    <wire from="(140,2880)" to="(140,3010)"/>
-    <wire from="(40,300)" to="(160,300)"/>
-    <wire from="(60,1600)" to="(180,1600)"/>
-    <wire from="(230,1630)" to="(230,1650)"/>
-    <wire from="(200,3930)" to="(240,3930)"/>
-    <wire from="(80,3240)" to="(180,3240)"/>
-    <wire from="(290,3700)" to="(330,3700)"/>
-    <wire from="(230,770)" to="(260,770)"/>
-    <wire from="(140,1710)" to="(230,1710)"/>
-    <wire from="(200,3300)" to="(230,3300)"/>
-    <wire from="(240,2390)" to="(260,2390)"/>
-    <wire from="(240,2710)" to="(260,2710)"/>
-    <wire from="(160,4230)" to="(180,4230)"/>
-    <wire from="(290,2120)" to="(310,2120)"/>
-    <wire from="(240,3670)" to="(260,3670)"/>
-    <wire from="(160,1420)" to="(240,1420)"/>
-    <wire from="(100,2970)" to="(100,3110)"/>
-    <wire from="(120,2990)" to="(120,3130)"/>
-    <wire from="(140,3010)" to="(140,3150)"/>
-    <wire from="(100,1050)" to="(100,1200)"/>
-    <wire from="(120,1070)" to="(120,1220)"/>
-    <wire from="(140,1090)" to="(140,1240)"/>
-    <wire from="(160,3030)" to="(160,3180)"/>
-    <wire from="(220,1840)" to="(260,1840)"/>
-    <wire from="(80,2090)" to="(180,2090)"/>
-    <wire from="(290,3270)" to="(380,3270)"/>
-    <wire from="(230,900)" to="(260,900)"/>
-    <wire from="(140,240)" to="(230,240)"/>
-    <wire from="(200,2150)" to="(230,2150)"/>
-    <wire from="(200,2470)" to="(230,2470)"/>
-    <wire from="(230,3140)" to="(260,3140)"/>
-    <wire from="(240,1240)" to="(260,1240)"/>
-    <wire from="(240,4120)" to="(260,4120)"/>
-    <wire from="(240,3050)" to="(240,3090)"/>
-    <wire from="(100,1820)" to="(100,1940)"/>
-    <wire from="(160,600)" to="(160,730)"/>
-    <wire from="(120,1850)" to="(180,1850)"/>
-    <wire from="(60,4100)" to="(180,4100)"/>
-    <wire from="(240,1900)" to="(240,1920)"/>
-    <wire from="(160,1880)" to="(160,2030)"/>
-    <wire from="(220,370)" to="(260,370)"/>
-    <wire from="(220,690)" to="(260,690)"/>
-    <wire from="(200,990)" to="(240,990)"/>
-    <wire from="(240,3500)" to="(240,3530)"/>
-    <wire from="(200,2910)" to="(240,2910)"/>
-    <wire from="(240,620)" to="(240,650)"/>
-    <wire from="(100,70)" to="(260,70)"/>
-    <wire from="(100,1350)" to="(260,1350)"/>
-    <wire from="(80,3080)" to="(80,3240)"/>
-    <wire from="(200,3240)" to="(230,3240)"/>
-    <wire from="(160,730)" to="(160,830)"/>
-    <wire from="(200,4200)" to="(230,4200)"/>
-    <wire from="(200,3890)" to="(220,3890)"/>
-    <wire from="(140,1540)" to="(140,1710)"/>
-    <wire from="(200,1970)" to="(220,1970)"/>
-    <wire from="(100,670)" to="(100,780)"/>
-    <wire from="(100,1940)" to="(180,1940)"/>
-    <wire from="(100,3860)" to="(180,3860)"/>
-    <wire from="(120,1070)" to="(260,1070)"/>
-    <wire from="(120,2990)" to="(260,2990)"/>
-    <wire from="(290,1830)" to="(350,1830)"/>
-    <wire from="(120,380)" to="(180,380)"/>
-    <wire from="(120,700)" to="(180,700)"/>
-    <wire from="(230,100)" to="(230,110)"/>
-    <wire from="(310,3120)" to="(310,3260)"/>
-    <wire from="(80,3530)" to="(80,3670)"/>
-    <wire from="(100,3550)" to="(100,3690)"/>
-    <wire from="(120,3570)" to="(120,3710)"/>
-    <wire from="(230,1380)" to="(230,1400)"/>
-    <wire from="(160,3930)" to="(160,4080)"/>
-    <wire from="(140,2630)" to="(140,2780)"/>
-    <wire from="(240,110)" to="(240,130)"/>
-    <wire from="(240,1390)" to="(240,1420)"/>
-    <wire from="(200,1120)" to="(240,1120)"/>
-    <wire from="(200,1440)" to="(240,1440)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(140,3300)" to="(180,3300)"/>
-    <wire from="(200,3360)" to="(240,3360)"/>
-    <wire from="(100,200)" to="(260,200)"/>
-    <wire from="(100,520)" to="(260,520)"/>
-    <wire from="(120,1970)" to="(120,2130)"/>
-    <wire from="(120,3890)" to="(120,4050)"/>
-    <wire from="(140,820)" to="(230,820)"/>
-    <wire from="(140,3910)" to="(140,4070)"/>
-    <wire from="(230,1480)" to="(260,1480)"/>
-    <wire from="(200,2090)" to="(230,2090)"/>
-    <wire from="(230,2440)" to="(260,2440)"/>
-    <wire from="(230,2760)" to="(260,2760)"/>
-    <wire from="(230,3400)" to="(260,3400)"/>
-    <wire from="(230,3720)" to="(260,3720)"/>
-    <wire from="(240,1180)" to="(260,1180)"/>
-    <wire from="(240,4060)" to="(260,4060)"/>
-    <wire from="(410,3270)" to="(430,3270)"/>
-    <wire from="(100,350)" to="(100,520)"/>
-    <wire from="(240,2350)" to="(240,2390)"/>
-    <wire from="(60,2680)" to="(60,2800)"/>
-    <wire from="(80,2700)" to="(80,2820)"/>
-    <wire from="(290,1950)" to="(360,1950)"/>
-    <comp lib="1" loc="(200,1900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4030)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3080)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(430,2190)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(430,1130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3270)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="13"/>
-    </comp>
-    <comp lib="1" loc="(200,320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1060)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,360)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2980)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3870)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,790)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2590)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,1130)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="12"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,300)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,140)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,2190)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,3420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,4100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,3120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4200)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2850)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,80)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,3270)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1360)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2740)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-  </circuit>
-  <circuit name="Opcode_Decoder">
-    <a name="circuit" val="Opcode_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="235" stroke="#000000" stroke-width="2" width="31" x="50" y="55"/>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="136"/>
-      <circ-port height="10" pin="420,70" width="10" x="75" y="65"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="146"/>
-      <circ-port height="8" pin="40,140" width="8" x="46" y="156"/>
-      <circ-port height="10" pin="420,180" width="10" x="75" y="85"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="166"/>
-      <circ-port height="8" pin="40,250" width="8" x="46" y="176"/>
-      <circ-port height="8" pin="40,300" width="8" x="46" y="186"/>
-      <circ-port height="10" pin="420,750" width="10" x="75" y="105"/>
-      <circ-port height="10" pin="420,1490" width="10" x="75" y="125"/>
-      <circ-port height="10" pin="420,1690" width="10" x="75" y="145"/>
-      <circ-port height="10" pin="420,1900" width="10" x="75" y="165"/>
-      <circ-port height="10" pin="420,2130" width="10" x="75" y="185"/>
-      <circ-port height="10" pin="420,2970" width="10" x="75" y="205"/>
-      <circ-port height="10" pin="420,3790" width="10" x="75" y="225"/>
-      <circ-port height="10" pin="420,3930" width="10" x="75" y="245"/>
-      <circ-port height="10" pin="420,4130" width="10" x="75" y="265"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
-    </appear>
-    <wire from="(120,190)" to="(180,190)"/>
-    <wire from="(350,3020)" to="(350,3610)"/>
-    <wire from="(60,3720)" to="(180,3720)"/>
-    <wire from="(330,450)" to="(330,720)"/>
-    <wire from="(220,2140)" to="(220,2150)"/>
-    <wire from="(230,3750)" to="(230,3770)"/>
-    <wire from="(230,2150)" to="(230,2180)"/>
-    <wire from="(140,2790)" to="(180,2790)"/>
-    <wire from="(240,3120)" to="(240,3150)"/>
-    <wire from="(200,2210)" to="(240,2210)"/>
-    <wire from="(200,2850)" to="(240,2850)"/>
-    <wire from="(240,240)" to="(240,270)"/>
-    <wire from="(320,730)" to="(360,730)"/>
-    <wire from="(230,2890)" to="(260,2890)"/>
-    <wire from="(200,3820)" to="(230,3820)"/>
-    <wire from="(240,990)" to="(260,990)"/>
-    <wire from="(200,3510)" to="(220,3510)"/>
-    <wire from="(350,3020)" to="(370,3020)"/>
-    <wire from="(200,1590)" to="(220,1590)"/>
-    <wire from="(100,1560)" to="(180,1560)"/>
-    <wire from="(160,1620)" to="(240,1620)"/>
-    <wire from="(100,3480)" to="(180,3480)"/>
-    <wire from="(160,3540)" to="(240,3540)"/>
-    <wire from="(120,690)" to="(260,690)"/>
-    <wire from="(240,2160)" to="(240,2210)"/>
-    <wire from="(120,4210)" to="(260,4210)"/>
-    <wire from="(310,1910)" to="(310,1970)"/>
-    <wire from="(120,1590)" to="(120,1710)"/>
-    <wire from="(140,1610)" to="(140,1730)"/>
-    <wire from="(120,3510)" to="(120,3630)"/>
-    <wire from="(200,3600)" to="(260,3600)"/>
-    <wire from="(200,3920)" to="(260,3920)"/>
-    <wire from="(140,3530)" to="(140,3660)"/>
-    <wire from="(200,1680)" to="(260,1680)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(80,270)" to="(80,410)"/>
-    <wire from="(80,3150)" to="(80,3290)"/>
-    <wire from="(100,3170)" to="(100,3310)"/>
-    <wire from="(120,3190)" to="(120,3330)"/>
-    <wire from="(100,290)" to="(100,440)"/>
-    <wire from="(200,740)" to="(240,740)"/>
-    <wire from="(200,2980)" to="(240,2980)"/>
-    <wire from="(80,1650)" to="(180,1650)"/>
-    <wire from="(80,3890)" to="(180,3890)"/>
-    <wire from="(200,1070)" to="(230,1070)"/>
-    <wire from="(120,310)" to="(120,470)"/>
-    <wire from="(160,1310)" to="(160,1470)"/>
-    <wire from="(230,3020)" to="(260,3020)"/>
-    <wire from="(290,2760)" to="(320,2760)"/>
-    <wire from="(230,3340)" to="(260,3340)"/>
-    <wire from="(240,800)" to="(260,800)"/>
-    <wire from="(240,1440)" to="(260,1440)"/>
-    <wire from="(240,480)" to="(260,480)"/>
-    <wire from="(310,760)" to="(310,830)"/>
-    <wire from="(120,3330)" to="(180,3330)"/>
-    <wire from="(60,2060)" to="(180,2060)"/>
-    <wire from="(60,2700)" to="(180,2700)"/>
-    <wire from="(230,2730)" to="(230,2740)"/>
-    <wire from="(230,2090)" to="(230,2110)"/>
-    <wire from="(240,2420)" to="(240,2450)"/>
-    <wire from="(60,1340)" to="(60,1500)"/>
-    <wire from="(100,1230)" to="(260,1230)"/>
-    <wire from="(60,3260)" to="(60,3420)"/>
-    <wire from="(140,3660)" to="(140,3820)"/>
-    <wire from="(390,750)" to="(420,750)"/>
-    <wire from="(230,1550)" to="(260,1550)"/>
-    <wire from="(230,3470)" to="(260,3470)"/>
-    <wire from="(240,930)" to="(260,930)"/>
-    <wire from="(340,710)" to="(360,710)"/>
-    <wire from="(160,3090)" to="(180,3090)"/>
-    <wire from="(60,510)" to="(60,620)"/>
-    <wire from="(330,2630)" to="(330,2940)"/>
-    <wire from="(160,600)" to="(240,600)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(80,530)" to="(80,650)"/>
-    <wire from="(100,550)" to="(100,670)"/>
-    <wire from="(120,570)" to="(120,690)"/>
-    <wire from="(140,590)" to="(140,710)"/>
-    <wire from="(80,2450)" to="(80,2590)"/>
-    <wire from="(230,1260)" to="(230,1280)"/>
-    <wire from="(100,2470)" to="(100,2620)"/>
-    <wire from="(290,450)" to="(330,450)"/>
-    <wire from="(200,3560)" to="(240,3560)"/>
-    <wire from="(140,3820)" to="(180,3820)"/>
-    <wire from="(200,1650)" to="(230,1650)"/>
-    <wire from="(120,2490)" to="(120,2650)"/>
-    <wire from="(200,3890)" to="(230,3890)"/>
-    <wire from="(240,1380)" to="(260,1380)"/>
-    <wire from="(240,2340)" to="(260,2340)"/>
-    <wire from="(240,2660)" to="(260,2660)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,1270)" to="(240,1310)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,420)" to="(260,420)"/>
-    <wire from="(160,2210)" to="(160,2390)"/>
-    <wire from="(320,770)" to="(320,960)"/>
-    <wire from="(200,1110)" to="(260,1110)"/>
-    <wire from="(60,1040)" to="(180,1040)"/>
-    <wire from="(230,1070)" to="(230,1080)"/>
-    <wire from="(220,1700)" to="(220,1710)"/>
-    <wire from="(160,740)" to="(160,880)"/>
-    <wire from="(220,3620)" to="(220,3630)"/>
-    <wire from="(220,3940)" to="(220,3950)"/>
-    <wire from="(230,1710)" to="(230,1730)"/>
-    <wire from="(240,1720)" to="(240,1740)"/>
-    <wire from="(230,3950)" to="(230,3970)"/>
-    <wire from="(240,3960)" to="(240,3980)"/>
-    <wire from="(230,3630)" to="(230,3660)"/>
-    <wire from="(200,3690)" to="(240,3690)"/>
-    <wire from="(230,850)" to="(260,850)"/>
-    <wire from="(200,1140)" to="(230,1140)"/>
-    <wire from="(100,1960)" to="(100,2120)"/>
-    <wire from="(100,4050)" to="(260,4050)"/>
-    <wire from="(140,3070)" to="(230,3070)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(120,1980)" to="(120,2150)"/>
-    <wire from="(240,2790)" to="(260,2790)"/>
-    <wire from="(240,4070)" to="(260,4070)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(160,2390)" to="(180,2390)"/>
-    <wire from="(160,220)" to="(240,220)"/>
-    <wire from="(60,2240)" to="(60,2420)"/>
-    <wire from="(240,3640)" to="(240,3690)"/>
-    <wire from="(140,2000)" to="(140,2180)"/>
-    <wire from="(80,150)" to="(80,270)"/>
-    <wire from="(100,170)" to="(100,290)"/>
-    <wire from="(120,190)" to="(120,310)"/>
-    <wire from="(200,3480)" to="(260,3480)"/>
-    <wire from="(330,4050)" to="(330,4120)"/>
-    <wire from="(60,770)" to="(60,900)"/>
-    <wire from="(200,1560)" to="(260,1560)"/>
-    <wire from="(200,620)" to="(240,620)"/>
-    <wire from="(200,1900)" to="(240,1900)"/>
-    <wire from="(80,1210)" to="(180,1210)"/>
-    <wire from="(290,2630)" to="(330,2630)"/>
-    <wire from="(200,4140)" to="(240,4140)"/>
-    <wire from="(80,1530)" to="(180,1530)"/>
-    <wire from="(80,3450)" to="(180,3450)"/>
-    <wire from="(230,660)" to="(260,660)"/>
-    <wire from="(230,980)" to="(260,980)"/>
-    <wire from="(100,2900)" to="(260,2900)"/>
-    <wire from="(340,3010)" to="(370,3010)"/>
-    <wire from="(230,4180)" to="(260,4180)"/>
-    <wire from="(240,2280)" to="(260,2280)"/>
-    <wire from="(240,2600)" to="(260,2600)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(120,1980)" to="(260,1980)"/>
-    <wire from="(330,780)" to="(330,1100)"/>
-    <wire from="(120,970)" to="(180,970)"/>
-    <wire from="(60,3860)" to="(180,3860)"/>
-    <wire from="(60,900)" to="(60,1040)"/>
-    <wire from="(230,2930)" to="(230,2940)"/>
-    <wire from="(140,3220)" to="(140,3360)"/>
-    <wire from="(230,1650)" to="(230,1670)"/>
-    <wire from="(240,2940)" to="(240,2960)"/>
-    <wire from="(230,3890)" to="(230,3910)"/>
-    <wire from="(160,3240)" to="(160,3390)"/>
-    <wire from="(140,340)" to="(140,490)"/>
-    <wire from="(240,3260)" to="(240,3290)"/>
-    <wire from="(200,2030)" to="(240,2030)"/>
-    <wire from="(230,470)" to="(260,470)"/>
-    <wire from="(140,3970)" to="(230,3970)"/>
-    <wire from="(100,3030)" to="(260,3030)"/>
-    <wire from="(140,1730)" to="(230,1730)"/>
-    <wire from="(230,1430)" to="(260,1430)"/>
-    <wire from="(200,2360)" to="(230,2360)"/>
-    <wire from="(240,1130)" to="(260,1130)"/>
-    <wire from="(240,2730)" to="(260,2730)"/>
-    <wire from="(160,4250)" to="(180,4250)"/>
-    <wire from="(240,1340)" to="(240,1380)"/>
-    <wire from="(320,2760)" to="(320,2950)"/>
-    <wire from="(60,390)" to="(60,510)"/>
-    <wire from="(80,410)" to="(80,530)"/>
-    <wire from="(310,1410)" to="(310,1480)"/>
-    <wire from="(160,300)" to="(160,370)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(230,3060)" to="(230,3070)"/>
-    <wire from="(240,3070)" to="(240,3090)"/>
-    <wire from="(160,3690)" to="(160,3840)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(240,510)" to="(240,530)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(140,1140)" to="(180,1140)"/>
-    <wire from="(200,240)" to="(240,240)"/>
-    <wire from="(200,3120)" to="(240,3120)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(80,4030)" to="(180,4030)"/>
-    <wire from="(230,280)" to="(260,280)"/>
-    <wire from="(200,1210)" to="(230,1210)"/>
-    <wire from="(200,1530)" to="(230,1530)"/>
-    <wire from="(80,1370)" to="(80,1530)"/>
-    <wire from="(80,3290)" to="(80,3450)"/>
-    <wire from="(200,3450)" to="(230,3450)"/>
-    <wire from="(230,3160)" to="(260,3160)"/>
-    <wire from="(290,2910)" to="(310,2910)"/>
-    <wire from="(240,3820)" to="(260,3820)"/>
-    <wire from="(100,3310)" to="(100,3480)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(120,3330)" to="(120,3510)"/>
-    <wire from="(290,180)" to="(420,180)"/>
-    <wire from="(340,790)" to="(340,1240)"/>
-    <wire from="(60,1630)" to="(240,1630)"/>
-    <wire from="(220,1580)" to="(220,1590)"/>
-    <wire from="(60,3720)" to="(60,3860)"/>
-    <wire from="(220,3500)" to="(220,3510)"/>
-    <wire from="(230,1590)" to="(230,1610)"/>
-    <wire from="(240,1600)" to="(240,1620)"/>
-    <wire from="(230,3510)" to="(230,3530)"/>
-    <wire from="(240,3520)" to="(240,3540)"/>
-    <wire from="(140,2520)" to="(140,2670)"/>
-    <wire from="(200,370)" to="(240,370)"/>
-    <wire from="(200,1010)" to="(240,1010)"/>
-    <wire from="(290,1100)" to="(330,1100)"/>
-    <wire from="(80,2880)" to="(180,2880)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(140,4230)" to="(230,4230)"/>
-    <wire from="(230,2330)" to="(260,2330)"/>
-    <wire from="(230,2650)" to="(260,2650)"/>
-    <wire from="(200,2940)" to="(230,2940)"/>
-    <wire from="(240,1070)" to="(260,1070)"/>
-    <wire from="(290,3040)" to="(310,3040)"/>
-    <wire from="(240,2240)" to="(240,2280)"/>
-    <wire from="(160,1310)" to="(180,1310)"/>
-    <wire from="(100,1960)" to="(180,1960)"/>
-    <wire from="(60,2570)" to="(60,2700)"/>
-    <wire from="(80,2590)" to="(80,2730)"/>
-    <wire from="(240,130)" to="(240,150)"/>
-    <wire from="(240,770)" to="(240,800)"/>
-    <wire from="(140,2360)" to="(180,2360)"/>
-    <wire from="(200,2420)" to="(240,2420)"/>
-    <wire from="(80,3010)" to="(180,3010)"/>
-    <wire from="(230,540)" to="(260,540)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(230,2460)" to="(260,2460)"/>
-    <wire from="(230,2780)" to="(260,2780)"/>
-    <wire from="(200,4030)" to="(230,4030)"/>
-    <wire from="(230,4060)" to="(260,4060)"/>
-    <wire from="(240,2160)" to="(260,2160)"/>
-    <wire from="(290,1570)" to="(310,1570)"/>
-    <wire from="(310,1910)" to="(330,1910)"/>
-    <wire from="(240,3760)" to="(260,3760)"/>
-    <wire from="(80,2270)" to="(80,2450)"/>
-    <wire from="(160,2030)" to="(160,2210)"/>
-    <wire from="(120,840)" to="(120,970)"/>
-    <wire from="(140,860)" to="(140,990)"/>
-    <wire from="(160,880)" to="(160,1010)"/>
-    <wire from="(310,2960)" to="(370,2960)"/>
-    <wire from="(80,800)" to="(80,930)"/>
-    <wire from="(100,820)" to="(100,950)"/>
-    <wire from="(200,1250)" to="(260,1250)"/>
-    <wire from="(60,1180)" to="(180,1180)"/>
-    <wire from="(60,1500)" to="(180,1500)"/>
-    <wire from="(60,3420)" to="(180,3420)"/>
-    <wire from="(230,1210)" to="(230,1220)"/>
-    <wire from="(230,1850)" to="(230,1860)"/>
-    <wire from="(230,1530)" to="(230,1550)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(230,3450)" to="(230,3470)"/>
-    <wire from="(60,2700)" to="(60,2850)"/>
-    <wire from="(240,900)" to="(240,930)"/>
-    <wire from="(200,2550)" to="(240,2550)"/>
-    <wire from="(140,4090)" to="(180,4090)"/>
-    <wire from="(330,3000)" to="(370,3000)"/>
-    <wire from="(100,670)" to="(260,670)"/>
-    <wire from="(200,1280)" to="(230,1280)"/>
-    <wire from="(100,4190)" to="(260,4190)"/>
-    <wire from="(140,1610)" to="(230,1610)"/>
-    <wire from="(140,3530)" to="(230,3530)"/>
-    <wire from="(230,1950)" to="(260,1950)"/>
-    <wire from="(200,2880)" to="(230,2880)"/>
-    <wire from="(340,790)" to="(360,790)"/>
-    <wire from="(160,2210)" to="(180,2210)"/>
-    <wire from="(160,3240)" to="(240,3240)"/>
-    <wire from="(60,2060)" to="(60,2240)"/>
-    <wire from="(160,370)" to="(160,500)"/>
-    <wire from="(230,700)" to="(230,710)"/>
-    <wire from="(80,930)" to="(80,1070)"/>
-    <wire from="(100,950)" to="(100,1090)"/>
-    <wire from="(120,970)" to="(120,1110)"/>
-    <wire from="(230,3580)" to="(230,3590)"/>
-    <wire from="(230,4220)" to="(230,4230)"/>
-    <wire from="(240,4230)" to="(240,4250)"/>
-    <wire from="(140,990)" to="(140,1140)"/>
-    <wire from="(160,1010)" to="(160,1160)"/>
-    <wire from="(220,460)" to="(260,460)"/>
-    <wire from="(140,2940)" to="(180,2940)"/>
-    <wire from="(220,1420)" to="(260,1420)"/>
-    <wire from="(240,390)" to="(240,420)"/>
-    <wire from="(240,710)" to="(240,740)"/>
-    <wire from="(290,4050)" to="(330,4050)"/>
-    <wire from="(230,160)" to="(260,160)"/>
-    <wire from="(230,1120)" to="(260,1120)"/>
-    <wire from="(200,3010)" to="(230,3010)"/>
-    <wire from="(160,500)" to="(160,600)"/>
-    <wire from="(240,2100)" to="(260,2100)"/>
-    <wire from="(290,1830)" to="(310,1830)"/>
-    <wire from="(160,740)" to="(180,740)"/>
-    <wire from="(100,440)" to="(100,550)"/>
-    <wire from="(120,840)" to="(260,840)"/>
-    <wire from="(120,470)" to="(180,470)"/>
-    <wire from="(120,1110)" to="(180,1110)"/>
-    <wire from="(120,1430)" to="(180,1430)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(60,4000)" to="(180,4000)"/>
-    <wire from="(60,1040)" to="(60,1180)"/>
-    <wire from="(230,4030)" to="(230,4040)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(120,4070)" to="(230,4070)"/>
-    <wire from="(200,4090)" to="(240,4090)"/>
-    <wire from="(330,2940)" to="(370,2940)"/>
-    <wire from="(100,290)" to="(260,290)"/>
-    <wire from="(200,1860)" to="(230,1860)"/>
-    <wire from="(100,1400)" to="(100,1560)"/>
-    <wire from="(100,3170)" to="(260,3170)"/>
-    <wire from="(140,590)" to="(230,590)"/>
-    <wire from="(200,2180)" to="(230,2180)"/>
-    <wire from="(230,3810)" to="(260,3810)"/>
-    <wire from="(290,680)" to="(310,680)"/>
-    <wire from="(240,1270)" to="(260,1270)"/>
-    <wire from="(140,3360)" to="(140,3530)"/>
-    <wire from="(240,3720)" to="(240,3760)"/>
-    <wire from="(200,1960)" to="(260,1960)"/>
-    <wire from="(160,2550)" to="(160,2680)"/>
-    <wire from="(60,2850)" to="(180,2850)"/>
-    <wire from="(230,2880)" to="(230,2890)"/>
-    <wire from="(80,3750)" to="(80,3890)"/>
-    <wire from="(230,3200)" to="(230,3220)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(230,320)" to="(230,340)"/>
-    <wire from="(140,1280)" to="(180,1280)"/>
-    <wire from="(240,2570)" to="(240,2600)"/>
-    <wire from="(220,80)" to="(260,80)"/>
-    <wire from="(200,1340)" to="(240,1340)"/>
-    <wire from="(240,3210)" to="(240,3240)"/>
-    <wire from="(220,2320)" to="(260,2320)"/>
-    <wire from="(220,2640)" to="(260,2640)"/>
-    <wire from="(200,3260)" to="(240,3260)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(80,650)" to="(180,650)"/>
-    <wire from="(80,1930)" to="(180,1930)"/>
-    <wire from="(80,4170)" to="(180,4170)"/>
-    <wire from="(200,710)" to="(230,710)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(230,3300)" to="(260,3300)"/>
-    <wire from="(240,1720)" to="(260,1720)"/>
-    <wire from="(240,3640)" to="(260,3640)"/>
-    <wire from="(240,3960)" to="(260,3960)"/>
-    <wire from="(240,330)" to="(240,370)"/>
-    <wire from="(200,3050)" to="(260,3050)"/>
-    <wire from="(100,2620)" to="(100,2750)"/>
-    <wire from="(120,90)" to="(180,90)"/>
-    <wire from="(120,2330)" to="(180,2330)"/>
-    <wire from="(120,2650)" to="(180,2650)"/>
-    <wire from="(60,2980)" to="(180,2980)"/>
-    <wire from="(230,3010)" to="(230,3020)"/>
-    <wire from="(60,3860)" to="(60,4000)"/>
-    <wire from="(160,2680)" to="(160,2820)"/>
-    <wire from="(240,2700)" to="(240,2730)"/>
-    <wire from="(200,1470)" to="(240,1470)"/>
-    <wire from="(200,3390)" to="(240,3390)"/>
-    <wire from="(100,550)" to="(260,550)"/>
-    <wire from="(100,2470)" to="(260,2470)"/>
-    <wire from="(140,210)" to="(230,210)"/>
-    <wire from="(230,2150)" to="(260,2150)"/>
-    <wire from="(240,1210)" to="(260,1210)"/>
-    <wire from="(160,3690)" to="(180,3690)"/>
-    <wire from="(100,2300)" to="(100,2470)"/>
-    <wire from="(350,2920)" to="(370,2920)"/>
-    <wire from="(400,2970)" to="(420,2970)"/>
-    <wire from="(240,2060)" to="(240,2100)"/>
-    <wire from="(160,880)" to="(240,880)"/>
-    <wire from="(290,2310)" to="(350,2310)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(320,2990)" to="(370,2990)"/>
-    <wire from="(230,580)" to="(230,590)"/>
-    <wire from="(240,590)" to="(240,600)"/>
-    <wire from="(310,740)" to="(360,740)"/>
-    <wire from="(230,2500)" to="(230,2520)"/>
-    <wire from="(80,2730)" to="(80,2880)"/>
-    <wire from="(100,2750)" to="(100,2900)"/>
-    <wire from="(120,2770)" to="(120,2920)"/>
-    <wire from="(140,2790)" to="(140,2940)"/>
-    <wire from="(140,1860)" to="(180,1860)"/>
-    <wire from="(140,2180)" to="(180,2180)"/>
-    <wire from="(200,2240)" to="(240,2240)"/>
-    <wire from="(80,270)" to="(180,270)"/>
-    <wire from="(80,3150)" to="(180,3150)"/>
-    <wire from="(200,650)" to="(230,650)"/>
-    <wire from="(200,1930)" to="(230,1930)"/>
-    <wire from="(330,780)" to="(360,780)"/>
-    <wire from="(200,4170)" to="(230,4170)"/>
-    <wire from="(240,1660)" to="(260,1660)"/>
-    <wire from="(240,2940)" to="(260,2940)"/>
-    <wire from="(240,3580)" to="(260,3580)"/>
-    <wire from="(240,3900)" to="(260,3900)"/>
-    <wire from="(240,2510)" to="(240,2550)"/>
-    <wire from="(80,2090)" to="(80,2270)"/>
-    <wire from="(60,3560)" to="(180,3560)"/>
-    <wire from="(230,1990)" to="(230,2000)"/>
-    <wire from="(140,710)" to="(180,710)"/>
-    <wire from="(240,1040)" to="(240,1070)"/>
-    <wire from="(240,2000)" to="(240,2030)"/>
-    <wire from="(200,770)" to="(240,770)"/>
-    <wire from="(100,170)" to="(260,170)"/>
-    <wire from="(230,810)" to="(260,810)"/>
-    <wire from="(200,3660)" to="(230,3660)"/>
-    <wire from="(120,470)" to="(120,570)"/>
-    <wire from="(140,490)" to="(140,590)"/>
-    <wire from="(240,3070)" to="(260,3070)"/>
-    <wire from="(240,4030)" to="(260,4030)"/>
-    <wire from="(200,470)" to="(220,470)"/>
-    <wire from="(200,1430)" to="(220,1430)"/>
-    <wire from="(160,2030)" to="(180,2030)"/>
-    <wire from="(100,440)" to="(180,440)"/>
-    <wire from="(160,500)" to="(240,500)"/>
-    <wire from="(100,1400)" to="(180,1400)"/>
-    <wire from="(120,2770)" to="(260,2770)"/>
-    <wire from="(290,70)" to="(420,70)"/>
-    <wire from="(230,200)" to="(230,210)"/>
-    <wire from="(240,210)" to="(240,220)"/>
-    <wire from="(80,1070)" to="(80,1210)"/>
-    <wire from="(100,1090)" to="(100,1230)"/>
-    <wire from="(120,1110)" to="(120,1250)"/>
-    <wire from="(160,3390)" to="(160,3540)"/>
-    <wire from="(160,1470)" to="(160,1620)"/>
-    <wire from="(200,900)" to="(240,900)"/>
-    <wire from="(200,2820)" to="(240,2820)"/>
-    <wire from="(80,530)" to="(180,530)"/>
-    <wire from="(80,2450)" to="(180,2450)"/>
-    <wire from="(200,270)" to="(230,270)"/>
-    <wire from="(230,940)" to="(260,940)"/>
-    <wire from="(120,1430)" to="(120,1590)"/>
-    <wire from="(140,1450)" to="(140,1610)"/>
-    <wire from="(230,1260)" to="(260,1260)"/>
-    <wire from="(200,3150)" to="(230,3150)"/>
-    <wire from="(330,720)" to="(360,720)"/>
-    <wire from="(240,1600)" to="(260,1600)"/>
-    <wire from="(290,1970)" to="(310,1970)"/>
-    <wire from="(240,2880)" to="(260,2880)"/>
-    <wire from="(240,3520)" to="(260,3520)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(330,4140)" to="(330,4200)"/>
-    <wire from="(360,1490)" to="(420,1490)"/>
-    <wire from="(60,1500)" to="(60,1630)"/>
-    <wire from="(120,1250)" to="(180,1250)"/>
-    <wire from="(160,3840)" to="(160,3980)"/>
-    <wire from="(60,620)" to="(180,620)"/>
-    <wire from="(230,650)" to="(230,660)"/>
-    <wire from="(60,1900)" to="(180,1900)"/>
-    <wire from="(60,4140)" to="(180,4140)"/>
-    <wire from="(60,3420)" to="(60,3560)"/>
-    <wire from="(100,3780)" to="(100,3920)"/>
-    <wire from="(230,4170)" to="(230,4180)"/>
-    <wire from="(230,1930)" to="(230,1950)"/>
-    <wire from="(120,3800)" to="(120,3950)"/>
-    <wire from="(140,3820)" to="(140,3970)"/>
-    <wire from="(340,300)" to="(340,710)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(60,1180)" to="(60,1340)"/>
-    <wire from="(100,3310)" to="(260,3310)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(230,1390)" to="(260,1390)"/>
-    <wire from="(230,1710)" to="(260,1710)"/>
-    <wire from="(200,2000)" to="(230,2000)"/>
-    <wire from="(140,110)" to="(140,210)"/>
-    <wire from="(230,3630)" to="(260,3630)"/>
-    <wire from="(230,3950)" to="(260,3950)"/>
-    <wire from="(200,2330)" to="(220,2330)"/>
-    <wire from="(200,2650)" to="(220,2650)"/>
-    <wire from="(310,1480)" to="(330,1480)"/>
-    <wire from="(240,3010)" to="(260,3010)"/>
-    <wire from="(240,3860)" to="(240,3900)"/>
-    <wire from="(160,370)" to="(180,370)"/>
-    <wire from="(160,1010)" to="(180,1010)"/>
-    <wire from="(200,90)" to="(220,90)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(100,2300)" to="(180,2300)"/>
-    <wire from="(100,2620)" to="(180,2620)"/>
-    <wire from="(160,2680)" to="(240,2680)"/>
-    <wire from="(120,2650)" to="(120,2770)"/>
-    <wire from="(140,2670)" to="(140,2790)"/>
-    <wire from="(60,1630)" to="(60,1760)"/>
-    <wire from="(290,1240)" to="(340,1240)"/>
-    <wire from="(80,1650)" to="(80,1790)"/>
-    <wire from="(80,3890)" to="(80,4030)"/>
-    <wire from="(230,3340)" to="(230,3360)"/>
-    <wire from="(140,3660)" to="(180,3660)"/>
-    <wire from="(220,2140)" to="(260,2140)"/>
-    <wire from="(200,3720)" to="(240,3720)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(200,530)" to="(230,530)"/>
-    <wire from="(120,2330)" to="(120,2490)"/>
-    <wire from="(200,2450)" to="(230,2450)"/>
-    <wire from="(290,3180)" to="(320,3180)"/>
-    <wire from="(240,1540)" to="(260,1540)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,3460)" to="(260,3460)"/>
-    <wire from="(240,3350)" to="(240,3390)"/>
-    <wire from="(120,3800)" to="(260,3800)"/>
-    <wire from="(200,3190)" to="(260,3190)"/>
-    <wire from="(310,2980)" to="(370,2980)"/>
-    <wire from="(310,1500)" to="(310,1570)"/>
-    <wire from="(120,2150)" to="(180,2150)"/>
-    <wire from="(200,310)" to="(260,310)"/>
-    <wire from="(60,240)" to="(180,240)"/>
-    <wire from="(230,270)" to="(230,280)"/>
-    <wire from="(60,3120)" to="(180,3120)"/>
-    <wire from="(60,1760)" to="(60,1900)"/>
-    <wire from="(60,4000)" to="(60,4140)"/>
-    <wire from="(230,3150)" to="(230,3160)"/>
-    <wire from="(160,2820)" to="(160,2960)"/>
-    <wire from="(320,770)" to="(360,770)"/>
-    <wire from="(100,140)" to="(100,170)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(200,340)" to="(230,340)"/>
-    <wire from="(140,990)" to="(230,990)"/>
-    <wire from="(230,2290)" to="(260,2290)"/>
-    <wire from="(230,2610)" to="(260,2610)"/>
-    <wire from="(230,2930)" to="(260,2930)"/>
-    <wire from="(200,3220)" to="(230,3220)"/>
-    <wire from="(240,4230)" to="(260,4230)"/>
-    <wire from="(240,710)" to="(260,710)"/>
-    <wire from="(160,2550)" to="(180,2550)"/>
-    <wire from="(310,2910)" to="(310,2960)"/>
-    <wire from="(100,2120)" to="(100,2300)"/>
-    <wire from="(290,3790)" to="(420,3790)"/>
-    <wire from="(60,2850)" to="(60,2980)"/>
-    <wire from="(340,2480)" to="(340,2930)"/>
-    <wire from="(200,440)" to="(260,440)"/>
-    <wire from="(200,1400)" to="(260,1400)"/>
-    <wire from="(140,2000)" to="(180,2000)"/>
-    <wire from="(200,2060)" to="(240,2060)"/>
-    <wire from="(200,2700)" to="(240,2700)"/>
-    <wire from="(80,410)" to="(180,410)"/>
-    <wire from="(80,1370)" to="(180,1370)"/>
-    <wire from="(80,3290)" to="(180,3290)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(100,820)" to="(260,820)"/>
-    <wire from="(330,4120)" to="(360,4120)"/>
-    <wire from="(290,560)" to="(320,560)"/>
-    <wire from="(230,2740)" to="(260,2740)"/>
-    <wire from="(230,3060)" to="(260,3060)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(200,2490)" to="(260,2490)"/>
-    <wire from="(200,570)" to="(260,570)"/>
-    <wire from="(120,3050)" to="(180,3050)"/>
-    <wire from="(230,530)" to="(230,540)"/>
-    <wire from="(230,850)" to="(230,860)"/>
-    <wire from="(60,2420)" to="(180,2420)"/>
-    <wire from="(230,2450)" to="(230,2460)"/>
-    <wire from="(60,2980)" to="(60,3120)"/>
-    <wire from="(140,1140)" to="(140,1280)"/>
-    <wire from="(240,860)" to="(240,880)"/>
-    <wire from="(160,1160)" to="(160,1310)"/>
-    <wire from="(240,1180)" to="(240,1210)"/>
-    <wire from="(290,4200)" to="(330,4200)"/>
-    <wire from="(100,950)" to="(260,950)"/>
-    <wire from="(230,1590)" to="(260,1590)"/>
-    <wire from="(200,2520)" to="(230,2520)"/>
-    <wire from="(230,3510)" to="(260,3510)"/>
-    <wire from="(240,3210)" to="(260,3210)"/>
-    <wire from="(240,4170)" to="(260,4170)"/>
-    <wire from="(240,1500)" to="(240,1540)"/>
-    <wire from="(240,3420)" to="(240,3460)"/>
-    <wire from="(240,330)" to="(260,330)"/>
-    <wire from="(240,650)" to="(260,650)"/>
-    <wire from="(100,3780)" to="(180,3780)"/>
-    <wire from="(160,3840)" to="(240,3840)"/>
-    <wire from="(80,1530)" to="(80,1650)"/>
-    <wire from="(290,2130)" to="(420,2130)"/>
-    <wire from="(200,2300)" to="(260,2300)"/>
-    <wire from="(200,2620)" to="(260,2620)"/>
-    <wire from="(80,3450)" to="(80,3580)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(230,980)" to="(230,990)"/>
-    <wire from="(240,990)" to="(240,1010)"/>
-    <wire from="(140,340)" to="(180,340)"/>
-    <wire from="(240,1630)" to="(240,1660)"/>
-    <wire from="(200,1040)" to="(240,1040)"/>
-    <wire from="(140,3220)" to="(180,3220)"/>
-    <wire from="(220,1700)" to="(260,1700)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(220,3620)" to="(260,3620)"/>
-    <wire from="(220,3940)" to="(260,3940)"/>
-    <wire from="(80,2270)" to="(180,2270)"/>
-    <wire from="(80,2590)" to="(180,2590)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(200,1370)" to="(230,1370)"/>
-    <wire from="(80,1210)" to="(80,1370)"/>
-    <wire from="(230,1080)" to="(260,1080)"/>
-    <wire from="(200,3290)" to="(230,3290)"/>
-    <wire from="(290,830)" to="(310,830)"/>
-    <wire from="(100,1230)" to="(100,1400)"/>
-    <wire from="(120,1250)" to="(120,1430)"/>
-    <wire from="(310,2980)" to="(310,3040)"/>
-    <wire from="(100,3920)" to="(100,4050)"/>
-    <wire from="(120,1710)" to="(180,1710)"/>
-    <wire from="(200,190)" to="(260,190)"/>
-    <wire from="(120,3630)" to="(180,3630)"/>
-    <wire from="(120,3950)" to="(180,3950)"/>
-    <wire from="(290,3490)" to="(340,3490)"/>
-    <wire from="(230,150)" to="(230,160)"/>
-    <wire from="(220,460)" to="(220,470)"/>
-    <wire from="(60,510)" to="(240,510)"/>
-    <wire from="(220,1420)" to="(220,1430)"/>
-    <wire from="(100,1680)" to="(100,1820)"/>
-    <wire from="(160,1740)" to="(160,1880)"/>
-    <wire from="(230,1430)" to="(230,1450)"/>
-    <wire from="(230,470)" to="(230,490)"/>
-    <wire from="(240,480)" to="(240,500)"/>
-    <wire from="(140,250)" to="(140,340)"/>
-    <wire from="(240,1440)" to="(240,1470)"/>
-    <wire from="(240,4000)" to="(240,4030)"/>
-    <wire from="(200,3090)" to="(240,3090)"/>
-    <wire from="(80,800)" to="(180,800)"/>
-    <wire from="(200,860)" to="(230,860)"/>
-    <wire from="(60,3560)" to="(60,3720)"/>
-    <wire from="(140,2360)" to="(140,2520)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(230,3770)" to="(260,3770)"/>
-    <wire from="(200,2150)" to="(220,2150)"/>
-    <wire from="(240,2510)" to="(260,2510)"/>
-    <wire from="(160,3390)" to="(180,3390)"/>
-    <wire from="(80,3580)" to="(80,3750)"/>
-    <wire from="(240,3150)" to="(260,3150)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(240,270)" to="(260,270)"/>
-    <wire from="(240,590)" to="(260,590)"/>
-    <wire from="(160,1470)" to="(180,1470)"/>
-    <wire from="(100,2120)" to="(180,2120)"/>
-    <wire from="(100,3600)" to="(100,3780)"/>
-    <wire from="(310,1830)" to="(310,1890)"/>
-    <wire from="(290,3610)" to="(350,3610)"/>
-    <wire from="(140,4090)" to="(140,4230)"/>
-    <wire from="(310,760)" to="(360,760)"/>
-    <wire from="(80,1790)" to="(80,1930)"/>
-    <wire from="(80,4030)" to="(80,4170)"/>
-    <wire from="(100,4050)" to="(100,4190)"/>
-    <wire from="(120,4070)" to="(120,4210)"/>
-    <wire from="(140,2520)" to="(180,2520)"/>
-    <wire from="(240,2850)" to="(240,2880)"/>
-    <wire from="(200,3860)" to="(240,3860)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(80,930)" to="(180,930)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(230,700)" to="(260,700)"/>
-    <wire from="(200,2270)" to="(230,2270)"/>
-    <wire from="(200,2590)" to="(230,2590)"/>
-    <wire from="(230,4220)" to="(260,4220)"/>
-    <wire from="(240,2000)" to="(260,2000)"/>
-    <wire from="(290,1410)" to="(310,1410)"/>
-    <wire from="(120,2150)" to="(120,2330)"/>
-    <wire from="(320,2990)" to="(320,3180)"/>
-    <wire from="(310,680)" to="(310,740)"/>
-    <wire from="(200,3330)" to="(260,3330)"/>
-    <wire from="(80,2880)" to="(80,3010)"/>
-    <wire from="(100,2900)" to="(100,3030)"/>
-    <wire from="(120,2920)" to="(120,3050)"/>
-    <wire from="(140,2940)" to="(140,3070)"/>
-    <wire from="(160,2960)" to="(160,3090)"/>
-    <wire from="(220,80)" to="(220,90)"/>
-    <wire from="(60,1340)" to="(180,1340)"/>
-    <wire from="(60,3260)" to="(180,3260)"/>
-    <wire from="(160,3980)" to="(160,4250)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(220,2320)" to="(220,2330)"/>
-    <wire from="(220,2640)" to="(220,2650)"/>
-    <wire from="(230,3290)" to="(230,3300)"/>
-    <wire from="(230,1370)" to="(230,1390)"/>
-    <wire from="(230,2650)" to="(230,2670)"/>
-    <wire from="(240,2660)" to="(240,2680)"/>
-    <wire from="(230,90)" to="(230,110)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(230,410)" to="(230,430)"/>
-    <wire from="(60,620)" to="(60,770)"/>
-    <wire from="(230,2330)" to="(230,2360)"/>
-    <wire from="(240,2980)" to="(240,3010)"/>
-    <wire from="(200,2390)" to="(240,2390)"/>
-    <wire from="(200,800)" to="(230,800)"/>
-    <wire from="(60,1900)" to="(60,2060)"/>
-    <wire from="(100,2750)" to="(260,2750)"/>
-    <wire from="(140,490)" to="(230,490)"/>
-    <wire from="(140,1450)" to="(230,1450)"/>
-    <wire from="(230,2110)" to="(260,2110)"/>
-    <wire from="(200,3360)" to="(230,3360)"/>
-    <wire from="(240,2450)" to="(260,2450)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(320,560)" to="(320,730)"/>
-    <wire from="(240,530)" to="(260,530)"/>
-    <wire from="(160,1160)" to="(240,1160)"/>
-    <wire from="(240,2340)" to="(240,2390)"/>
-    <wire from="(290,3930)" to="(420,3930)"/>
-    <wire from="(290,1690)" to="(420,1690)"/>
-    <wire from="(200,3780)" to="(260,3780)"/>
-    <wire from="(320,2950)" to="(370,2950)"/>
-    <wire from="(230,2780)" to="(230,2790)"/>
-    <wire from="(80,3010)" to="(80,3150)"/>
-    <wire from="(100,3030)" to="(100,3170)"/>
-    <wire from="(120,3050)" to="(120,3190)"/>
-    <wire from="(230,4060)" to="(230,4070)"/>
-    <wire from="(240,4070)" to="(240,4090)"/>
-    <wire from="(140,3070)" to="(140,3220)"/>
-    <wire from="(160,3090)" to="(160,3240)"/>
-    <wire from="(140,860)" to="(180,860)"/>
-    <wire from="(240,2790)" to="(240,2820)"/>
-    <wire from="(220,1580)" to="(260,1580)"/>
-    <wire from="(220,3500)" to="(260,3500)"/>
-    <wire from="(80,3750)" to="(180,3750)"/>
-    <wire from="(230,320)" to="(260,320)"/>
-    <wire from="(200,930)" to="(230,930)"/>
-    <wire from="(230,3200)" to="(260,3200)"/>
-    <wire from="(240,1940)" to="(260,1940)"/>
-    <wire from="(160,2820)" to="(180,2820)"/>
-    <wire from="(120,2920)" to="(260,2920)"/>
-    <wire from="(100,1560)" to="(100,1680)"/>
-    <wire from="(100,3480)" to="(100,3600)"/>
-    <wire from="(160,1620)" to="(160,1740)"/>
-    <wire from="(120,310)" to="(180,310)"/>
-    <wire from="(120,1590)" to="(180,1590)"/>
-    <wire from="(330,3000)" to="(330,3320)"/>
-    <wire from="(120,3190)" to="(180,3190)"/>
-    <wire from="(120,3510)" to="(180,3510)"/>
-    <wire from="(40,300)" to="(160,300)"/>
-    <wire from="(60,2240)" to="(180,2240)"/>
-    <wire from="(60,390)" to="(240,390)"/>
-    <wire from="(60,3120)" to="(60,3260)"/>
-    <wire from="(230,2270)" to="(230,2290)"/>
-    <wire from="(230,2590)" to="(230,2610)"/>
-    <wire from="(240,3560)" to="(240,3580)"/>
-    <wire from="(160,3540)" to="(160,3690)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(60,240)" to="(60,390)"/>
-    <wire from="(200,4250)" to="(240,4250)"/>
-    <wire from="(100,1090)" to="(260,1090)"/>
-    <wire from="(140,110)" to="(230,110)"/>
-    <wire from="(140,2670)" to="(230,2670)"/>
-    <wire from="(390,4130)" to="(420,4130)"/>
-    <wire from="(200,3630)" to="(220,3630)"/>
-    <wire from="(200,3950)" to="(220,3950)"/>
-    <wire from="(140,1280)" to="(140,1450)"/>
-    <wire from="(310,1500)" to="(330,1500)"/>
-    <wire from="(240,3350)" to="(260,3350)"/>
-    <wire from="(240,150)" to="(260,150)"/>
-    <wire from="(200,1710)" to="(220,1710)"/>
-    <wire from="(100,1680)" to="(180,1680)"/>
-    <wire from="(160,1740)" to="(240,1740)"/>
-    <wire from="(100,3600)" to="(180,3600)"/>
-    <wire from="(100,3920)" to="(180,3920)"/>
-    <wire from="(160,3980)" to="(240,3980)"/>
-    <wire from="(120,3950)" to="(120,4070)"/>
-    <wire from="(140,3970)" to="(140,4090)"/>
-    <wire from="(200,2120)" to="(260,2120)"/>
-    <wire from="(120,1710)" to="(120,1840)"/>
-    <wire from="(140,1730)" to="(140,1860)"/>
-    <wire from="(60,770)" to="(180,770)"/>
-    <wire from="(230,800)" to="(230,810)"/>
-    <wire from="(290,300)" to="(340,300)"/>
-    <wire from="(230,1120)" to="(230,1140)"/>
-    <wire from="(240,1130)" to="(240,1160)"/>
-    <wire from="(200,1180)" to="(240,1180)"/>
-    <wire from="(200,1500)" to="(240,1500)"/>
-    <wire from="(140,3360)" to="(180,3360)"/>
-    <wire from="(200,3420)" to="(240,3420)"/>
-    <wire from="(80,2090)" to="(180,2090)"/>
-    <wire from="(80,2730)" to="(180,2730)"/>
-    <wire from="(230,580)" to="(260,580)"/>
-    <wire from="(160,2390)" to="(160,2550)"/>
-    <wire from="(350,2310)" to="(350,2920)"/>
-    <wire from="(340,2930)" to="(370,2930)"/>
-    <wire from="(290,960)" to="(320,960)"/>
-    <wire from="(230,1220)" to="(260,1220)"/>
-    <wire from="(230,2500)" to="(260,2500)"/>
-    <wire from="(200,2790)" to="(230,2790)"/>
-    <wire from="(200,3750)" to="(230,3750)"/>
-    <wire from="(120,3630)" to="(120,3800)"/>
-    <wire from="(120,570)" to="(180,570)"/>
-    <wire from="(200,970)" to="(260,970)"/>
-    <wire from="(120,2490)" to="(180,2490)"/>
-    <wire from="(60,900)" to="(180,900)"/>
-    <wire from="(230,930)" to="(230,940)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(60,2570)" to="(240,2570)"/>
-    <wire from="(100,1820)" to="(100,1960)"/>
-    <wire from="(120,1840)" to="(120,1980)"/>
-    <wire from="(160,600)" to="(160,740)"/>
-    <wire from="(230,3810)" to="(230,3820)"/>
-    <wire from="(140,1860)" to="(140,2000)"/>
-    <wire from="(240,3820)" to="(240,3840)"/>
-    <wire from="(60,2420)" to="(60,2570)"/>
-    <wire from="(160,1880)" to="(160,2030)"/>
-    <wire from="(200,1310)" to="(240,1310)"/>
-    <wire from="(240,4140)" to="(240,4170)"/>
-    <wire from="(240,620)" to="(240,650)"/>
-    <wire from="(290,3320)" to="(330,3320)"/>
-    <wire from="(230,1670)" to="(260,1670)"/>
-    <wire from="(230,1990)" to="(260,1990)"/>
-    <wire from="(340,3010)" to="(340,3490)"/>
-    <wire from="(230,3590)" to="(260,3590)"/>
-    <wire from="(230,3910)" to="(260,3910)"/>
-    <wire from="(240,3290)" to="(260,3290)"/>
-    <wire from="(80,3580)" to="(230,3580)"/>
-    <wire from="(240,1900)" to="(240,1940)"/>
-    <wire from="(160,2960)" to="(240,2960)"/>
-    <wire from="(140,2180)" to="(140,2360)"/>
-    <wire from="(360,1900)" to="(420,1900)"/>
-    <wire from="(290,2480)" to="(340,2480)"/>
-    <wire from="(160,220)" to="(160,300)"/>
-    <wire from="(120,690)" to="(120,840)"/>
-    <wire from="(140,710)" to="(140,860)"/>
-    <wire from="(80,650)" to="(80,800)"/>
-    <wire from="(100,670)" to="(100,820)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(200,4000)" to="(240,4000)"/>
-    <wire from="(80,1070)" to="(180,1070)"/>
-    <wire from="(230,200)" to="(260,200)"/>
-    <wire from="(80,1930)" to="(80,2090)"/>
-    <wire from="(330,4140)" to="(360,4140)"/>
-    <wire from="(200,2090)" to="(230,2090)"/>
-    <wire from="(200,2730)" to="(230,2730)"/>
-    <wire from="(230,4040)" to="(260,4040)"/>
-    <wire from="(240,860)" to="(260,860)"/>
-    <wire from="(310,1890)" to="(330,1890)"/>
-    <wire from="(120,1840)" to="(260,1840)"/>
-    <comp lib="1" loc="(200,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1900)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Branch"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,2130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegDst"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1590)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWrite"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,1690)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoReg"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,960)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2590)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1240)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2630)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2130)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,3790)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneBeq"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,300)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,70)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemRead"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3920)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4200)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3930)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,4050)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2910)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(390,4130)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Jump"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(360,1900)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,2620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,4130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ZeroExtend"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(390,750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="1" loc="(400,2970)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="0" loc="(420,750)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrc"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,2970)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWrite"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1100)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2760)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,300)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1490)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,3750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2480)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,3930)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJAL"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3790)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
   </circuit>
   <circuit name="Syscall_Decoder">
     <a name="circuit" val="Syscall_Decoder"/>
@@ -6382,39 +1914,25 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(490,460)" to="(490,480)"/>
     <wire from="(480,290)" to="(480,320)"/>
     <wire from="(170,440)" to="(300,440)"/>
+    <comp lib="0" loc="(420,270)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(510,480)" name="Tunnel">
+      <a name="label" val="Enable"/>
+    </comp>
     <comp lib="0" loc="(440,130)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(470,430)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(270,460)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0xa"/>
-    </comp>
-    <comp lib="0" loc="(470,130)" name="Tunnel">
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="2" loc="(510,440)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(320,130)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="3" loc="(340,450)" name="Comparator">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(580,420)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(440,320)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="Enable"/>
     </comp>
-    <comp lib="0" loc="(510,480)" name="Tunnel">
-      <a name="label" val="Enable"/>
+    <comp lib="0" loc="(270,460)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0xa"/>
     </comp>
     <comp lib="0" loc="(170,440)" name="Pin">
       <a name="width" val="32"/>
@@ -6425,20 +1943,26 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
     </comp>
+    <comp lib="2" loc="(510,440)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
     <comp lib="0" loc="(570,440)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="Halt"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(420,270)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
     <comp lib="0" loc="(480,320)" name="Tunnel">
       <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(500,270)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(470,130)" name="Tunnel">
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(320,130)" name="Tunnel">
       <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(660,270)" name="Pin">
@@ -6448,7 +1972,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Hex"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(500,270)" name="Register">
+    <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
+    <comp lib="0" loc="(470,430)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(580,420)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="3" loc="(340,450)" name="Comparator">
       <a name="width" val="32"/>
     </comp>
   </circuit>
@@ -6836,92 +2368,153 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(80,1450)" to="(80,1630)"/>
     <wire from="(120,320)" to="(260,320)"/>
     <wire from="(120,1330)" to="(120,1510)"/>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="1" loc="(200,630)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(290,880)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+    <comp lib="1" loc="(200,1570)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1290)" name="NOT Gate">
+    <comp lib="1" loc="(200,1690)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(290,450)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="1" loc="(200,340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1450)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(200,90)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(290,1180)" name="AND Gate">
+    <comp lib="1" loc="(200,1190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(360,1750)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,1630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1670)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
+    <comp lib="0" loc="(40,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,70)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,1830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1850)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
+    <comp lib="1" loc="(200,1730)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
+    <comp lib="1" loc="(200,540)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,990)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,30)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,670)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="i"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(290,310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,1490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(400,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(200,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,880)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -6931,153 +2524,13 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="r"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
+    <comp lib="1" loc="(200,380)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(200,1090)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(360,1750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(400,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(290,1490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="i"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
+    <comp lib="1" loc="(200,440)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(420,1750)" name="Pin">
@@ -7086,25 +2539,104 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="j"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
+    <comp lib="1" loc="(200,1790)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
+    <comp lib="1" loc="(290,600)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
     <comp lib="1" loc="(200,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,60)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(200,1600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
+    <comp lib="1" loc="(200,1360)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
+    <comp lib="0" loc="(40,250)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
+      <a name="label" val="op4"/>
       <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,190)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,890)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
   </circuit>
   <circuit name="IF/ID">
@@ -7148,10 +2680,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="InstIF"/>
     </comp>
+    <comp lib="0" loc="(340,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
     <comp lib="0" loc="(310,470)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="4" loc="(380,470)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(410,470)" name="Pin">
       <a name="facing" val="west"/>
@@ -7161,11 +2702,17 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlus4IF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(340,590)" name="Pin">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(570,350)" name="Pin">
+      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(160,350)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(410,370)" name="Pin">
       <a name="facing" val="west"/>
@@ -7175,22 +2722,7 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="InstID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(160,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
     <comp lib="4" loc="(380,370)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
       <a name="width" val="32"/>
     </comp>
   </circuit>
@@ -7495,13 +3027,246 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(900,630)" to="(980,630)"/>
     <wire from="(900,390)" to="(980,390)"/>
     <wire from="(1230,410)" to="(1250,410)"/>
+    <comp lib="4" loc="(570,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(910,480)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,600)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeqEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,670)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1250,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BranchEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1180,350)" name="Pin">
+      <a name="label" val="MemWriteID"/>
+    </comp>
     <comp lib="0" loc="(1180,470)" name="Pin">
       <a name="label" val="BranchID"/>
+    </comp>
+    <comp lib="0" loc="(590,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ImmID"/>
     </comp>
     <comp lib="0" loc="(170,560)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="R2ID"/>
+    </comp>
+    <comp lib="0" loc="(240,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ImmEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,660)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrcEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,480)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
+    </comp>
+    <comp lib="0" loc="(520,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="JumpAddr"/>
+    </comp>
+    <comp lib="0" loc="(860,780)" name="Pin">
+      <a name="label" val="MemReadID"/>
+    </comp>
+    <comp lib="0" loc="(180,830)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1180,710)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#ID"/>
+    </comp>
+    <comp lib="0" loc="(1250,780)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,670)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="CP0Dout"/>
+    </comp>
+    <comp lib="0" loc="(930,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1250,590)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(60,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(570,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(860,600)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="0" loc="(1180,410)" name="Pin">
+      <a name="label" val="JumpID"/>
+    </comp>
+    <comp lib="0" loc="(1250,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="JumpEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(920,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,540)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,710)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(860,360)" name="Pin">
+      <a name="label" val="IsJALID"/>
+    </comp>
+    <comp lib="4" loc="(910,780)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,420)" name="Pin">
+      <a name="label" val="IsShamtID"/>
+    </comp>
+    <comp lib="4" loc="(1230,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(910,540)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,780)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R1EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,600)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(240,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R2EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1250,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1180,530)" name="Pin">
+      <a name="label" val="IsJRID"/>
+    </comp>
+    <comp lib="4" loc="(570,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(220,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(860,540)" name="Pin">
+      <a name="label" val="RegWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1180,590)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="4" loc="(1230,650)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(1180,780)" name="Pin">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(240,670)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1240,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(590,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="PCPlusEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(100,290)" name="Pin">
       <a name="facing" val="south"/>
@@ -7516,190 +3281,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUopEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="0" loc="(590,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="PCPlusEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
-    </comp>
-    <comp lib="0" loc="(930,660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrcEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(520,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="4" loc="(910,540)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
-    </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
-    </comp>
-    <comp lib="0" loc="(1250,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsEret"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,670)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1180,780)" name="Pin">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="0" loc="(860,720)" name="Pin">
-      <a name="label" val="IsExceptionID"/>
-    </comp>
-    <comp lib="0" loc="(930,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-    <comp lib="0" loc="(170,670)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(180,830)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,420)" name="Pin">
-      <a name="label" val="IsShamtID"/>
-    </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(930,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(930,480)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -7709,110 +3290,61 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="4" loc="(1230,780)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
-    </comp>
-    <comp lib="0" loc="(240,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R2EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
     <comp lib="4" loc="(1230,590)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(240,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R1EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
-    </comp>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
+    <comp lib="4" loc="(910,660)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(240,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ImmEX"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="4" loc="(1230,530)" name="Register">
+      <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
+    <comp lib="0" loc="(520,360)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
+      <a name="label" val="ShamtID"/>
     </comp>
     <comp lib="4" loc="(910,420)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(860,720)" name="Pin">
+      <a name="label" val="IsExceptionID"/>
     </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
+    <comp lib="0" loc="(520,560)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
+      <a name="label" val="PCPlus4ID"/>
     </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
+    <comp lib="4" loc="(1230,410)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(590,460)" name="Pin">
+    <comp lib="0" loc="(1180,650)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
+    </comp>
+    <comp lib="0" loc="(860,660)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
+    </comp>
+    <comp lib="0" loc="(590,360)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
+      <a name="label" val="ShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJREX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,720)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamtEX"/>
       <a name="labelloc" val="east"/>
     </comp>
   </circuit>
@@ -7979,164 +3511,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(430,530)" to="(450,530)"/>
     <wire from="(430,410)" to="(450,410)"/>
     <wire from="(830,460)" to="(840,460)"/>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,530)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
-    </comp>
-    <comp lib="4" loc="(870,450)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
     <comp lib="4" loc="(480,170)" name="Register">
       <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(890,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(500,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(820,450)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,530)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="4" loc="(870,340)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(350,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(890,240)" name="Pin">
       <a name="facing" val="west"/>
@@ -8145,12 +3521,168 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="WriteDataMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(500,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,470)" name="Pin">
+      <a name="label" val="IsSyscallEX"/>
+    </comp>
+    <comp lib="0" loc="(430,290)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
+    </comp>
+    <comp lib="0" loc="(350,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(890,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(870,450)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(500,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(820,340)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrEX"/>
+    </comp>
+    <comp lib="0" loc="(300,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(500,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,530)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(500,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,410)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(430,110)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="4" loc="(480,110)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(820,450)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+    </comp>
     <comp lib="0" loc="(500,530)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="5"/>
       <a name="label" val="WriteReg#MEM"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(890,450)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(870,140)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(820,140)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="0" loc="(820,240)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataEX"/>
+    </comp>
+    <comp lib="4" loc="(870,240)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(890,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(480,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(500,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,230)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(870,340)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,290)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(500,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,530)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(440,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(430,170)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
+    </comp>
+    <comp lib="0" loc="(430,350)" name="Pin">
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="4" loc="(480,410)" name="Register">
+      <a name="width" val="1"/>
     </comp>
   </circuit>
   <circuit name="MEM/WB">
@@ -8292,50 +3824,39 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(250,290)" to="(390,290)"/>
     <wire from="(290,200)" to="(490,200)"/>
     <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
     </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="0" loc="(360,440)" name="Pin">
+      <a name="label" val="IsExceptionMEM"/>
     </comp>
-    <comp lib="0" loc="(430,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultWB"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(360,560)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="4" loc="(770,290)" name="Register">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="4" loc="(410,560)" name="Register">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(720,390)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataMEM"/>
+    </comp>
+    <comp lib="4" loc="(770,500)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(410,260)" name="Register">
+      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(360,500)" name="Pin">
       <a name="label" val="IsSyscallMEM"/>
     </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
+    <comp lib="0" loc="(790,390)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="4" loc="(770,610)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
+      <a name="label" val="ReadDataWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(370,720)" name="Pin">
       <a name="facing" val="north"/>
@@ -8343,10 +3864,38 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
+    <comp lib="0" loc="(430,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(720,500)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,260)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
+    <comp lib="0" loc="(250,180)" name="Pin">
+      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(360,380)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(720,290)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
     </comp>
     <comp lib="0" loc="(790,610)" name="Pin">
       <a name="facing" val="west"/>
@@ -8355,18 +3904,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
-    </comp>
-    <comp lib="0" loc="(720,390)" name="Pin">
+    <comp lib="4" loc="(770,610)" name="Register">
       <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
     </comp>
-    <comp lib="0" loc="(720,610)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
+    <comp lib="4" loc="(410,500)" name="Register">
       <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(430,500)" name="Pin">
@@ -8375,14 +3916,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsSyscallWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
+    <comp lib="4" loc="(410,320)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(790,290)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultWB"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
     </comp>
     <comp lib="4" loc="(410,380)" name="Register">
       <a name="width" val="1"/>
@@ -8394,43 +3936,26 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(290,180)" name="Pin">
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
       <a name="label" val="clr"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(430,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="4" loc="(410,440)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
+    <comp lib="0" loc="(430,260)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
+      <a name="label" val="IsJALWB"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
     </comp>
     <comp lib="0" loc="(430,380)" name="Pin">
       <a name="facing" val="west"/>
@@ -8438,8 +3963,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RegWriteWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="4" loc="(410,560)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
     <comp lib="4" loc="(770,390)" name="Register">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(720,610)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
     </comp>
   </circuit>
   <circuit name="Regfile_Wrapper">
@@ -8486,55 +4018,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(240,190)" to="(280,190)"/>
     <wire from="(240,230)" to="(280,230)"/>
     <wire from="(320,90)" to="(320,180)"/>
-    <comp lib="0" loc="(300,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="v0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(320,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WE"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="8" loc="(370,210)" name="main"/>
-    <comp lib="0" loc="(240,230)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RW"/>
-    </comp>
-    <comp lib="0" loc="(240,190)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1#"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2#"/>
-    </comp>
-    <comp lib="0" loc="(400,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="a0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(350,290)" name="Pin">
       <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(300,350)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(240,190)" name="Pin">
+      <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
+      <a name="label" val="R1#"/>
     </comp>
     <comp lib="0" loc="(400,260)" name="Pin">
       <a name="facing" val="west"/>
@@ -8544,6 +4037,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R2"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(400,80)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="a0"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="8" loc="(370,210)" name="main"/>
+    <comp lib="0" loc="(300,350)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
     <comp lib="0" loc="(400,140)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -8551,6 +4059,30 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="R1"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,230)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RW"/>
+    </comp>
+    <comp lib="0" loc="(300,80)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="v0"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,210)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2#"/>
+    </comp>
+    <comp lib="0" loc="(320,290)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WE"/>
+      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="ALU_Wrapper">
@@ -8597,12 +4129,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="X"/>
     </comp>
     <comp lib="7" loc="(640,440)" name="ALU"/>
-    <comp lib="0" loc="(630,540)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="AluOP"/>
-      <a name="labelloc" val="south"/>
+    <comp lib="0" loc="(680,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Equal"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(750,430)" name="Pin">
       <a name="facing" val="west"/>
@@ -8611,11 +4142,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Result"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(680,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Equal"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(630,540)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="AluOP"/>
+      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="Immediate_Extend">
@@ -8645,28 +4177,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(410,310)" to="(410,330)"/>
     <wire from="(410,330)" to="(410,350)"/>
     <wire from="(560,280)" to="(560,310)"/>
-    <comp lib="0" loc="(480,350)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(480,310)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-      <a name="type" val="sign"/>
-    </comp>
-    <comp lib="2" loc="(580,330)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(630,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Output"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(560,280)" name="Pin">
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
@@ -8676,6 +4186,28 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="Input"/>
+    </comp>
+    <comp lib="2" loc="(580,330)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(480,310)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
+      <a name="type" val="sign"/>
+    </comp>
+    <comp lib="0" loc="(480,350)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(630,330)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Output"/>
+      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">
@@ -8794,85 +4326,98 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,600)" to="(1000,600)"/>
     <wire from="(900,550)" to="(910,550)"/>
     <wire from="(900,530)" to="(910,530)"/>
-    <comp lib="1" loc="(1160,450)" name="OR Gate">
-      <a name="size" val="30"/>
+    <comp lib="1" loc="(1290,430)" name="AND Gate">
       <a name="inputs" val="2"/>
     </comp>
-    <comp loc="(800,470)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(150,130)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(980,350)" name="Constant">
+      <a name="width" val="2"/>
+    </comp>
     <comp lib="0" loc="(380,200)" name="Tunnel">
       <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(130,170)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(130,330)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RT"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(140,250)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(900,530)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1350,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(900,320)" name="Constant">
       <a name="width" val="2"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(790,540)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteEX"/>
+    <comp lib="0" loc="(150,170)" name="Tunnel">
+      <a name="label" val="ReadWriteMEM"/>
     </comp>
-    <comp lib="0" loc="(160,250)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
+    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="2" loc="(940,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(130,210)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="RS"/>
     </comp>
-    <comp lib="0" loc="(360,200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
+    <comp lib="6" loc="(917,390)" name="Text">
+      <a name="text" val="Rs Hazard in EX"/>
     </comp>
-    <comp lib="0" loc="(1350,180)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
+    <comp lib="0" loc="(160,250)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp loc="(800,270)" name="Hazard_Detector"/>
-    <comp loc="(800,570)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(1540,510)" name="Pin">
+    <comp lib="6" loc="(1204,445)" name="Text">
+      <a name="text" val="hasHazard"/>
+    </comp>
+    <comp lib="0" loc="(1350,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1420,410)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="BubbleNum"/>
+      <a name="label" val="StallIF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(360,240)" name="Pin">
+    <comp lib="0" loc="(130,170)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteEX"/>
+      <a name="label" val="RegWriteMEM"/>
     </comp>
-    <comp lib="6" loc="(912,490)" name="Text">
-      <a name="text" val="Rt Hazard in MEM"/>
+    <comp lib="0" loc="(130,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="0" loc="(160,290)" name="Tunnel">
+    <comp lib="0" loc="(740,250)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="0" loc="(130,290)" name="Pin">
+    <comp lib="0" loc="(900,340)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(150,210)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(570,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(1570,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(140,250)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="2" loc="(1020,550)" name="Multiplexer">
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(1550,150)" name="Pin">
       <a name="facing" val="west"/>
@@ -8880,121 +4425,66 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="FlushIF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(150,170)" name="Tunnel">
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="1" loc="(1550,340)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
     <comp lib="2" loc="(940,330)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="2"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(170,50)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(980,350)" name="Constant">
+    <comp lib="0" loc="(1040,550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp loc="(800,370)" name="Hazard_Detector"/>
-    <comp lib="2" loc="(940,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="1" loc="(1160,450)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1540,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="BubbleNum"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(1020,340)" name="Multiplexer">
       <a name="width" val="2"/>
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1204,445)" name="Text">
-      <a name="text" val="hasHazard"/>
-    </comp>
-    <comp lib="4" loc="(1480,510)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
     </comp>
     <comp lib="6" loc="(922,290)" name="Text">
       <a name="text" val="Rs Hazard in MEM"/>
     </comp>
-    <comp lib="0" loc="(530,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
+    <comp lib="0" loc="(360,200)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRt"/>
     </comp>
-    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(790,340)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(150,130)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="6" loc="(909,590)" name="Text">
-      <a name="text" val="Rt Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(1390,350)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp loc="(800,570)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(1460,550)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(790,360)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="0" loc="(160,330)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(790,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(840,220)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(790,460)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="2" loc="(1020,340)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(380,240)" name="Tunnel">
-      <a name="label" val="ReadWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(740,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(570,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(900,550)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="6" loc="(917,390)" name="Text">
-      <a name="text" val="Rs Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(1420,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallID"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(360,240)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteEX"/>
     </comp>
     <comp lib="0" loc="(820,250)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="0" loc="(640,250)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(900,550)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="1" loc="(1550,340)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(160,290)" name="Tunnel">
       <a name="width" val="5"/>
       <a name="label" val="WriteReg#EX"/>
     </comp>
@@ -9005,67 +4495,109 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RsOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1210,410)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="IsLW"/>
-    </comp>
-    <comp lib="0" loc="(900,340)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(1460,550)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+    <comp loc="(800,470)" name="Hazard_Detector"/>
+    <comp lib="4" loc="(1480,510)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
     <comp lib="0" loc="(790,560)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ReadRt"/>
     </comp>
-    <comp lib="0" loc="(130,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRs"/>
+    <comp lib="6" loc="(912,490)" name="Text">
+      <a name="text" val="Rt Hazard in MEM"/>
     </comp>
     <comp lib="0" loc="(130,50)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1570,340)" name="Pin">
+    <comp lib="0" loc="(1350,180)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="6" loc="(909,590)" name="Text">
+      <a name="text" val="Rt Hazard in EX"/>
+    </comp>
+    <comp lib="0" loc="(170,50)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(640,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(1420,450)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="FlushID"/>
+      <a name="label" val="StallID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1420,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallIF"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(790,540)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadWriteEX"/>
     </comp>
-    <comp lib="1" loc="(1290,430)" name="AND Gate">
-      <a name="inputs" val="2"/>
+    <comp loc="(800,370)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(790,460)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
     </comp>
-    <comp lib="0" loc="(1040,550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1390,350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(130,290)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(380,240)" name="Tunnel">
+      <a name="label" val="ReadWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(790,340)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(530,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RT"/>
     </comp>
     <comp lib="0" loc="(980,560)" name="Constant">
       <a name="width" val="2"/>
     </comp>
-    <comp lib="2" loc="(1020,550)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(840,220)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(790,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(1210,410)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="IsLW"/>
     </comp>
     <comp lib="1" loc="(1540,150)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
       <a name="negate0" val="true"/>
     </comp>
-    <comp lib="0" loc="(150,210)" name="Tunnel">
+    <comp loc="(800,270)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(900,530)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(130,330)" name="Pin">
       <a name="width" val="5"/>
-      <a name="label" val="RS"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RT"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(160,330)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RT"/>
     </comp>
   </circuit>
   <circuit name="RegisterRead_Detector">
@@ -10064,426 +5596,7 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(360,3430)" to="(360,3470)"/>
     <wire from="(220,3150)" to="(300,3150)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="0" loc="(40,430)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3640)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,530)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(710,1960)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="0" loc="(40,580)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,830)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="9"/>
-    </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(730,1960)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -10491,183 +5604,158 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(410,950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,4260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,2320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,410)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4550)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(510,2500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1290)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,3640)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="11"/>
     </comp>
-    <comp lib="1" loc="(520,4790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,2940)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
+    <comp lib="1" loc="(600,2450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(730,4550)" name="Pin">
@@ -10676,28 +5764,472 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ReadRt"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
+    <comp lib="1" loc="(600,2570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,3250)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(690,4550)" name="OR Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,530)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,580)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(600,2320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(320,3370)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(510,2390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,4790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4830)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
   </circuit>
   <circuit name="Hazard_Detector">
@@ -10732,43 +6264,43 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,300)" to="(610,300)"/>
     <wire from="(590,290)" to="(600,290)"/>
     <wire from="(600,340)" to="(610,340)"/>
-    <comp lib="0" loc="(590,310)" name="Pin">
+    <comp lib="0" loc="(400,340)" name="Pin">
+      <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="RegWrite"/>
+      <a name="label" val="WriteReg"/>
+    </comp>
+    <comp lib="1" loc="(530,330)" name="NOT Gate"/>
+    <comp lib="3" loc="(490,370)" name="Comparator">
+      <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(590,290)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="Read"/>
     </comp>
-    <comp lib="1" loc="(530,330)" name="NOT Gate"/>
     <comp lib="0" loc="(700,320)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="Hazard"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(400,340)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg"/>
-    </comp>
-    <comp lib="3" loc="(490,370)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
     <comp lib="3" loc="(490,330)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="1" loc="(660,320)" name="AND Gate">
-      <a name="inputs" val="4"/>
+    <comp lib="0" loc="(430,320)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
     </comp>
     <comp lib="0" loc="(400,380)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="Register#"/>
     </comp>
-    <comp lib="0" loc="(430,320)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
+    <comp lib="1" loc="(660,320)" name="AND Gate">
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="0" loc="(590,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWrite"/>
     </comp>
   </circuit>
   <circuit name="CP0">
@@ -10964,143 +6496,143 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(850,680)" to="(850,730)"/>
     <wire from="(590,240)" to="(590,1190)"/>
     <wire from="(180,1050)" to="(180,1110)"/>
-    <comp lib="0" loc="(220,1030)" name="Constant">
+    <comp lib="0" loc="(1030,790)" name="Splitter">
       <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(140,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(740,1010)" name="Constant">
+    <comp lib="1" loc="(790,1010)" name="Controlled Buffer">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(710,480)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCin"/>
-    </comp>
-    <comp lib="0" loc="(270,960)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
+    <comp lib="0" loc="(880,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
     </comp>
     <comp lib="0" loc="(220,160)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ExpBlock"/>
     </comp>
-    <comp lib="0" loc="(470,770)" name="Tunnel">
+    <comp lib="0" loc="(500,160)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="0" loc="(1130,840)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(750,410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(780,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(1170,930)" name="Tunnel">
-      <a name="label" val="BlockSrc0"/>
-    </comp>
-    <comp lib="0" loc="(870,180)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(1150,110)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(490,900)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="1" loc="(890,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(770,490)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(970,990)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(230,110)" name="Tunnel">
+    <comp lib="0" loc="(710,580)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(210,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
     </comp>
     <comp lib="0" loc="(400,390)" name="Tunnel">
       <a name="width" val="2"/>
       <a name="label" val="Sel"/>
     </comp>
-    <comp lib="0" loc="(110,1110)" name="Tunnel">
+    <comp lib="0" loc="(970,990)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc0"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(290,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(240,410)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Inst"/>
+    </comp>
+    <comp lib="2" loc="(770,650)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1170,950)" name="Tunnel">
+      <a name="label" val="BlockSrc1"/>
+    </comp>
+    <comp lib="0" loc="(740,1010)" name="Constant">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1150,110)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(306,664)" name="Text">
+      <a name="text" val="Exception Signals"/>
+      <a name="font" val="Monaco plain 26"/>
     </comp>
     <comp lib="2" loc="(280,1070)" name="Demultiplexer">
       <a name="facing" val="north"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="6" loc="(327,306)" name="Text">
-      <a name="text" val="Signal Decoding"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(280,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
     <comp lib="1" loc="(940,520)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(790,1120)" name="Controlled Buffer">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(870,180)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(260,110)" name="Pin">
+    <comp lib="0" loc="(740,1070)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x3"/>
+    </comp>
+    <comp lib="6" loc="(654,60)" name="Text">
+      <a name="text" val="Input &amp; Output"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="6" loc="(953,342)" name="Text">
+      <a name="text" val="Registers"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(550,160)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="ExRegWrite"/>
+      <a name="label" val="HasExp"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(780,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
+    <comp lib="0" loc="(260,160)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExpBlock"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1090,160)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="enable"/>
+    <comp lib="0" loc="(760,650)" name="Constant"/>
+    <comp lib="1" loc="(750,460)" name="NOT Gate">
+      <a name="facing" val="south"/>
     </comp>
-    <comp lib="0" loc="(1090,110)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(750,410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="2" loc="(210,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(790,1070)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(870,140)" name="Tunnel">
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(790,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="1" loc="(770,570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
+    <comp lib="0" loc="(260,860)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpClick"/>
     </comp>
     <comp lib="0" loc="(1180,790)" name="Pin">
       <a name="facing" val="west"/>
@@ -11109,100 +6641,140 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="Dout"/>
     </comp>
-    <comp lib="6" loc="(306,664)" name="Text">
-      <a name="text" val="Exception Signals"/>
-      <a name="font" val="Monaco plain 26"/>
+    <comp lib="2" loc="(210,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(970,530)" name="Tunnel">
+    <comp lib="0" loc="(1150,160)" name="Tunnel">
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="1" loc="(770,570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(780,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="4" loc="(1000,1070)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Cause"/>
+    </comp>
+    <comp lib="1" loc="(390,460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+      <a name="negate0" val="true"/>
+      <a name="negate3" val="true"/>
+      <a name="negate4" val="true"/>
+      <a name="negate5" val="true"/>
+    </comp>
+    <comp lib="0" loc="(490,110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(400,360)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(140,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(220,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(890,670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(810,100)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(740,1120)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x7"/>
+    </comp>
+    <comp lib="0" loc="(870,100)" name="Tunnel">
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(710,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(1170,970)" name="Tunnel">
+      <a name="label" val="BlockSrc2"/>
+    </comp>
+    <comp lib="0" loc="(470,770)" name="Tunnel">
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(410,460)" name="Tunnel">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="4" loc="(990,780)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Status"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(980,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="1" loc="(890,720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(260,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExRegWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(790,1120)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="1" loc="(490,900)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(710,780)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
+    <comp lib="0" loc="(780,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(790,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="1" loc="(260,890)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="4" loc="(990,950)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Block"/>
     </comp>
     <comp lib="2" loc="(1150,790)" name="Multiplexer">
       <a name="select" val="2"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(260,160)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ExpBlock"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(150,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="4" loc="(990,780)" name="Register">
+    <comp lib="1" loc="(790,1070)" name="Controlled Buffer">
       <a name="width" val="32"/>
-      <a name="label" val="Status"/>
-    </comp>
-    <comp lib="0" loc="(1170,970)" name="Tunnel">
-      <a name="label" val="BlockSrc2"/>
-    </comp>
-    <comp lib="0" loc="(430,920)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="2" loc="(140,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(710,580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="1" loc="(790,1010)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="1" loc="(200,960)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(440,770)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(740,1120)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x7"/>
-    </comp>
-    <comp lib="1" loc="(890,670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(240,410)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Inst"/>
-    </comp>
-    <comp lib="0" loc="(550,160)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="HasExp"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(550,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsEret"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(890,720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1170,950)" name="Tunnel">
-      <a name="label" val="BlockSrc1"/>
-    </comp>
-    <comp lib="0" loc="(490,110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="2" loc="(770,650)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(780,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
     </comp>
     <comp lib="0" loc="(290,390)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -11241,87 +6813,73 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1030,790)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+    <comp lib="6" loc="(327,306)" name="Text">
+      <a name="text" val="Signal Decoding"/>
+      <a name="font" val="Monaco plain 26"/>
     </comp>
-    <comp lib="0" loc="(870,100)" name="Tunnel">
-      <a name="label" val="ExpSrc0"/>
+    <comp lib="2" loc="(140,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(110,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="BlockSrc0"/>
+    </comp>
+    <comp lib="0" loc="(710,480)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCin"/>
+    </comp>
+    <comp lib="0" loc="(270,960)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="2" loc="(770,490)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(810,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1030,810)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(390,760)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1180,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCout"/>
+    </comp>
+    <comp lib="0" loc="(970,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="4" loc="(340,850)" name="Counter">
       <a name="width" val="1"/>
       <a name="max" val="0x1"/>
       <a name="ongoal" val="stay"/>
     </comp>
-    <comp lib="0" loc="(710,780)" name="Pin">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(1170,930)" name="Tunnel">
+      <a name="label" val="BlockSrc0"/>
+    </comp>
+    <comp lib="0" loc="(870,140)" name="Tunnel">
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1090,160)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
-    </comp>
-    <comp lib="1" loc="(390,460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(710,560)" name="Tunnel">
-      <a name="facing" val="east"/>
       <a name="label" val="enable"/>
     </comp>
-    <comp lib="0" loc="(410,460)" name="Tunnel">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(880,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="4" loc="(450,880)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(400,360)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(500,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
+    <comp lib="0" loc="(180,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="BlockSrc1"/>
     </comp>
     <comp lib="0" loc="(300,460)" name="Splitter">
       <a name="fanout" val="6"/>
@@ -11360,20 +6918,27 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="4" loc="(990,950)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Block"/>
-    </comp>
-    <comp lib="0" loc="(1180,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(1090,110)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="PCout"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(810,140)" name="Pin">
-      <a name="tristate" val="false"/>
+    <comp lib="1" loc="(200,960)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="4" loc="(990,490)" name="Register">
+      <a name="width" val="32"/>
+      <a name="trigger" val="low"/>
+      <a name="label" val="EPC"/>
+    </comp>
+    <comp lib="0" loc="(210,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(780,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
     <comp lib="0" loc="(1130,950)" name="Splitter">
       <a name="fanout" val="3"/>
@@ -11409,27 +6974,32 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1150,160)" name="Tunnel">
-      <a name="label" val="enable"/>
+    <comp lib="0" loc="(430,920)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="0" loc="(150,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(750,460)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(810,100)" name="Pin">
+    <comp lib="1" loc="(370,360)" name="NOT Gate"/>
+    <comp lib="0" loc="(810,180)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc0"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(290,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
+    <comp lib="4" loc="(450,880)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+      <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="6" loc="(953,342)" name="Text">
-      <a name="text" val="Registers"/>
-      <a name="font" val="Monaco plain 26"/>
+    <comp lib="0" loc="(230,110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="1" loc="(440,770)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(250,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="BlockSrc2"/>
     </comp>
     <comp lib="0" loc="(300,360)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -11468,62 +7038,24 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(980,1110)" name="Tunnel">
+    <comp lib="0" loc="(1130,840)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="ExpClick"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
     </comp>
-    <comp lib="0" loc="(260,860)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="0" loc="(760,650)" name="Constant"/>
-    <comp lib="1" loc="(370,360)" name="NOT Gate"/>
-    <comp lib="1" loc="(260,890)" name="AND Gate">
-      <a name="facing" val="north"/>
+    <comp lib="1" loc="(890,610)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
     </comp>
-    <comp lib="0" loc="(740,1070)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x3"/>
-    </comp>
-    <comp lib="4" loc="(1000,1070)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Cause"/>
-    </comp>
-    <comp lib="0" loc="(390,760)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(250,1110)" name="Tunnel">
+    <comp lib="0" loc="(280,1080)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc2"/>
-    </comp>
-    <comp lib="0" loc="(180,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc1"/>
-    </comp>
-    <comp lib="6" loc="(654,60)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(1030,810)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(810,180)" name="Pin">
-      <a name="tristate" val="false"/>
       <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="4" loc="(990,490)" name="Register">
-      <a name="width" val="32"/>
-      <a name="trigger" val="low"/>
-      <a name="label" val="EPC"/>
-    </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(550,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
+      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="RegWrite_Decider">
@@ -11544,27 +7076,27 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(390,240)" to="(420,240)"/>
     <wire from="(390,260)" to="(420,260)"/>
     <wire from="(430,270)" to="(430,310)"/>
-    <comp lib="0" loc="(390,260)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="2" loc="(450,250)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
     <comp lib="0" loc="(430,310)" name="Pin">
       <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
       <a name="label" val="IsException"/>
-    </comp>
-    <comp lib="0" loc="(390,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWrite"/>
     </comp>
     <comp lib="0" loc="(460,250)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="FinalRegWrite"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(390,240)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="2" loc="(450,250)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(390,260)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExRegWrite"/>
     </comp>
   </circuit>
 </project>

--- a/src/pipeline_cpu_bubbling.circ
+++ b/src/pipeline_cpu_bubbling.circ
@@ -97,6 +97,7 @@
   </lib>
   <lib desc="file#common/alu.circ" name="7"/>
   <lib desc="file#common/regfile.circ" name="8"/>
+  <lib desc="file#common/control.circ" name="9"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -447,21 +448,124 @@
     <wire from="(530,360)" to="(540,360)"/>
     <wire from="(560,870)" to="(570,870)"/>
     <wire from="(350,410)" to="(420,410)"/>
+    <comp lib="0" loc="(400,270)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+      <a name="bit11" val="2"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+      <a name="bit14" val="3"/>
+      <a name="bit15" val="3"/>
+      <a name="bit16" val="4"/>
+      <a name="bit17" val="4"/>
+      <a name="bit18" val="4"/>
+      <a name="bit19" val="4"/>
+      <a name="bit20" val="5"/>
+      <a name="bit21" val="5"/>
+      <a name="bit22" val="5"/>
+      <a name="bit23" val="5"/>
+      <a name="bit24" val="6"/>
+      <a name="bit25" val="6"/>
+      <a name="bit26" val="6"/>
+      <a name="bit27" val="6"/>
+      <a name="bit28" val="7"/>
+      <a name="bit29" val="7"/>
+      <a name="bit30" val="7"/>
+      <a name="bit31" val="7"/>
+    </comp>
+    <comp lib="0" loc="(670,500)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(693,306)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(1510,1050)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="1" loc="(580,1030)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(970,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
     <comp lib="0" loc="(380,450)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10unsigned"/>
       <a name="label" val="R"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(2080,450)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
+    <comp lib="3" loc="(1440,920)" name="Adder">
+      <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(500,730)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
+    <comp lib="6" loc="(1840,685)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="0" loc="(670,840)" name="Splitter">
+    <comp lib="6" loc="(1035,755)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="0" loc="(780,460)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="2" loc="(1350,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(2010,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(670,320)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -470,16 +574,16 @@
       <a name="bit3" val="0"/>
       <a name="bit4" val="0"/>
       <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
       <a name="bit16" val="none"/>
       <a name="bit17" val="none"/>
       <a name="bit18" val="none"/>
@@ -497,19 +601,72 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
+    <comp lib="1" loc="(1450,330)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(490,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp loc="(1410,580)" name="ALU_Wrapper"/>
+    <comp lib="0" loc="(300,580)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(590,120)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(1370,410)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="2" loc="(90,530)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1010,470)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="2" loc="(830,680)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1410,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(1520,920)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2030,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(800,810)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="4" loc="(320,550)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
     <comp lib="0" loc="(200,730)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="4" loc="(220,700)" name="Counter">
+    <comp lib="2" loc="(200,550)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(310,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
+    <comp lib="0" loc="(410,630)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
     </comp>
     <comp lib="0" loc="(540,550)" name="Splitter">
       <a name="facing" val="north"/>
@@ -549,32 +706,51 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
-    <comp lib="0" loc="(670,500)" name="Splitter">
+    <comp lib="0" loc="(1780,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="2" loc="(910,690)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(510,350)" name="Statistics"/>
+    <comp lib="6" loc="(2028,981)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="5" loc="(420,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(670,760)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
       <a name="bit21" val="0"/>
       <a name="bit22" val="0"/>
       <a name="bit23" val="0"/>
@@ -587,118 +763,11 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="5" loc="(300,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1780,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(2030,500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="0" loc="(420,720)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Bubble Number"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="2" loc="(2010,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1953,236)" name="Text">
-      <a name="text" val="Ignored"/>
-    </comp>
-    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="2" loc="(2060,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1410,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(660,870)" name="Splitter">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(670,840)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="6" loc="(995,966)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="0" loc="(1020,620)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(1309,1055)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="4" loc="(1830,580)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp loc="(1890,130)" name="MEM/WB"/>
-    <comp lib="0" loc="(1670,580)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
+      <a name="bit1" val="0"/>
       <a name="bit2" val="0"/>
       <a name="bit3" val="0"/>
       <a name="bit4" val="0"/>
@@ -709,10 +778,10 @@
       <a name="bit9" val="0"/>
       <a name="bit10" val="0"/>
       <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
       <a name="bit16" val="none"/>
       <a name="bit17" val="none"/>
       <a name="bit18" val="none"/>
@@ -730,53 +799,71 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp loc="(1510,140)" name="EX/MEM"/>
-    <comp lib="0" loc="(670,540)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+    <comp lib="2" loc="(2060,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(450,450)" name="Probe">
+    <comp lib="0" loc="(530,360)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="6" loc="(414,100)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp lib="0" loc="(2030,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(780,440)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="6" loc="(1005,925)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="0" loc="(1900,910)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
+    </comp>
+    <comp lib="0" loc="(2130,500)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="6" loc="(690,678)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="2" loc="(1290,610)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(230,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="4" loc="(440,300)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
+    <comp lib="0" loc="(270,700)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(810,750)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="9" loc="(720,140)" name="Control"/>
+    <comp loc="(1510,140)" name="EX/MEM"/>
+    <comp lib="6" loc="(997,944)" name="Text">
+      <a name="text" val="Jump Addr"/>
     </comp>
     <comp lib="4" loc="(520,550)" name="ROM">
       <a name="addrWidth" val="10"/>
@@ -826,49 +913,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="2" loc="(90,530)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+    <comp lib="6" loc="(1035,833)" name="Text">
+      <a name="text" val="Immediate"/>
     </comp>
-    <comp lib="0" loc="(670,320)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2130,500)" name="Tunnel">
-      <a name="label" val="Halt"/>
+    <comp loc="(950,480)" name="Regfile_Wrapper"/>
+    <comp lib="6" loc="(1044,617)" name="Text">
+      <a name="text" val="Shamt"/>
     </comp>
     <comp lib="0" loc="(670,240)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -907,54 +957,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(490,670)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="6" loc="(1840,685)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(2030,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="6" loc="(1454,655)" name="Text">
-      <a name="text" val="WriteDataEX"/>
-    </comp>
-    <comp lib="2" loc="(1260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1005,925)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp lib="2" loc="(490,680)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1090,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp loc="(570,130)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
-    </comp>
-    <comp lib="6" loc="(693,306)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="4" loc="(320,550)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="6" loc="(1973,684)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="0" loc="(300,580)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
     <comp lib="0" loc="(670,620)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -992,354 +994,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp loc="(190,1060)" name="Hazard Unit"/>
-    <comp lib="0" loc="(810,750)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(200,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(692,230)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="5" loc="(460,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1310,940)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="2" loc="(1290,610)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(1410,580)" name="ALU_Wrapper"/>
-    <comp lib="6" loc="(414,100)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="1" loc="(1450,330)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(410,630)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="6" loc="(1044,617)" name="Text">
-      <a name="text" val="Shamt"/>
-    </comp>
-    <comp lib="4" loc="(370,320)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="1" loc="(1010,470)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="2" loc="(910,690)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1035,833)" name="Text">
-      <a name="text" val="Immediate"/>
-    </comp>
-    <comp lib="6" loc="(512,867)" name="Text">
-      <a name="text" val="PCPlus4IF"/>
-    </comp>
-    <comp lib="6" loc="(1035,755)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="5" loc="(420,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(970,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="0" loc="(670,690)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp loc="(510,350)" name="Statistics"/>
-    <comp loc="(720,140)" name="Control">
-      <a name="labelfont" val="Dialog plain 16"/>
-    </comp>
-    <comp lib="2" loc="(150,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(350,420)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(590,120)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1900,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="2" loc="(830,680)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="3" loc="(470,620)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="1" loc="(1480,270)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(1040,682)" name="Text">
-      <a name="text" val="WriteReg#"/>
-    </comp>
-    <comp lib="6" loc="(690,678)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="6" loc="(689,491)" name="Text">
-      <a name="text" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(400,270)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-      <a name="bit16" val="4"/>
-      <a name="bit17" val="4"/>
-      <a name="bit18" val="4"/>
-      <a name="bit19" val="4"/>
-      <a name="bit20" val="5"/>
-      <a name="bit21" val="5"/>
-      <a name="bit22" val="5"/>
-      <a name="bit23" val="5"/>
-      <a name="bit24" val="6"/>
-      <a name="bit25" val="6"/>
-      <a name="bit26" val="6"/>
-      <a name="bit27" val="6"/>
-      <a name="bit28" val="7"/>
-      <a name="bit29" val="7"/>
-      <a name="bit30" val="7"/>
-      <a name="bit31" val="7"/>
-    </comp>
-    <comp loc="(2060,450)" name="Syscall_Decoder"/>
-    <comp lib="4" loc="(300,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp loc="(780,820)" name="Immediate_Extend"/>
-    <comp lib="0" loc="(270,700)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="6" loc="(1953,236)" name="Text">
+      <a name="text" val="Ignored"/>
     </comp>
     <comp lib="0" loc="(860,700)" name="Constant">
       <a name="width" val="5"/>
       <a name="value" val="0x1f"/>
     </comp>
-    <comp lib="3" loc="(1440,920)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(800,810)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(990,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="1" loc="(580,1030)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(350,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1510,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="6" loc="(1033,862)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="1" loc="(1370,410)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="0" loc="(230,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="4" loc="(220,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp loc="(950,480)" name="Regfile_Wrapper"/>
     <comp lib="0" loc="(810,710)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="RegDstID"/>
     </comp>
-    <comp loc="(1080,130)" name="ID/EX"/>
-    <comp lib="3" loc="(1360,930)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(780,440)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="6" loc="(997,944)" name="Text">
-      <a name="text" val="Jump Addr"/>
-    </comp>
-    <comp lib="6" loc="(2028,981)" name="Text">
-      <a name="text" val="WB_DATA"/>
-    </comp>
-    <comp lib="0" loc="(670,760)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1520,920)" name="Constant">
-      <a name="facing" val="north"/>
+    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
     <comp lib="0" loc="(850,760)" name="Splitter">
       <a name="facing" val="west"/>
@@ -1378,4519 +1047,382 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="2"/>
       <a name="bit31" val="2"/>
     </comp>
+    <comp lib="4" loc="(440,300)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp loc="(2060,450)" name="Syscall_Decoder"/>
+    <comp lib="6" loc="(1973,684)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="0" loc="(1020,620)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(480,730)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp loc="(190,1060)" name="Hazard Unit"/>
+    <comp lib="0" loc="(2080,450)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(512,867)" name="Text">
+      <a name="text" val="PCPlus4IF"/>
+    </comp>
+    <comp lib="6" loc="(689,491)" name="Text">
+      <a name="text" val="RS"/>
+    </comp>
+    <comp lib="6" loc="(692,230)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp lib="4" loc="(370,320)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
     <comp lib="6" loc="(687,529)" name="Text">
       <a name="text" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(1670,580)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="1" loc="(1480,270)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(500,730)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
+    <comp lib="0" loc="(1750,1050)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(420,720)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Bubble Number"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp loc="(780,820)" name="Immediate_Extend"/>
+    <comp lib="4" loc="(220,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
     </comp>
     <comp lib="0" loc="(1540,920)" name="Constant">
       <a name="facing" val="north"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(530,360)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(180,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(350,420)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1920,910)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(780,460)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(480,730)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="2" loc="(1350,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="4" loc="(220,700)" name="Counter">
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(1090,910)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(670,690)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="5" loc="(460,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="4" loc="(300,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="6" loc="(1454,655)" name="Text">
+      <a name="text" val="WriteDataEX"/>
+    </comp>
+    <comp lib="3" loc="(470,620)" name="Adder">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(1760,630)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1750,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="4" loc="(1830,580)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
     </comp>
-  </circuit>
-  <circuit name="Control">
-    <a name="circuit" val="Control"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#4b00ff" height="342" stroke="#ffffff" stroke-width="2" width="33" x="60" y="160"/>
-      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="74" y="300">Ctrl</text>
-      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="75" y="323">Unit</text>
-      <circ-port height="8" pin="240,130" width="8" x="56" y="256"/>
-      <circ-port height="8" pin="460,130" width="8" x="56" y="336"/>
-      <circ-port height="10" pin="980,360" width="10" x="85" y="375"/>
-      <circ-port height="10" pin="260,170" width="10" x="85" y="175"/>
-      <circ-port height="10" pin="260,210" width="10" x="85" y="415"/>
-      <circ-port height="10" pin="260,250" width="10" x="85" y="215"/>
-      <circ-port height="10" pin="260,290" width="10" x="85" y="195"/>
-      <circ-port height="10" pin="480,170" width="10" x="85" y="275"/>
-      <circ-port height="10" pin="480,210" width="10" x="85" y="255"/>
-      <circ-port height="10" pin="480,250" width="10" x="85" y="355"/>
-      <circ-port height="10" pin="480,290" width="10" x="85" y="315"/>
-      <circ-port height="10" pin="480,330" width="10" x="85" y="455"/>
-      <circ-port height="10" pin="260,330" width="10" x="85" y="335"/>
-      <circ-port height="10" pin="260,370" width="10" x="85" y="395"/>
-      <circ-port height="10" pin="480,370" width="10" x="85" y="295"/>
-      <circ-port height="10" pin="260,410" width="10" x="85" y="435"/>
-      <circ-port height="10" pin="480,410" width="10" x="85" y="235"/>
-      <circ-port height="10" pin="260,450" width="10" x="85" y="475"/>
-      <circ-port height="10" pin="480,440" width="10" x="65" y="495"/>
-      <circ-port height="10" pin="480,470" width="10" x="75" y="495"/>
-      <circ-anchor facing="east" height="6" width="6" x="57" y="157"/>
-    </appear>
-    <wire from="(910,470)" to="(910,480)"/>
-    <wire from="(820,740)" to="(820,750)"/>
-    <wire from="(840,720)" to="(840,730)"/>
-    <wire from="(140,50)" to="(580,50)"/>
-    <wire from="(140,850)" to="(580,850)"/>
-    <wire from="(140,490)" to="(580,490)"/>
-    <wire from="(750,220)" to="(750,310)"/>
-    <wire from="(930,170)" to="(930,190)"/>
-    <wire from="(820,370)" to="(820,450)"/>
-    <wire from="(830,740)" to="(850,740)"/>
-    <wire from="(230,170)" to="(260,170)"/>
-    <wire from="(910,300)" to="(930,300)"/>
-    <wire from="(1080,50)" to="(1080,550)"/>
-    <wire from="(460,250)" to="(480,250)"/>
-    <wire from="(460,130)" to="(480,130)"/>
-    <wire from="(460,170)" to="(480,170)"/>
-    <wire from="(460,210)" to="(480,210)"/>
-    <wire from="(460,290)" to="(480,290)"/>
-    <wire from="(460,330)" to="(480,330)"/>
-    <wire from="(460,370)" to="(480,370)"/>
-    <wire from="(460,410)" to="(480,410)"/>
-    <wire from="(950,130)" to="(980,130)"/>
-    <wire from="(950,210)" to="(980,210)"/>
-    <wire from="(900,440)" to="(930,440)"/>
-    <wire from="(430,670)" to="(440,670)"/>
-    <wire from="(490,690)" to="(500,690)"/>
-    <wire from="(250,250)" to="(260,250)"/>
-    <wire from="(250,290)" to="(260,290)"/>
-    <wire from="(250,330)" to="(260,330)"/>
-    <wire from="(230,710)" to="(240,710)"/>
-    <wire from="(710,430)" to="(720,430)"/>
-    <wire from="(710,470)" to="(720,470)"/>
-    <wire from="(600,50)" to="(600,550)"/>
-    <wire from="(930,300)" to="(930,310)"/>
-    <wire from="(800,350)" to="(920,350)"/>
-    <wire from="(1080,570)" to="(1080,850)"/>
-    <wire from="(730,140)" to="(920,140)"/>
-    <wire from="(600,570)" to="(600,850)"/>
-    <wire from="(750,220)" to="(920,220)"/>
-    <wire from="(860,460)" to="(880,460)"/>
-    <wire from="(900,460)" to="(920,460)"/>
-    <wire from="(660,450)" to="(690,450)"/>
-    <wire from="(270,750)" to="(290,750)"/>
-    <wire from="(270,710)" to="(290,710)"/>
-    <wire from="(270,670)" to="(290,670)"/>
-    <wire from="(270,790)" to="(290,790)"/>
-    <wire from="(270,630)" to="(290,630)"/>
-    <wire from="(600,50)" to="(1080,50)"/>
-    <wire from="(600,570)" to="(1080,570)"/>
-    <wire from="(600,850)" to="(1080,850)"/>
-    <wire from="(950,260)" to="(980,260)"/>
-    <wire from="(820,690)" to="(850,690)"/>
-    <wire from="(900,450)" to="(930,450)"/>
-    <wire from="(900,490)" to="(930,490)"/>
-    <wire from="(900,170)" to="(930,170)"/>
-    <wire from="(580,50)" to="(580,490)"/>
-    <wire from="(230,680)" to="(240,680)"/>
-    <wire from="(230,720)" to="(240,720)"/>
-    <wire from="(970,460)" to="(980,460)"/>
-    <wire from="(140,50)" to="(140,490)"/>
-    <wire from="(900,470)" to="(910,470)"/>
-    <wire from="(910,200)" to="(920,200)"/>
-    <wire from="(910,120)" to="(920,120)"/>
-    <wire from="(840,730)" to="(850,730)"/>
-    <wire from="(710,440)" to="(720,440)"/>
-    <wire from="(920,460)" to="(920,470)"/>
-    <wire from="(830,730)" to="(830,740)"/>
-    <wire from="(900,480)" to="(900,490)"/>
-    <wire from="(140,510)" to="(580,510)"/>
-    <wire from="(140,510)" to="(140,850)"/>
-    <wire from="(930,150)" to="(930,170)"/>
-    <wire from="(580,510)" to="(580,850)"/>
-    <wire from="(800,450)" to="(820,450)"/>
-    <wire from="(770,270)" to="(920,270)"/>
-    <wire from="(910,480)" to="(930,480)"/>
-    <wire from="(770,270)" to="(770,310)"/>
-    <wire from="(670,350)" to="(700,350)"/>
-    <wire from="(460,470)" to="(480,470)"/>
-    <wire from="(240,130)" to="(260,130)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(240,370)" to="(260,370)"/>
-    <wire from="(240,410)" to="(260,410)"/>
-    <wire from="(240,450)" to="(260,450)"/>
-    <wire from="(430,730)" to="(440,730)"/>
-    <wire from="(490,710)" to="(500,710)"/>
-    <wire from="(230,690)" to="(240,690)"/>
-    <wire from="(230,730)" to="(240,730)"/>
-    <wire from="(910,250)" to="(920,250)"/>
-    <wire from="(710,450)" to="(720,450)"/>
-    <wire from="(820,370)" to="(920,370)"/>
-    <wire from="(820,700)" to="(860,700)"/>
-    <wire from="(930,280)" to="(930,300)"/>
-    <wire from="(820,720)" to="(840,720)"/>
-    <wire from="(780,720)" to="(800,720)"/>
-    <wire from="(730,140)" to="(730,310)"/>
-    <wire from="(270,730)" to="(290,730)"/>
-    <wire from="(270,690)" to="(290,690)"/>
-    <wire from="(270,770)" to="(290,770)"/>
-    <wire from="(270,810)" to="(290,810)"/>
-    <wire from="(270,610)" to="(290,610)"/>
-    <wire from="(270,650)" to="(290,650)"/>
-    <wire from="(600,550)" to="(1080,550)"/>
-    <wire from="(460,440)" to="(480,440)"/>
-    <wire from="(950,360)" to="(980,360)"/>
-    <wire from="(820,710)" to="(850,710)"/>
-    <wire from="(820,750)" to="(850,750)"/>
-    <wire from="(900,430)" to="(930,430)"/>
-    <wire from="(230,700)" to="(240,700)"/>
-    <wire from="(200,710)" to="(210,710)"/>
-    <wire from="(920,470)" to="(930,470)"/>
-    <wire from="(820,730)" to="(830,730)"/>
-    <wire from="(890,720)" to="(900,720)"/>
-    <wire from="(710,420)" to="(720,420)"/>
-    <wire from="(710,460)" to="(720,460)"/>
-    <comp lib="0" loc="(480,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Branch"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(660,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
+    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(210,710)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(290,750)" name="Tunnel">
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(260,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscall"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp loc="(720,320)" name="Funct_Decoder"/>
-    <comp lib="1" loc="(930,340)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(230,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="2" loc="(950,130)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(260,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJAL"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(670,350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(240,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(430,670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(460,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(480,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegDst"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp loc="(240,600)" name="Opcode_Decoder"/>
-    <comp lib="0" loc="(800,720)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(480,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(440,730)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(290,610)" name="Tunnel">
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(290,790)" name="Tunnel">
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="0" loc="(430,730)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(780,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(240,370)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp loc="(460,640)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(290,690)" name="Tunnel">
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="0" loc="(240,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="1" loc="(890,720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate2" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(260,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ZeroExtend"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="6" loc="(840,609)" name="Text">
-      <a name="text" val="Exception Handler"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(460,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(290,810)" name="Tunnel">
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(480,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Jump"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(910,120)" name="Constant">
+    <comp lib="0" loc="(1920,910)" name="Constant">
+      <a name="facing" val="north"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(460,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
+    <comp lib="0" loc="(310,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(290,630)" name="Tunnel">
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(460,130)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="6" loc="(371,553)" name="Text">
-      <a name="text" val="OP Decoding Area"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(480,130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(480,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemRead"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(900,720)" name="Tunnel">
-      <a name="label" val="IsException"/>
-    </comp>
-    <comp lib="0" loc="(480,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(910,300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(240,130)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(260,210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(480,210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(980,460)" name="Tunnel">
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(860,460)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(290,650)" name="Tunnel">
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(460,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(480,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsException"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(250,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="0" loc="(260,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(910,200)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(290,670)" name="Tunnel">
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(800,350)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="3"/>
-      <a name="bit1" val="2"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="0" loc="(250,250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="0" loc="(900,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="6" loc="(353,93)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(690,450)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(980,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(880,460)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(700,350)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(260,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeq"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,690)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(260,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrc"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(980,210)" name="Tunnel">
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="0" loc="(460,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(250,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp loc="(770,430)" name="ALU_Decoder"/>
-    <comp lib="0" loc="(460,250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(260,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoReg"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(980,260)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(800,450)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="3"/>
-      <a name="bit1" val="2"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="1" loc="(970,460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate1" val="true"/>
-      <a name="negate2" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(290,710)" name="Tunnel">
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(290,730)" name="Tunnel">
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(980,130)" name="Tunnel">
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(260,130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(290,770)" name="Tunnel">
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="0" loc="(460,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsException"/>
-    </comp>
-    <comp lib="6" loc="(851,85)" name="Text">
-      <a name="text" val="ALU Decoding Area"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="2" loc="(950,260)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(480,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJR"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(950,360)" name="Multiplexer">
+    <comp lib="2" loc="(150,540)" name="Multiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="4"/>
+      <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(910,250)" name="Constant">
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(990,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
     </comp>
-    <comp lib="0" loc="(460,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRs"/>
+    <comp lib="3" loc="(1360,930)" name="Shifter">
+      <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(460,370)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJR"/>
+    <comp lib="2" loc="(1260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(200,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
+    <comp loc="(570,130)" name="IF/ID">
+      <a name="labelfont" val="Monaco bold 44"/>
     </comp>
-    <comp lib="0" loc="(500,710)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
+    <comp lib="6" loc="(1040,682)" name="Text">
+      <a name="text" val="WriteReg#"/>
     </comp>
-    <comp lib="2" loc="(950,210)" name="Multiplexer">
+    <comp lib="6" loc="(995,966)" name="Text">
+      <a name="text" val="Branch Addr"/>
+    </comp>
+    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(490,680)" name="Multiplexer">
+      <a name="facing" val="north"/>
       <a name="selloc" val="tr"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(440,670)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
+    <comp lib="0" loc="(180,1080)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(660,870)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="5" loc="(300,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(670,540)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1310,940)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(450,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="6" loc="(1033,862)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
+    </comp>
+    <comp loc="(1890,130)" name="MEM/WB"/>
+    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(350,550)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
       <a name="bit5" val="0"/>
-    </comp>
-  </circuit>
-  <circuit name="Funct_Decoder">
-    <a name="circuit" val="Funct_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="71" stroke="#000000" stroke-width="2" width="60" x="50" y="50"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="81" y="82">Funct</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="101">Decoder</text>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
-      <circ-port height="8" pin="40,140" width="8" x="46" y="76"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
-      <circ-port height="10" pin="390,240" width="10" x="105" y="65"/>
-      <circ-port height="8" pin="40,250" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="40,310" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="390,700" width="10" x="105" y="75"/>
-      <circ-port height="10" pin="390,1310" width="10" x="105" y="85"/>
-      <circ-port height="10" pin="390,1870" width="10" x="105" y="95"/>
-      <circ-port height="10" pin="390,2210" width="10" x="75" y="45"/>
-      <circ-port height="10" pin="390,2370" width="10" x="55" y="45"/>
-      <circ-port height="10" pin="390,2670" width="10" x="95" y="45"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
-    </appear>
-    <wire from="(160,700)" to="(160,830)"/>
-    <wire from="(100,640)" to="(100,770)"/>
-    <wire from="(200,910)" to="(260,910)"/>
-    <wire from="(230,870)" to="(230,880)"/>
-    <wire from="(220,1020)" to="(220,1030)"/>
-    <wire from="(60,2600)" to="(180,2600)"/>
-    <wire from="(60,2760)" to="(180,2760)"/>
-    <wire from="(60,590)" to="(240,590)"/>
-    <wire from="(210,770)" to="(260,770)"/>
-    <wire from="(60,1390)" to="(240,1390)"/>
-    <wire from="(230,2630)" to="(230,2650)"/>
-    <wire from="(230,2790)" to="(230,2810)"/>
-    <wire from="(240,240)" to="(240,260)"/>
-    <wire from="(230,1030)" to="(230,1050)"/>
-    <wire from="(60,1240)" to="(60,1390)"/>
-    <wire from="(290,2210)" to="(390,2210)"/>
-    <wire from="(290,2370)" to="(390,2370)"/>
-    <wire from="(240,1040)" to="(240,1070)"/>
-    <wire from="(240,720)" to="(240,750)"/>
-    <wire from="(80,1520)" to="(180,1520)"/>
-    <wire from="(230,170)" to="(260,170)"/>
-    <wire from="(230,650)" to="(260,650)"/>
-    <wire from="(140,2710)" to="(230,2710)"/>
-    <wire from="(290,70)" to="(320,70)"/>
-    <wire from="(310,250)" to="(340,250)"/>
-    <wire from="(230,1130)" to="(260,1130)"/>
-    <wire from="(230,1290)" to="(260,1290)"/>
-    <wire from="(230,1930)" to="(260,1930)"/>
-    <wire from="(230,2090)" to="(260,2090)"/>
-    <wire from="(240,1790)" to="(260,1790)"/>
-    <wire from="(200,2550)" to="(220,2550)"/>
-    <wire from="(310,2660)" to="(330,2660)"/>
-    <wire from="(160,830)" to="(160,940)"/>
-    <wire from="(160,1070)" to="(180,1070)"/>
-    <wire from="(210,480)" to="(230,480)"/>
-    <wire from="(210,800)" to="(230,800)"/>
-    <wire from="(100,2520)" to="(180,2520)"/>
-    <wire from="(160,2580)" to="(240,2580)"/>
-    <wire from="(100,770)" to="(100,890)"/>
-    <wire from="(120,2080)" to="(180,2080)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(40,310)" to="(160,310)"/>
-    <wire from="(60,240)" to="(240,240)"/>
-    <wire from="(60,720)" to="(240,720)"/>
-    <wire from="(120,2550)" to="(120,2690)"/>
-    <wire from="(140,2570)" to="(140,2710)"/>
-    <wire from="(240,850)" to="(240,870)"/>
-    <wire from="(140,2250)" to="(140,2400)"/>
-    <wire from="(160,2430)" to="(160,2580)"/>
-    <wire from="(230,520)" to="(230,540)"/>
-    <wire from="(220,2680)" to="(260,2680)"/>
-    <wire from="(220,2840)" to="(260,2840)"/>
-    <wire from="(230,780)" to="(260,780)"/>
-    <wire from="(100,2060)" to="(260,2060)"/>
-    <wire from="(140,440)" to="(230,440)"/>
-    <wire from="(360,2670)" to="(390,2670)"/>
-    <wire from="(240,2240)" to="(260,2240)"/>
-    <wire from="(240,1280)" to="(260,1280)"/>
-    <wire from="(240,1120)" to="(260,1120)"/>
-    <wire from="(240,1920)" to="(260,1920)"/>
-    <wire from="(240,2400)" to="(260,2400)"/>
-    <wire from="(240,2560)" to="(260,2560)"/>
-    <wire from="(320,720)" to="(340,720)"/>
-    <wire from="(290,1810)" to="(310,1810)"/>
-    <wire from="(240,530)" to="(240,570)"/>
-    <wire from="(240,160)" to="(260,160)"/>
-    <wire from="(240,320)" to="(260,320)"/>
-    <wire from="(320,510)" to="(320,680)"/>
-    <wire from="(210,610)" to="(230,610)"/>
-    <wire from="(200,1720)" to="(220,1720)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(100,1690)" to="(180,1690)"/>
-    <wire from="(160,1750)" to="(240,1750)"/>
-    <wire from="(120,1460)" to="(260,1460)"/>
-    <wire from="(310,1880)" to="(310,1940)"/>
-    <wire from="(120,1720)" to="(120,1840)"/>
-    <wire from="(140,1740)" to="(140,1870)"/>
-    <wire from="(60,1500)" to="(60,1630)"/>
-    <wire from="(120,2690)" to="(180,2690)"/>
-    <wire from="(120,2850)" to="(180,2850)"/>
-    <wire from="(140,800)" to="(190,800)"/>
-    <wire from="(60,850)" to="(240,850)"/>
-    <wire from="(80,1520)" to="(80,1660)"/>
-    <wire from="(230,2090)" to="(230,2100)"/>
-    <wire from="(60,2460)" to="(60,2600)"/>
-    <wire from="(240,2100)" to="(240,2120)"/>
-    <wire from="(100,1540)" to="(100,1690)"/>
-    <wire from="(160,1600)" to="(160,1750)"/>
-    <wire from="(230,650)" to="(230,670)"/>
-    <wire from="(230,970)" to="(230,990)"/>
-    <wire from="(140,2250)" to="(180,2250)"/>
-    <wire from="(200,2150)" to="(240,2150)"/>
-    <wire from="(200,2310)" to="(240,2310)"/>
-    <wire from="(230,270)" to="(260,270)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(210,570)" to="(240,570)"/>
-    <wire from="(200,1520)" to="(230,1520)"/>
-    <wire from="(100,2660)" to="(100,2820)"/>
-    <wire from="(120,1560)" to="(120,1720)"/>
-    <wire from="(140,1580)" to="(140,1740)"/>
-    <wire from="(140,1050)" to="(230,1050)"/>
-    <wire from="(100,1810)" to="(190,1810)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(230,2190)" to="(260,2190)"/>
-    <wire from="(230,2350)" to="(260,2350)"/>
-    <wire from="(230,2510)" to="(260,2510)"/>
-    <wire from="(140,1870)" to="(140,1970)"/>
-    <wire from="(240,930)" to="(260,930)"/>
-    <wire from="(240,1730)" to="(260,1730)"/>
-    <wire from="(320,1330)" to="(340,1330)"/>
-    <wire from="(290,1940)" to="(310,1940)"/>
-    <wire from="(240,660)" to="(240,700)"/>
-    <wire from="(310,250)" to="(310,290)"/>
-    <wire from="(210,740)" to="(230,740)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(60,1630)" to="(60,1760)"/>
-    <wire from="(120,420)" to="(180,420)"/>
-    <wire from="(200,180)" to="(260,180)"/>
-    <wire from="(200,1140)" to="(260,1140)"/>
-    <wire from="(200,1300)" to="(260,1300)"/>
-    <wire from="(140,1470)" to="(260,1470)"/>
-    <wire from="(120,190)" to="(120,200)"/>
-    <wire from="(310,2680)" to="(310,2830)"/>
-    <wire from="(230,780)" to="(230,800)"/>
-    <wire from="(240,950)" to="(240,980)"/>
-    <wire from="(220,1020)" to="(260,1020)"/>
-    <wire from="(200,2120)" to="(240,2120)"/>
-    <wire from="(200,2280)" to="(240,2280)"/>
-    <wire from="(200,2600)" to="(240,2600)"/>
-    <wire from="(200,2760)" to="(240,2760)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(80,1110)" to="(180,1110)"/>
-    <wire from="(80,1270)" to="(180,1270)"/>
-    <wire from="(100,400)" to="(260,400)"/>
-    <wire from="(210,700)" to="(240,700)"/>
-    <wire from="(230,880)" to="(260,880)"/>
-    <wire from="(100,1940)" to="(190,1940)"/>
-    <wire from="(230,1680)" to="(260,1680)"/>
-    <wire from="(240,2180)" to="(260,2180)"/>
-    <wire from="(240,2340)" to="(260,2340)"/>
-    <wire from="(240,2500)" to="(260,2500)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,790)" to="(240,830)"/>
-    <wire from="(160,340)" to="(180,340)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,260)" to="(260,260)"/>
-    <wire from="(320,1890)" to="(320,2070)"/>
-    <wire from="(120,540)" to="(190,540)"/>
-    <wire from="(80,1780)" to="(80,1910)"/>
-    <wire from="(120,540)" to="(120,670)"/>
-    <wire from="(60,1760)" to="(60,1890)"/>
-    <wire from="(120,1030)" to="(180,1030)"/>
-    <wire from="(230,430)" to="(230,440)"/>
-    <wire from="(240,440)" to="(240,450)"/>
-    <wire from="(60,950)" to="(240,950)"/>
-    <wire from="(100,1000)" to="(100,1140)"/>
-    <wire from="(320,260)" to="(320,410)"/>
-    <wire from="(320,1700)" to="(320,1850)"/>
-    <wire from="(200,2730)" to="(240,2730)"/>
-    <wire from="(80,2040)" to="(180,2040)"/>
-    <wire from="(160,1480)" to="(260,1480)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(210,830)" to="(240,830)"/>
-    <wire from="(230,1170)" to="(260,1170)"/>
-    <wire from="(230,1330)" to="(260,1330)"/>
-    <wire from="(290,1550)" to="(320,1550)"/>
-    <wire from="(240,870)" to="(260,870)"/>
-    <wire from="(240,1670)" to="(260,1670)"/>
-    <wire from="(240,1830)" to="(260,1830)"/>
-    <wire from="(100,140)" to="(100,180)"/>
-    <wire from="(310,190)" to="(310,230)"/>
-    <wire from="(240,1240)" to="(240,1280)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(80,150)" to="(80,260)"/>
-    <wire from="(100,1440)" to="(180,1440)"/>
-    <wire from="(120,670)" to="(190,670)"/>
-    <wire from="(160,450)" to="(160,700)"/>
-    <wire from="(200,2520)" to="(260,2520)"/>
-    <wire from="(80,1910)" to="(80,2040)"/>
-    <wire from="(140,1970)" to="(140,2100)"/>
-    <wire from="(60,1890)" to="(60,2020)"/>
-    <wire from="(200,1560)" to="(260,1560)"/>
-    <wire from="(80,1270)" to="(80,1410)"/>
-    <wire from="(230,1520)" to="(230,1530)"/>
-    <wire from="(320,70)" to="(320,220)"/>
-    <wire from="(60,1090)" to="(60,1240)"/>
-    <wire from="(80,2490)" to="(180,2490)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(230,500)" to="(260,500)"/>
-    <wire from="(200,1110)" to="(230,1110)"/>
-    <wire from="(200,1270)" to="(230,1270)"/>
-    <wire from="(80,1110)" to="(80,1270)"/>
-    <wire from="(140,320)" to="(230,320)"/>
-    <wire from="(310,1860)" to="(340,1860)"/>
-    <wire from="(240,1960)" to="(260,1960)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(310,640)" to="(310,690)"/>
-    <wire from="(160,1480)" to="(160,1600)"/>
-    <wire from="(60,2020)" to="(60,2150)"/>
-    <wire from="(200,1690)" to="(260,1690)"/>
-    <wire from="(220,1320)" to="(220,1330)"/>
-    <wire from="(290,1310)" to="(340,1310)"/>
-    <wire from="(230,1170)" to="(230,1180)"/>
-    <wire from="(80,2040)" to="(80,2180)"/>
-    <wire from="(100,2060)" to="(100,2200)"/>
-    <wire from="(120,2080)" to="(120,2220)"/>
-    <wire from="(230,1330)" to="(230,1350)"/>
-    <wire from="(240,1500)" to="(240,1520)"/>
-    <wire from="(310,1150)" to="(310,1300)"/>
-    <wire from="(140,2100)" to="(140,2250)"/>
-    <wire from="(160,2280)" to="(160,2430)"/>
-    <wire from="(240,1180)" to="(240,1210)"/>
-    <wire from="(240,1340)" to="(240,1370)"/>
-    <wire from="(200,1070)" to="(240,1070)"/>
-    <wire from="(80,380)" to="(180,380)"/>
-    <wire from="(80,1660)" to="(180,1660)"/>
-    <wire from="(230,310)" to="(260,310)"/>
-    <wire from="(230,630)" to="(260,630)"/>
-    <wire from="(160,2000)" to="(190,2000)"/>
-    <wire from="(160,2120)" to="(160,2280)"/>
-    <wire from="(140,930)" to="(230,930)"/>
-    <wire from="(310,230)" to="(340,230)"/>
-    <wire from="(290,1010)" to="(320,1010)"/>
-    <wire from="(230,1430)" to="(260,1430)"/>
-    <wire from="(200,2040)" to="(230,2040)"/>
-    <wire from="(230,2230)" to="(260,2230)"/>
-    <wire from="(230,2390)" to="(260,2390)"/>
-    <wire from="(230,2550)" to="(260,2550)"/>
-    <wire from="(310,710)" to="(340,710)"/>
-    <wire from="(200,2690)" to="(220,2690)"/>
-    <wire from="(200,2850)" to="(220,2850)"/>
-    <wire from="(320,1850)" to="(340,1850)"/>
-    <wire from="(240,2460)" to="(240,2500)"/>
-    <wire from="(240,490)" to="(260,490)"/>
-    <wire from="(160,1210)" to="(180,1210)"/>
-    <wire from="(160,1370)" to="(180,1370)"/>
-    <wire from="(100,2660)" to="(180,2660)"/>
-    <wire from="(100,2820)" to="(180,2820)"/>
-    <wire from="(120,670)" to="(120,910)"/>
-    <wire from="(120,300)" to="(180,300)"/>
-    <wire from="(120,2220)" to="(180,2220)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(60,1500)" to="(240,1500)"/>
-    <wire from="(80,2490)" to="(80,2630)"/>
-    <wire from="(230,1780)" to="(230,1800)"/>
-    <wire from="(80,1780)" to="(190,1780)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(60,2310)" to="(60,2460)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(100,280)" to="(260,280)"/>
-    <wire from="(230,760)" to="(260,760)"/>
-    <wire from="(230,920)" to="(260,920)"/>
-    <wire from="(60,2150)" to="(60,2310)"/>
-    <wire from="(100,2200)" to="(260,2200)"/>
-    <wire from="(100,2360)" to="(260,2360)"/>
-    <wire from="(120,2690)" to="(120,2850)"/>
-    <wire from="(60,360)" to="(60,460)"/>
-    <wire from="(80,380)" to="(80,480)"/>
-    <wire from="(230,1720)" to="(260,1720)"/>
-    <wire from="(200,2490)" to="(230,2490)"/>
-    <wire from="(310,1320)" to="(340,1320)"/>
-    <wire from="(320,220)" to="(340,220)"/>
-    <wire from="(290,190)" to="(310,190)"/>
-    <wire from="(290,1150)" to="(310,1150)"/>
-    <wire from="(240,1420)" to="(260,1420)"/>
-    <wire from="(240,1580)" to="(260,1580)"/>
-    <wire from="(240,2700)" to="(260,2700)"/>
-    <wire from="(240,2860)" to="(260,2860)"/>
-    <wire from="(140,2710)" to="(140,2880)"/>
-    <wire from="(370,1870)" to="(390,1870)"/>
-    <wire from="(240,1630)" to="(240,1670)"/>
-    <wire from="(240,620)" to="(260,620)"/>
-    <wire from="(100,400)" to="(100,510)"/>
-    <wire from="(160,450)" to="(240,450)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(160,2730)" to="(160,2910)"/>
-    <wire from="(80,1660)" to="(80,1780)"/>
-    <wire from="(120,420)" to="(120,540)"/>
-    <wire from="(140,440)" to="(140,570)"/>
-    <wire from="(160,940)" to="(160,1070)"/>
-    <wire from="(140,250)" to="(140,320)"/>
-    <wire from="(120,910)" to="(180,910)"/>
-    <wire from="(310,2530)" to="(310,2660)"/>
-    <wire from="(230,310)" to="(230,320)"/>
-    <wire from="(60,1240)" to="(180,1240)"/>
-    <wire from="(210,1810)" to="(260,1810)"/>
-    <wire from="(230,2390)" to="(230,2400)"/>
-    <wire from="(220,2540)" to="(220,2550)"/>
-    <wire from="(230,1270)" to="(230,1290)"/>
-    <wire from="(230,1110)" to="(230,1130)"/>
-    <wire from="(230,1910)" to="(230,1930)"/>
-    <wire from="(80,1910)" to="(190,1910)"/>
-    <wire from="(230,2230)" to="(230,2250)"/>
-    <wire from="(230,2550)" to="(230,2570)"/>
-    <wire from="(240,2560)" to="(240,2580)"/>
-    <wire from="(230,150)" to="(230,170)"/>
-    <wire from="(240,320)" to="(240,340)"/>
-    <wire from="(240,1760)" to="(240,1790)"/>
-    <wire from="(240,2400)" to="(240,2430)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(200,380)" to="(230,380)"/>
-    <wire from="(200,1180)" to="(230,1180)"/>
-    <wire from="(200,1660)" to="(230,1660)"/>
-    <wire from="(100,890)" to="(260,890)"/>
-    <wire from="(60,2600)" to="(60,2760)"/>
-    <wire from="(140,1350)" to="(230,1350)"/>
-    <wire from="(230,1530)" to="(260,1530)"/>
-    <wire from="(230,2650)" to="(260,2650)"/>
-    <wire from="(230,2810)" to="(260,2810)"/>
-    <wire from="(100,510)" to="(190,510)"/>
-    <wire from="(290,2070)" to="(320,2070)"/>
-    <wire from="(290,640)" to="(310,640)"/>
-    <wire from="(240,750)" to="(260,750)"/>
-    <wire from="(210,1840)" to="(230,1840)"/>
-    <wire from="(370,240)" to="(390,240)"/>
-    <wire from="(240,2240)" to="(240,2280)"/>
-    <wire from="(200,1030)" to="(220,1030)"/>
-    <wire from="(160,2430)" to="(180,2430)"/>
-    <wire from="(160,2910)" to="(180,2910)"/>
-    <wire from="(100,1000)" to="(180,1000)"/>
-    <wire from="(310,710)" to="(310,770)"/>
-    <wire from="(200,2080)" to="(260,2080)"/>
-    <wire from="(100,1810)" to="(100,1940)"/>
-    <wire from="(120,1030)" to="(120,1160)"/>
-    <wire from="(140,1050)" to="(140,1180)"/>
-    <wire from="(200,1440)" to="(260,1440)"/>
-    <wire from="(230,920)" to="(230,930)"/>
-    <wire from="(210,1940)" to="(260,1940)"/>
-    <wire from="(60,1760)" to="(240,1760)"/>
-    <wire from="(140,1870)" to="(190,1870)"/>
-    <wire from="(240,930)" to="(240,940)"/>
-    <wire from="(220,1710)" to="(220,1720)"/>
-    <wire from="(230,2040)" to="(230,2050)"/>
-    <wire from="(160,1070)" to="(160,1210)"/>
-    <wire from="(230,1720)" to="(230,1740)"/>
-    <wire from="(240,1730)" to="(240,1750)"/>
-    <wire from="(240,1090)" to="(240,1120)"/>
-    <wire from="(240,1890)" to="(240,1920)"/>
-    <wire from="(200,340)" to="(240,340)"/>
-    <wire from="(220,1320)" to="(260,1320)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(240,130)" to="(240,160)"/>
-    <wire from="(80,1410)" to="(180,1410)"/>
-    <wire from="(290,2670)" to="(330,2670)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(100,180)" to="(100,280)"/>
-    <wire from="(120,200)" to="(120,300)"/>
-    <wire from="(230,1820)" to="(260,1820)"/>
-    <wire from="(100,640)" to="(190,640)"/>
-    <wire from="(290,290)" to="(310,290)"/>
-    <wire from="(240,1520)" to="(260,1520)"/>
-    <wire from="(240,2640)" to="(260,2640)"/>
-    <wire from="(240,1040)" to="(260,1040)"/>
-    <wire from="(210,1970)" to="(230,1970)"/>
-    <wire from="(290,770)" to="(310,770)"/>
-    <wire from="(290,2530)" to="(310,2530)"/>
-    <wire from="(240,2800)" to="(260,2800)"/>
-    <wire from="(160,1600)" to="(180,1600)"/>
-    <wire from="(100,1940)" to="(100,2060)"/>
-    <wire from="(160,2000)" to="(160,2120)"/>
-    <wire from="(60,460)" to="(60,590)"/>
-    <wire from="(80,480)" to="(80,610)"/>
-    <wire from="(120,1330)" to="(180,1330)"/>
-    <wire from="(230,90)" to="(230,100)"/>
-    <wire from="(60,2460)" to="(180,2460)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(60,1090)" to="(240,1090)"/>
-    <wire from="(60,1890)" to="(240,1890)"/>
-    <wire from="(100,1300)" to="(100,1440)"/>
-    <wire from="(240,2020)" to="(240,2040)"/>
-    <wire from="(230,2490)" to="(230,2510)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(80,260)" to="(180,260)"/>
-    <wire from="(80,2180)" to="(180,2180)"/>
-    <wire from="(80,2340)" to="(180,2340)"/>
-    <wire from="(230,990)" to="(260,990)"/>
-    <wire from="(100,1140)" to="(100,1300)"/>
-    <wire from="(140,570)" to="(140,800)"/>
-    <wire from="(140,2570)" to="(230,2570)"/>
-    <wire from="(290,410)" to="(320,410)"/>
-    <wire from="(230,1950)" to="(260,1950)"/>
-    <wire from="(200,2400)" to="(230,2400)"/>
-    <wire from="(200,2880)" to="(230,2880)"/>
-    <wire from="(100,770)" to="(190,770)"/>
-    <wire from="(210,1780)" to="(230,1780)"/>
-    <wire from="(120,1160)" to="(120,1330)"/>
-    <wire from="(140,1180)" to="(140,1350)"/>
-    <wire from="(320,1890)" to="(340,1890)"/>
-    <wire from="(310,2680)" to="(330,2680)"/>
-    <wire from="(140,1470)" to="(140,1580)"/>
-    <wire from="(240,530)" to="(260,530)"/>
-    <wire from="(60,1390)" to="(60,1500)"/>
-    <wire from="(80,1410)" to="(80,1520)"/>
-    <wire from="(320,720)" to="(320,900)"/>
-    <wire from="(200,2660)" to="(260,2660)"/>
-    <wire from="(200,2820)" to="(260,2820)"/>
-    <wire from="(60,590)" to="(60,720)"/>
-    <wire from="(80,610)" to="(80,740)"/>
-    <wire from="(200,420)" to="(260,420)"/>
-    <wire from="(310,1320)" to="(310,1450)"/>
-    <wire from="(230,380)" to="(230,390)"/>
-    <wire from="(60,1630)" to="(180,1630)"/>
-    <wire from="(140,1970)" to="(190,1970)"/>
-    <wire from="(60,2020)" to="(240,2020)"/>
-    <wire from="(230,1660)" to="(230,1680)"/>
-    <wire from="(230,1820)" to="(230,1840)"/>
-    <wire from="(140,1180)" to="(180,1180)"/>
-    <wire from="(240,2150)" to="(240,2180)"/>
-    <wire from="(240,2310)" to="(240,2340)"/>
-    <wire from="(200,1240)" to="(240,1240)"/>
-    <wire from="(220,2540)" to="(260,2540)"/>
-    <wire from="(160,310)" to="(160,340)"/>
-    <wire from="(80,870)" to="(180,870)"/>
-    <wire from="(80,2630)" to="(180,2630)"/>
-    <wire from="(80,2790)" to="(180,2790)"/>
-    <wire from="(200,1410)" to="(230,1410)"/>
-    <wire from="(140,1580)" to="(230,1580)"/>
-    <wire from="(140,1740)" to="(230,1740)"/>
-    <wire from="(320,260)" to="(340,260)"/>
-    <wire from="(240,980)" to="(260,980)"/>
-    <wire from="(210,1910)" to="(230,1910)"/>
-    <wire from="(240,2100)" to="(260,2100)"/>
-    <wire from="(240,1830)" to="(240,1870)"/>
-    <wire from="(160,340)" to="(160,450)"/>
-    <wire from="(240,660)" to="(260,660)"/>
-    <wire from="(120,200)" to="(260,200)"/>
-    <wire from="(120,1160)" to="(260,1160)"/>
-    <wire from="(60,240)" to="(60,360)"/>
-    <wire from="(80,260)" to="(80,380)"/>
-    <wire from="(100,280)" to="(100,400)"/>
-    <wire from="(120,300)" to="(120,420)"/>
-    <wire from="(140,320)" to="(140,440)"/>
-    <wire from="(140,800)" to="(140,930)"/>
-    <wire from="(60,720)" to="(60,850)"/>
-    <wire from="(80,740)" to="(80,870)"/>
-    <wire from="(120,2550)" to="(180,2550)"/>
-    <wire from="(100,2520)" to="(100,2660)"/>
-    <wire from="(230,1950)" to="(230,1970)"/>
-    <wire from="(80,2340)" to="(80,2490)"/>
-    <wire from="(160,2580)" to="(160,2730)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(240,360)" to="(240,380)"/>
-    <wire from="(320,1330)" to="(320,1550)"/>
-    <wire from="(200,1210)" to="(240,1210)"/>
-    <wire from="(200,1370)" to="(240,1370)"/>
-    <wire from="(220,1710)" to="(260,1710)"/>
-    <wire from="(160,700)" to="(190,700)"/>
-    <wire from="(200,100)" to="(230,100)"/>
-    <wire from="(200,260)" to="(230,260)"/>
-    <wire from="(80,2180)" to="(80,2340)"/>
-    <wire from="(100,2200)" to="(100,2360)"/>
-    <wire from="(100,2360)" to="(100,2520)"/>
-    <wire from="(120,2220)" to="(120,2380)"/>
-    <wire from="(60,850)" to="(60,950)"/>
-    <wire from="(80,870)" to="(80,970)"/>
-    <wire from="(230,1570)" to="(260,1570)"/>
-    <wire from="(290,510)" to="(320,510)"/>
-    <wire from="(210,1870)" to="(240,1870)"/>
-    <wire from="(230,2050)" to="(260,2050)"/>
-    <wire from="(200,2180)" to="(230,2180)"/>
-    <wire from="(200,2340)" to="(230,2340)"/>
-    <wire from="(230,2690)" to="(260,2690)"/>
-    <wire from="(230,2850)" to="(260,2850)"/>
-    <wire from="(310,690)" to="(340,690)"/>
-    <wire from="(240,790)" to="(260,790)"/>
-    <wire from="(120,2380)" to="(120,2550)"/>
-    <wire from="(140,2400)" to="(140,2570)"/>
-    <wire from="(240,1960)" to="(240,2000)"/>
-    <wire from="(240,2600)" to="(240,2640)"/>
-    <wire from="(240,2760)" to="(240,2800)"/>
-    <wire from="(100,890)" to="(100,1000)"/>
-    <wire from="(160,940)" to="(240,940)"/>
-    <wire from="(100,1690)" to="(100,1810)"/>
-    <wire from="(120,910)" to="(120,1030)"/>
-    <wire from="(140,930)" to="(140,1050)"/>
-    <wire from="(120,1560)" to="(180,1560)"/>
-    <wire from="(120,1720)" to="(180,1720)"/>
-    <wire from="(200,1000)" to="(260,1000)"/>
-    <wire from="(140,210)" to="(260,210)"/>
-    <wire from="(60,360)" to="(240,360)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(80,480)" to="(190,480)"/>
-    <wire from="(230,480)" to="(230,500)"/>
-    <wire from="(140,2400)" to="(180,2400)"/>
-    <wire from="(140,2880)" to="(180,2880)"/>
-    <wire from="(200,2460)" to="(240,2460)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(320,1010)" to="(320,1290)"/>
-    <wire from="(80,970)" to="(180,970)"/>
-    <wire from="(160,830)" to="(190,830)"/>
-    <wire from="(200,870)" to="(230,870)"/>
-    <wire from="(100,1540)" to="(260,1540)"/>
-    <wire from="(80,2630)" to="(80,2790)"/>
-    <wire from="(210,2000)" to="(240,2000)"/>
-    <wire from="(200,2630)" to="(230,2630)"/>
-    <wire from="(200,2790)" to="(230,2790)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(310,1300)" to="(340,1300)"/>
-    <wire from="(240,2040)" to="(260,2040)"/>
-    <wire from="(320,680)" to="(340,680)"/>
-    <wire from="(290,1450)" to="(310,1450)"/>
-    <wire from="(140,100)" to="(140,210)"/>
-    <wire from="(240,440)" to="(260,440)"/>
-    <wire from="(160,2120)" to="(180,2120)"/>
-    <wire from="(160,2280)" to="(180,2280)"/>
-    <wire from="(120,80)" to="(120,190)"/>
-    <wire from="(120,2380)" to="(260,2380)"/>
-    <wire from="(120,1840)" to="(190,1840)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(210,510)" to="(260,510)"/>
-    <wire from="(230,1570)" to="(230,1580)"/>
-    <wire from="(220,2680)" to="(220,2690)"/>
-    <wire from="(220,2840)" to="(220,2850)"/>
-    <wire from="(230,1410)" to="(230,1430)"/>
-    <wire from="(240,1580)" to="(240,1600)"/>
-    <wire from="(230,2690)" to="(230,2710)"/>
-    <wire from="(80,610)" to="(190,610)"/>
-    <wire from="(230,610)" to="(230,630)"/>
-    <wire from="(240,2700)" to="(240,2730)"/>
-    <wire from="(230,2850)" to="(230,2880)"/>
-    <wire from="(200,1630)" to="(240,1630)"/>
-    <wire from="(200,2430)" to="(240,2430)"/>
-    <wire from="(200,2910)" to="(240,2910)"/>
-    <wire from="(240,460)" to="(240,490)"/>
-    <wire from="(160,220)" to="(260,220)"/>
-    <wire from="(230,390)" to="(260,390)"/>
-    <wire from="(230,1030)" to="(260,1030)"/>
-    <wire from="(370,700)" to="(390,700)"/>
-    <wire from="(320,1290)" to="(340,1290)"/>
-    <wire from="(160,1370)" to="(160,1480)"/>
-    <wire from="(210,540)" to="(230,540)"/>
-    <wire from="(200,1330)" to="(220,1330)"/>
-    <wire from="(160,2730)" to="(180,2730)"/>
-    <wire from="(100,180)" to="(180,180)"/>
-    <wire from="(100,1140)" to="(180,1140)"/>
-    <wire from="(100,1300)" to="(180,1300)"/>
-    <wire from="(310,1810)" to="(310,1860)"/>
-    <wire from="(240,2860)" to="(240,2910)"/>
-    <wire from="(160,1750)" to="(160,2000)"/>
-    <wire from="(140,1350)" to="(140,1470)"/>
-    <wire from="(200,2220)" to="(260,2220)"/>
-    <wire from="(120,1330)" to="(120,1460)"/>
-    <wire from="(100,510)" to="(100,640)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(200,300)" to="(260,300)"/>
-    <wire from="(230,260)" to="(230,270)"/>
-    <wire from="(60,2150)" to="(180,2150)"/>
-    <wire from="(60,2310)" to="(180,2310)"/>
-    <wire from="(140,570)" to="(190,570)"/>
-    <wire from="(60,460)" to="(240,460)"/>
-    <wire from="(210,640)" to="(260,640)"/>
-    <wire from="(60,950)" to="(60,1090)"/>
-    <wire from="(80,970)" to="(80,1110)"/>
-    <wire from="(230,2180)" to="(230,2190)"/>
-    <wire from="(230,2340)" to="(230,2350)"/>
-    <wire from="(80,740)" to="(190,740)"/>
-    <wire from="(230,740)" to="(230,760)"/>
-    <wire from="(160,220)" to="(160,310)"/>
-    <wire from="(140,100)" to="(180,100)"/>
-    <wire from="(240,1390)" to="(240,1420)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(240,590)" to="(240,620)"/>
-    <wire from="(230,520)" to="(260,520)"/>
-    <wire from="(200,970)" to="(230,970)"/>
-    <wire from="(160,1210)" to="(160,1370)"/>
-    <wire from="(140,2100)" to="(230,2100)"/>
-    <wire from="(290,900)" to="(320,900)"/>
-    <wire from="(230,1800)" to="(260,1800)"/>
-    <wire from="(200,2250)" to="(230,2250)"/>
-    <wire from="(100,1440)" to="(100,1540)"/>
-    <wire from="(120,1460)" to="(120,1560)"/>
-    <wire from="(290,1700)" to="(320,1700)"/>
-    <wire from="(310,1880)" to="(340,1880)"/>
-    <wire from="(240,1180)" to="(260,1180)"/>
-    <wire from="(240,1340)" to="(260,1340)"/>
-    <wire from="(290,2830)" to="(310,2830)"/>
-    <wire from="(370,1310)" to="(390,1310)"/>
-    <wire from="(240,380)" to="(260,380)"/>
-    <wire from="(210,670)" to="(230,670)"/>
-    <wire from="(120,1840)" to="(120,2080)"/>
-    <wire from="(120,80)" to="(260,80)"/>
-    <comp lib="1" loc="(370,240)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(200,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2370)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(370,700)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(210,1970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,2210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJR"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,610)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,1870)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="0" loc="(390,1870)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(360,2670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(290,900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,640)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,1310)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1010)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,770)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,190)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1810)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(390,2370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscall"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,2210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,1910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2070)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(370,1310)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(210,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1940)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(210,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,2670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,510)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,290)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2080)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-  </circuit>
-  <circuit name="ALU_Decoder">
-    <a name="circuit" val="ALU_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="66" stroke="#000000" stroke-width="2" width="60" x="50" y="55"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="88">ALU</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="104">Decoder</text>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
-      <circ-port height="8" pin="40,130" width="8" x="46" y="76"/>
-      <circ-port height="10" pin="430,140" width="10" x="105" y="65"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
-      <circ-port height="8" pin="40,240" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="40,300" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="430,1130" width="10" x="105" y="75"/>
-      <circ-port height="10" pin="430,2190" width="10" x="105" y="85"/>
-      <circ-port height="10" pin="430,3270" width="10" x="105" y="95"/>
-      <circ-anchor facing="east" height="6" width="6" x="97" y="67"/>
-    </appear>
-    <wire from="(310,1140)" to="(310,1210)"/>
-    <wire from="(200,910)" to="(260,910)"/>
-    <wire from="(120,3710)" to="(180,3710)"/>
-    <wire from="(230,230)" to="(230,240)"/>
-    <wire from="(60,3960)" to="(60,4100)"/>
-    <wire from="(240,2800)" to="(240,2820)"/>
-    <wire from="(240,240)" to="(240,260)"/>
-    <wire from="(230,550)" to="(230,570)"/>
-    <wire from="(200,290)" to="(240,290)"/>
-    <wire from="(200,1570)" to="(240,1570)"/>
-    <wire from="(140,2150)" to="(180,2150)"/>
-    <wire from="(140,2470)" to="(180,2470)"/>
-    <wire from="(200,2210)" to="(240,2210)"/>
-    <wire from="(200,2530)" to="(240,2530)"/>
-    <wire from="(80,880)" to="(180,880)"/>
-    <wire from="(340,3310)" to="(380,3310)"/>
-    <wire from="(60,3640)" to="(60,3800)"/>
-    <wire from="(230,1930)" to="(260,1930)"/>
-    <wire from="(230,2250)" to="(260,2250)"/>
-    <wire from="(230,2570)" to="(260,2570)"/>
-    <wire from="(230,3850)" to="(260,3850)"/>
-    <wire from="(230,4170)" to="(260,4170)"/>
-    <wire from="(290,80)" to="(310,80)"/>
-    <wire from="(80,1920)" to="(230,1920)"/>
-    <wire from="(160,3470)" to="(180,3470)"/>
-    <wire from="(240,560)" to="(240,600)"/>
-    <wire from="(80,2380)" to="(80,2560)"/>
-    <wire from="(310,1140)" to="(380,1140)"/>
-    <wire from="(60,3210)" to="(180,3210)"/>
-    <wire from="(290,2740)" to="(340,2740)"/>
-    <wire from="(230,3240)" to="(230,3250)"/>
-    <wire from="(200,2660)" to="(240,2660)"/>
-    <wire from="(140,4200)" to="(180,4200)"/>
-    <wire from="(80,50)" to="(180,50)"/>
-    <wire from="(80,1330)" to="(180,1330)"/>
-    <wire from="(200,110)" to="(230,110)"/>
-    <wire from="(100,780)" to="(260,780)"/>
-    <wire from="(80,80)" to="(80,180)"/>
-    <wire from="(290,210)" to="(310,210)"/>
-    <wire from="(240,4000)" to="(260,4000)"/>
-    <wire from="(160,2320)" to="(180,2320)"/>
-    <wire from="(100,1050)" to="(180,1050)"/>
-    <wire from="(100,2970)" to="(180,2970)"/>
-    <wire from="(160,3030)" to="(240,3030)"/>
-    <wire from="(230,810)" to="(230,820)"/>
-    <wire from="(60,2060)" to="(180,2060)"/>
-    <wire from="(240,820)" to="(240,830)"/>
-    <wire from="(230,2090)" to="(230,2100)"/>
-    <wire from="(160,1120)" to="(160,1270)"/>
-    <wire from="(320,1150)" to="(320,1360)"/>
-    <wire from="(80,180)" to="(180,180)"/>
-    <wire from="(80,500)" to="(180,500)"/>
-    <wire from="(200,880)" to="(230,880)"/>
-    <wire from="(350,530)" to="(350,1080)"/>
-    <wire from="(140,3450)" to="(230,3450)"/>
-    <wire from="(230,1230)" to="(260,1230)"/>
-    <wire from="(230,2830)" to="(260,2830)"/>
-    <wire from="(200,1850)" to="(220,1850)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(120,1850)" to="(120,1970)"/>
-    <wire from="(200,1940)" to="(260,1940)"/>
-    <wire from="(200,3860)" to="(260,3860)"/>
-    <wire from="(140,1870)" to="(140,2000)"/>
-    <wire from="(230,940)" to="(230,950)"/>
-    <wire from="(240,950)" to="(240,970)"/>
-    <wire from="(100,3110)" to="(100,3260)"/>
-    <wire from="(120,3130)" to="(120,3280)"/>
-    <wire from="(140,3150)" to="(140,3300)"/>
-    <wire from="(60,1150)" to="(60,1300)"/>
-    <wire from="(80,3830)" to="(180,3830)"/>
-    <wire from="(120,190)" to="(120,220)"/>
-    <wire from="(200,50)" to="(230,50)"/>
-    <wire from="(200,1330)" to="(230,1330)"/>
-    <wire from="(160,1570)" to="(160,1730)"/>
-    <wire from="(140,2300)" to="(230,2300)"/>
-    <wire from="(230,1040)" to="(260,1040)"/>
-    <wire from="(230,2960)" to="(260,2960)"/>
-    <wire from="(120,700)" to="(120,800)"/>
-    <wire from="(140,720)" to="(140,820)"/>
-    <wire from="(240,1700)" to="(260,1700)"/>
-    <wire from="(240,3300)" to="(260,3300)"/>
-    <wire from="(200,380)" to="(220,380)"/>
-    <wire from="(200,700)" to="(220,700)"/>
-    <wire from="(100,350)" to="(180,350)"/>
-    <wire from="(100,670)" to="(180,670)"/>
-    <wire from="(160,730)" to="(240,730)"/>
-    <wire from="(160,2660)" to="(160,2790)"/>
-    <wire from="(140,3600)" to="(140,3740)"/>
-    <wire from="(330,1160)" to="(330,1500)"/>
-    <wire from="(160,3620)" to="(160,3770)"/>
-    <wire from="(140,2000)" to="(140,2150)"/>
-    <wire from="(140,110)" to="(180,110)"/>
-    <wire from="(240,2680)" to="(240,2710)"/>
-    <wire from="(240,3640)" to="(240,3670)"/>
-    <wire from="(220,2430)" to="(260,2430)"/>
-    <wire from="(220,2750)" to="(260,2750)"/>
-    <wire from="(200,3050)" to="(240,3050)"/>
-    <wire from="(80,760)" to="(180,760)"/>
-    <wire from="(200,180)" to="(230,180)"/>
-    <wire from="(200,500)" to="(230,500)"/>
-    <wire from="(60,1600)" to="(60,1760)"/>
-    <wire from="(100,1490)" to="(260,1490)"/>
-    <wire from="(120,380)" to="(120,540)"/>
-    <wire from="(100,3410)" to="(260,3410)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(230,4050)" to="(260,4050)"/>
-    <wire from="(160,2790)" to="(160,2890)"/>
-    <wire from="(240,2150)" to="(260,2150)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(100,2730)" to="(100,2840)"/>
-    <wire from="(240,3960)" to="(240,4000)"/>
-    <wire from="(120,3130)" to="(260,3130)"/>
-    <wire from="(310,3260)" to="(380,3260)"/>
-    <wire from="(290,360)" to="(360,360)"/>
-    <wire from="(80,3990)" to="(80,4120)"/>
-    <wire from="(120,2440)" to="(180,2440)"/>
-    <wire from="(120,2760)" to="(180,2760)"/>
-    <wire from="(330,3300)" to="(380,3300)"/>
-    <wire from="(60,850)" to="(180,850)"/>
-    <wire from="(230,3440)" to="(230,3450)"/>
-    <wire from="(230,1520)" to="(230,1540)"/>
-    <wire from="(240,3450)" to="(240,3470)"/>
-    <wire from="(230,880)" to="(230,900)"/>
-    <wire from="(200,1900)" to="(240,1900)"/>
-    <wire from="(200,3180)" to="(240,3180)"/>
-    <wire from="(200,3500)" to="(240,3500)"/>
-    <wire from="(220,4160)" to="(260,4160)"/>
-    <wire from="(230,340)" to="(260,340)"/>
-    <wire from="(200,950)" to="(230,950)"/>
-    <wire from="(230,660)" to="(260,660)"/>
-    <wire from="(100,2260)" to="(260,2260)"/>
-    <wire from="(100,2580)" to="(260,2580)"/>
-    <wire from="(80,3670)" to="(80,3830)"/>
-    <wire from="(140,2880)" to="(230,2880)"/>
-    <wire from="(200,3830)" to="(230,3830)"/>
-    <wire from="(290,1360)" to="(320,1360)"/>
-    <wire from="(230,3540)" to="(260,3540)"/>
-    <wire from="(240,1640)" to="(260,1640)"/>
-    <wire from="(100,2410)" to="(100,2580)"/>
-    <wire from="(240,3240)" to="(260,3240)"/>
-    <wire from="(100,3690)" to="(100,3860)"/>
-    <wire from="(240,1530)" to="(240,1570)"/>
-    <wire from="(160,600)" to="(180,600)"/>
-    <wire from="(120,3710)" to="(120,3890)"/>
-    <wire from="(200,2970)" to="(260,2970)"/>
-    <wire from="(200,1050)" to="(260,1050)"/>
-    <wire from="(200,1370)" to="(260,1370)"/>
-    <wire from="(120,4170)" to="(180,4170)"/>
-    <wire from="(60,20)" to="(180,20)"/>
-    <wire from="(230,50)" to="(230,60)"/>
-    <wire from="(60,1300)" to="(180,1300)"/>
-    <wire from="(230,1330)" to="(230,1340)"/>
-    <wire from="(220,1960)" to="(220,1970)"/>
-    <wire from="(230,2290)" to="(230,2300)"/>
-    <wire from="(220,3880)" to="(220,3890)"/>
-    <wire from="(240,2300)" to="(240,2320)"/>
-    <wire from="(230,2610)" to="(230,2630)"/>
-    <wire from="(230,3890)" to="(230,3910)"/>
-    <wire from="(230,1970)" to="(230,2000)"/>
-    <wire from="(240,3900)" to="(240,3930)"/>
-    <wire from="(200,2030)" to="(240,2030)"/>
-    <wire from="(200,2350)" to="(240,2350)"/>
-    <wire from="(80,1020)" to="(180,1020)"/>
-    <wire from="(80,2940)" to="(180,2940)"/>
-    <wire from="(200,760)" to="(230,760)"/>
-    <wire from="(200,1400)" to="(230,1400)"/>
-    <wire from="(240,2090)" to="(260,2090)"/>
-    <wire from="(160,3930)" to="(180,3930)"/>
-    <wire from="(290,3420)" to="(310,3420)"/>
-    <wire from="(240,2620)" to="(240,2660)"/>
-    <wire from="(340,1170)" to="(340,1670)"/>
-    <wire from="(240,1980)" to="(240,2030)"/>
-    <wire from="(200,220)" to="(260,220)"/>
-    <wire from="(200,540)" to="(260,540)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(330,3240)" to="(380,3240)"/>
-    <wire from="(60,150)" to="(180,150)"/>
-    <wire from="(230,180)" to="(230,190)"/>
-    <wire from="(60,470)" to="(180,470)"/>
-    <wire from="(230,500)" to="(230,510)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(240,1150)" to="(240,1180)"/>
-    <wire from="(80,1470)" to="(180,1470)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(80,3390)" to="(180,3390)"/>
-    <wire from="(200,570)" to="(230,570)"/>
-    <wire from="(100,2840)" to="(260,2840)"/>
-    <wire from="(290,2270)" to="(310,2270)"/>
-    <wire from="(100,3110)" to="(180,3110)"/>
-    <wire from="(320,1110)" to="(380,1110)"/>
-    <wire from="(200,350)" to="(260,350)"/>
-    <wire from="(200,670)" to="(260,670)"/>
-    <wire from="(60,3800)" to="(180,3800)"/>
-    <wire from="(230,2870)" to="(230,2880)"/>
-    <wire from="(160,300)" to="(160,440)"/>
-    <wire from="(240,2880)" to="(240,2890)"/>
-    <wire from="(230,3830)" to="(230,3850)"/>
-    <wire from="(100,1200)" to="(100,1350)"/>
-    <wire from="(120,1220)" to="(120,1370)"/>
-    <wire from="(160,3180)" to="(160,3330)"/>
-    <wire from="(80,1180)" to="(80,1330)"/>
-    <wire from="(140,950)" to="(180,950)"/>
-    <wire from="(80,320)" to="(180,320)"/>
-    <wire from="(80,640)" to="(180,640)"/>
-    <wire from="(80,2240)" to="(180,2240)"/>
-    <wire from="(80,2560)" to="(180,2560)"/>
-    <wire from="(200,1020)" to="(230,1020)"/>
-    <wire from="(140,3910)" to="(230,3910)"/>
-    <wire from="(140,1240)" to="(140,1400)"/>
-    <wire from="(230,1690)" to="(260,1690)"/>
-    <wire from="(200,2940)" to="(230,2940)"/>
-    <wire from="(230,3290)" to="(260,3290)"/>
-    <wire from="(240,1390)" to="(260,1390)"/>
-    <wire from="(360,1190)" to="(380,1190)"/>
-    <wire from="(240,1600)" to="(240,1640)"/>
-    <wire from="(240,110)" to="(260,110)"/>
-    <wire from="(160,3620)" to="(240,3620)"/>
-    <wire from="(200,800)" to="(260,800)"/>
-    <wire from="(230,760)" to="(230,770)"/>
-    <wire from="(230,1080)" to="(230,1090)"/>
-    <wire from="(230,3000)" to="(230,3010)"/>
-    <wire from="(350,1180)" to="(350,1830)"/>
-    <wire from="(240,3010)" to="(240,3030)"/>
-    <wire from="(60,3210)" to="(60,3360)"/>
-    <wire from="(160,2030)" to="(160,2180)"/>
-    <wire from="(240,1090)" to="(240,1120)"/>
-    <wire from="(140,1400)" to="(180,1400)"/>
-    <wire from="(220,4040)" to="(260,4040)"/>
-    <wire from="(200,1470)" to="(230,1470)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(80,1630)" to="(80,1790)"/>
-    <wire from="(140,410)" to="(140,570)"/>
-    <wire from="(350,3220)" to="(380,3220)"/>
-    <wire from="(290,920)" to="(320,920)"/>
-    <wire from="(230,2140)" to="(260,2140)"/>
-    <wire from="(200,3390)" to="(230,3390)"/>
-    <wire from="(230,3100)" to="(260,3100)"/>
-    <wire from="(120,2760)" to="(120,2860)"/>
-    <wire from="(140,2780)" to="(140,2880)"/>
-    <wire from="(200,2440)" to="(220,2440)"/>
-    <wire from="(200,2760)" to="(220,2760)"/>
-    <wire from="(160,1120)" to="(180,1120)"/>
-    <wire from="(240,240)" to="(260,240)"/>
-    <wire from="(240,560)" to="(260,560)"/>
-    <wire from="(350,2590)" to="(350,3220)"/>
-    <wire from="(100,2410)" to="(180,2410)"/>
-    <wire from="(100,2730)" to="(180,2730)"/>
-    <wire from="(160,2790)" to="(240,2790)"/>
-    <wire from="(120,1220)" to="(260,1220)"/>
-    <wire from="(310,2120)" to="(310,2180)"/>
-    <wire from="(100,4020)" to="(100,4140)"/>
-    <wire from="(320,3290)" to="(380,3290)"/>
-    <wire from="(40,130)" to="(100,130)"/>
-    <wire from="(120,4050)" to="(180,4050)"/>
-    <wire from="(290,1670)" to="(340,1670)"/>
-    <wire from="(220,1840)" to="(220,1850)"/>
-    <wire from="(230,1850)" to="(230,1870)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(240,4100)" to="(240,4120)"/>
-    <wire from="(160,4080)" to="(160,4230)"/>
-    <wire from="(60,2060)" to="(60,2210)"/>
-    <wire from="(140,570)" to="(180,570)"/>
-    <wire from="(200,1270)" to="(240,1270)"/>
-    <wire from="(340,1090)" to="(380,1090)"/>
-    <wire from="(80,2820)" to="(180,2820)"/>
-    <wire from="(200,320)" to="(230,320)"/>
-    <wire from="(200,640)" to="(230,640)"/>
-    <wire from="(100,3550)" to="(260,3550)"/>
-    <wire from="(120,2440)" to="(120,2600)"/>
-    <wire from="(200,2240)" to="(230,2240)"/>
-    <wire from="(200,2560)" to="(230,2560)"/>
-    <wire from="(290,1060)" to="(310,1060)"/>
-    <wire from="(240,1330)" to="(260,1330)"/>
-    <wire from="(200,4170)" to="(220,4170)"/>
-    <wire from="(140,3740)" to="(140,3910)"/>
-    <wire from="(240,50)" to="(260,50)"/>
-    <wire from="(160,1570)" to="(180,1570)"/>
-    <wire from="(330,790)" to="(330,1100)"/>
-    <wire from="(100,4140)" to="(180,4140)"/>
-    <wire from="(360,1190)" to="(360,1950)"/>
-    <wire from="(290,2420)" to="(360,2420)"/>
-    <wire from="(290,4030)" to="(350,4030)"/>
-    <wire from="(360,360)" to="(360,1070)"/>
-    <wire from="(220,370)" to="(220,380)"/>
-    <wire from="(220,690)" to="(220,700)"/>
-    <wire from="(60,990)" to="(180,990)"/>
-    <wire from="(60,2910)" to="(180,2910)"/>
-    <wire from="(60,740)" to="(240,740)"/>
-    <wire from="(230,2940)" to="(230,2960)"/>
-    <wire from="(230,3580)" to="(230,3600)"/>
-    <wire from="(230,700)" to="(230,720)"/>
-    <wire from="(240,710)" to="(240,730)"/>
-    <wire from="(230,1020)" to="(230,1040)"/>
-    <wire from="(200,440)" to="(240,440)"/>
-    <wire from="(240,3590)" to="(240,3620)"/>
-    <wire from="(200,3640)" to="(240,3640)"/>
-    <wire from="(200,3960)" to="(240,3960)"/>
-    <wire from="(230,380)" to="(230,410)"/>
-    <wire from="(200,1090)" to="(230,1090)"/>
-    <wire from="(230,2400)" to="(260,2400)"/>
-    <wire from="(230,2720)" to="(260,2720)"/>
-    <wire from="(200,3010)" to="(230,3010)"/>
-    <wire from="(230,3680)" to="(260,3680)"/>
-    <wire from="(240,820)" to="(260,820)"/>
-    <wire from="(240,180)" to="(260,180)"/>
-    <wire from="(240,500)" to="(260,500)"/>
-    <wire from="(160,2660)" to="(180,2660)"/>
-    <wire from="(240,390)" to="(240,440)"/>
-    <wire from="(290,4150)" to="(360,4150)"/>
-    <wire from="(200,3110)" to="(260,3110)"/>
-    <wire from="(200,3430)" to="(260,3430)"/>
-    <wire from="(200,1510)" to="(260,1510)"/>
-    <wire from="(60,1440)" to="(180,1440)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(60,3360)" to="(180,3360)"/>
-    <wire from="(60,20)" to="(60,30)"/>
-    <wire from="(230,1470)" to="(230,1480)"/>
-    <wire from="(230,3390)" to="(230,3400)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(200,3770)" to="(240,3770)"/>
-    <wire from="(80,3080)" to="(180,3080)"/>
-    <wire from="(200,1540)" to="(230,1540)"/>
-    <wire from="(140,1870)" to="(230,1870)"/>
-    <wire from="(200,2820)" to="(230,2820)"/>
-    <wire from="(230,4130)" to="(260,4130)"/>
-    <wire from="(240,950)" to="(260,950)"/>
-    <wire from="(360,1070)" to="(380,1070)"/>
-    <wire from="(80,4120)" to="(230,4120)"/>
-    <wire from="(200,2280)" to="(260,2280)"/>
-    <wire from="(200,2600)" to="(260,2600)"/>
-    <wire from="(60,290)" to="(180,290)"/>
-    <wire from="(60,2210)" to="(180,2210)"/>
-    <wire from="(60,2530)" to="(180,2530)"/>
-    <wire from="(60,850)" to="(60,990)"/>
-    <wire from="(230,1920)" to="(230,1930)"/>
-    <wire from="(230,2240)" to="(230,2250)"/>
-    <wire from="(230,2560)" to="(230,2570)"/>
-    <wire from="(160,1270)" to="(160,1420)"/>
-    <wire from="(230,320)" to="(230,340)"/>
-    <wire from="(230,640)" to="(230,660)"/>
-    <wire from="(240,3210)" to="(240,3240)"/>
-    <wire from="(290,790)" to="(330,790)"/>
-    <wire from="(220,1680)" to="(260,1680)"/>
-    <wire from="(80,3530)" to="(180,3530)"/>
-    <wire from="(230,100)" to="(260,100)"/>
-    <wire from="(140,720)" to="(230,720)"/>
-    <wire from="(230,1380)" to="(260,1380)"/>
-    <wire from="(200,2630)" to="(230,2630)"/>
-    <wire from="(350,1180)" to="(380,1180)"/>
-    <wire from="(240,760)" to="(260,760)"/>
-    <wire from="(310,80)" to="(310,130)"/>
-    <wire from="(200,2410)" to="(260,2410)"/>
-    <wire from="(200,2730)" to="(260,2730)"/>
-    <wire from="(120,1370)" to="(180,1370)"/>
-    <wire from="(120,1690)" to="(180,1690)"/>
-    <wire from="(60,1300)" to="(60,1440)"/>
-    <wire from="(80,3240)" to="(80,3390)"/>
-    <wire from="(100,3260)" to="(100,3410)"/>
-    <wire from="(120,3280)" to="(120,3430)"/>
-    <wire from="(140,3300)" to="(140,3450)"/>
-    <wire from="(140,1090)" to="(180,1090)"/>
-    <wire from="(240,2060)" to="(240,2090)"/>
-    <wire from="(200,1150)" to="(240,1150)"/>
-    <wire from="(140,3010)" to="(180,3010)"/>
-    <wire from="(80,2380)" to="(180,2380)"/>
-    <wire from="(80,2700)" to="(180,2700)"/>
-    <wire from="(230,230)" to="(260,230)"/>
-    <wire from="(230,550)" to="(260,550)"/>
-    <wire from="(100,1660)" to="(100,1820)"/>
-    <wire from="(160,440)" to="(160,600)"/>
-    <wire from="(230,1190)" to="(260,1190)"/>
-    <wire from="(200,3080)" to="(230,3080)"/>
-    <wire from="(240,890)" to="(260,890)"/>
-    <wire from="(240,1530)" to="(260,1530)"/>
-    <wire from="(240,3450)" to="(260,3450)"/>
-    <wire from="(200,4050)" to="(220,4050)"/>
-    <wire from="(100,4020)" to="(180,4020)"/>
-    <wire from="(160,4080)" to="(240,4080)"/>
-    <wire from="(320,920)" to="(320,1110)"/>
-    <wire from="(120,4050)" to="(120,4170)"/>
-    <wire from="(310,3280)" to="(380,3280)"/>
-    <wire from="(200,2860)" to="(260,2860)"/>
-    <wire from="(200,4140)" to="(260,4140)"/>
-    <wire from="(120,220)" to="(180,220)"/>
-    <wire from="(120,540)" to="(180,540)"/>
-    <wire from="(140,4070)" to="(140,4200)"/>
-    <wire from="(310,3280)" to="(310,3420)"/>
-    <wire from="(60,150)" to="(60,290)"/>
-    <wire from="(60,620)" to="(240,620)"/>
-    <wire from="(230,2820)" to="(230,2830)"/>
-    <wire from="(230,3140)" to="(230,3150)"/>
-    <wire from="(80,2090)" to="(80,2240)"/>
-    <wire from="(100,2110)" to="(100,2260)"/>
-    <wire from="(120,2130)" to="(120,2280)"/>
-    <wire from="(140,2150)" to="(140,2300)"/>
-    <wire from="(60,470)" to="(60,620)"/>
-    <wire from="(140,1540)" to="(180,1540)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(240,3150)" to="(240,3180)"/>
-    <wire from="(140,2470)" to="(140,2630)"/>
-    <wire from="(160,3770)" to="(160,3930)"/>
-    <wire from="(200,3530)" to="(230,3530)"/>
-    <wire from="(290,2980)" to="(320,2980)"/>
-    <wire from="(310,130)" to="(330,130)"/>
-    <wire from="(240,1980)" to="(260,1980)"/>
-    <wire from="(240,2300)" to="(260,2300)"/>
-    <wire from="(240,2620)" to="(260,2620)"/>
-    <wire from="(240,3900)" to="(260,3900)"/>
-    <wire from="(160,3180)" to="(180,3180)"/>
-    <wire from="(120,3280)" to="(260,3280)"/>
-    <wire from="(100,130)" to="(100,200)"/>
-    <wire from="(200,1730)" to="(240,1730)"/>
-    <wire from="(140,2630)" to="(180,2630)"/>
-    <wire from="(200,3330)" to="(240,3330)"/>
-    <wire from="(290,1500)" to="(330,1500)"/>
-    <wire from="(340,680)" to="(340,1090)"/>
-    <wire from="(230,810)" to="(260,810)"/>
-    <wire from="(60,3800)" to="(60,3960)"/>
-    <wire from="(100,3690)" to="(260,3690)"/>
-    <wire from="(200,2380)" to="(230,2380)"/>
-    <wire from="(200,2700)" to="(230,2700)"/>
-    <wire from="(230,4010)" to="(260,4010)"/>
-    <wire from="(240,1470)" to="(260,1470)"/>
-    <wire from="(310,2180)" to="(330,2180)"/>
-    <wire from="(290,3120)" to="(310,3120)"/>
-    <wire from="(240,3390)" to="(260,3390)"/>
-    <wire from="(160,2030)" to="(180,2030)"/>
-    <wire from="(120,2130)" to="(260,2130)"/>
-    <wire from="(310,150)" to="(310,210)"/>
-    <wire from="(120,800)" to="(180,800)"/>
-    <wire from="(320,3290)" to="(320,3560)"/>
-    <wire from="(60,3050)" to="(180,3050)"/>
-    <wire from="(220,2430)" to="(220,2440)"/>
-    <wire from="(220,2750)" to="(220,2760)"/>
-    <wire from="(60,2800)" to="(240,2800)"/>
-    <wire from="(160,830)" to="(160,970)"/>
-    <wire from="(230,2760)" to="(230,2780)"/>
-    <wire from="(240,2770)" to="(240,2790)"/>
-    <wire from="(230,3080)" to="(230,3100)"/>
-    <wire from="(230,3720)" to="(230,3740)"/>
-    <wire from="(230,2440)" to="(230,2470)"/>
-    <wire from="(200,260)" to="(240,260)"/>
-    <wire from="(200,2180)" to="(240,2180)"/>
-    <wire from="(200,2500)" to="(240,2500)"/>
-    <wire from="(200,4100)" to="(240,4100)"/>
-    <wire from="(80,50)" to="(80,80)"/>
-    <wire from="(230,940)" to="(260,940)"/>
-    <wire from="(290,3560)" to="(320,3560)"/>
-    <wire from="(200,3150)" to="(230,3150)"/>
-    <wire from="(240,1920)" to="(260,1920)"/>
-    <wire from="(240,2240)" to="(260,2240)"/>
-    <wire from="(240,2560)" to="(260,2560)"/>
-    <wire from="(240,2880)" to="(260,2880)"/>
-    <wire from="(240,3840)" to="(260,3840)"/>
-    <wire from="(410,1130)" to="(430,1130)"/>
-    <wire from="(240,850)" to="(240,890)"/>
-    <wire from="(240,3730)" to="(240,3770)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(240,2450)" to="(240,2500)"/>
-    <wire from="(100,70)" to="(100,130)"/>
-    <wire from="(330,2850)" to="(330,3240)"/>
-    <wire from="(200,3570)" to="(260,3570)"/>
-    <wire from="(310,2200)" to="(310,2270)"/>
-    <wire from="(60,1900)" to="(180,1900)"/>
-    <wire from="(60,3500)" to="(180,3500)"/>
-    <wire from="(80,880)" to="(80,1020)"/>
-    <wire from="(230,3530)" to="(230,3540)"/>
-    <wire from="(220,4160)" to="(220,4170)"/>
-    <wire from="(360,2420)" to="(360,3210)"/>
-    <wire from="(240,1300)" to="(240,1330)"/>
-    <wire from="(230,4170)" to="(230,4200)"/>
-    <wire from="(240,20)" to="(240,50)"/>
-    <wire from="(340,1170)" to="(380,1170)"/>
-    <wire from="(200,4230)" to="(240,4230)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(200,2000)" to="(230,2000)"/>
-    <wire from="(200,3600)" to="(230,3600)"/>
-    <wire from="(240,1090)" to="(260,1090)"/>
-    <wire from="(240,3010)" to="(260,3010)"/>
-    <wire from="(160,260)" to="(160,300)"/>
-    <wire from="(200,1690)" to="(220,1690)"/>
-    <wire from="(100,1660)" to="(180,1660)"/>
-    <wire from="(240,4180)" to="(240,4230)"/>
-    <wire from="(60,30)" to="(60,150)"/>
-    <wire from="(140,110)" to="(140,240)"/>
-    <wire from="(160,130)" to="(160,260)"/>
-    <wire from="(200,4020)" to="(260,4020)"/>
-    <wire from="(160,3330)" to="(160,3470)"/>
-    <wire from="(60,2350)" to="(180,2350)"/>
-    <wire from="(80,1330)" to="(80,1470)"/>
-    <wire from="(60,2910)" to="(60,3050)"/>
-    <wire from="(100,1350)" to="(100,1490)"/>
-    <wire from="(120,1370)" to="(120,1510)"/>
-    <wire from="(230,2380)" to="(230,2400)"/>
-    <wire from="(230,2700)" to="(230,2720)"/>
-    <wire from="(160,1730)" to="(160,1880)"/>
-    <wire from="(330,3300)" to="(330,3700)"/>
-    <wire from="(240,150)" to="(240,180)"/>
-    <wire from="(240,470)" to="(240,500)"/>
-    <wire from="(290,2850)" to="(330,2850)"/>
-    <wire from="(80,3670)" to="(180,3670)"/>
-    <wire from="(80,3990)" to="(180,3990)"/>
-    <wire from="(60,990)" to="(60,1150)"/>
-    <wire from="(100,1200)" to="(260,1200)"/>
-    <wire from="(120,1690)" to="(120,1850)"/>
-    <wire from="(140,1710)" to="(140,1870)"/>
-    <wire from="(140,2780)" to="(230,2780)"/>
-    <wire from="(230,1520)" to="(260,1520)"/>
-    <wire from="(230,3440)" to="(260,3440)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,2820)" to="(260,2820)"/>
-    <wire from="(360,140)" to="(430,140)"/>
-    <wire from="(120,1510)" to="(180,1510)"/>
-    <wire from="(120,3430)" to="(180,3430)"/>
-    <wire from="(60,1760)" to="(60,1900)"/>
-    <wire from="(80,180)" to="(80,320)"/>
-    <wire from="(80,500)" to="(80,640)"/>
-    <wire from="(230,1230)" to="(230,1240)"/>
-    <wire from="(60,3360)" to="(60,3500)"/>
-    <wire from="(160,2180)" to="(160,2320)"/>
-    <wire from="(100,200)" to="(100,350)"/>
-    <wire from="(100,520)" to="(100,670)"/>
-    <wire from="(240,1240)" to="(240,1270)"/>
-    <wire from="(140,3150)" to="(180,3150)"/>
-    <wire from="(200,3210)" to="(240,3210)"/>
-    <wire from="(40,240)" to="(140,240)"/>
-    <wire from="(60,1440)" to="(60,1600)"/>
-    <wire from="(120,220)" to="(120,380)"/>
-    <wire from="(120,540)" to="(120,700)"/>
-    <wire from="(160,2500)" to="(160,2660)"/>
-    <wire from="(230,1650)" to="(260,1650)"/>
-    <wire from="(230,1970)" to="(260,1970)"/>
-    <wire from="(230,2290)" to="(260,2290)"/>
-    <wire from="(230,2610)" to="(260,2610)"/>
-    <wire from="(230,3250)" to="(260,3250)"/>
-    <wire from="(230,3890)" to="(260,3890)"/>
-    <wire from="(240,1030)" to="(260,1030)"/>
-    <wire from="(140,240)" to="(140,410)"/>
-    <wire from="(240,2950)" to="(260,2950)"/>
-    <wire from="(240,3590)" to="(260,3590)"/>
-    <wire from="(240,3800)" to="(240,3840)"/>
-    <wire from="(240,390)" to="(260,390)"/>
-    <wire from="(240,710)" to="(260,710)"/>
-    <wire from="(160,1270)" to="(180,1270)"/>
-    <wire from="(120,90)" to="(260,90)"/>
-    <wire from="(360,2190)" to="(430,2190)"/>
-    <wire from="(290,530)" to="(350,530)"/>
-    <wire from="(120,2280)" to="(180,2280)"/>
-    <wire from="(120,2600)" to="(180,2600)"/>
-    <wire from="(60,2210)" to="(60,2350)"/>
-    <wire from="(60,2680)" to="(240,2680)"/>
-    <wire from="(60,2530)" to="(60,2680)"/>
-    <wire from="(140,2000)" to="(180,2000)"/>
-    <wire from="(140,3600)" to="(180,3600)"/>
-    <wire from="(200,2060)" to="(240,2060)"/>
-    <wire from="(80,3830)" to="(80,3990)"/>
-    <wire from="(230,2100)" to="(260,2100)"/>
-    <wire from="(200,3670)" to="(230,3670)"/>
-    <wire from="(200,3990)" to="(230,3990)"/>
-    <wire from="(290,1210)" to="(310,1210)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(160,440)" to="(180,440)"/>
-    <wire from="(60,740)" to="(60,850)"/>
-    <wire from="(160,830)" to="(240,830)"/>
-    <wire from="(60,290)" to="(60,470)"/>
-    <wire from="(340,3310)" to="(340,3870)"/>
-    <wire from="(80,760)" to="(80,880)"/>
-    <wire from="(120,800)" to="(120,930)"/>
-    <wire from="(140,820)" to="(140,950)"/>
-    <wire from="(320,3250)" to="(380,3250)"/>
-    <wire from="(100,780)" to="(100,910)"/>
-    <wire from="(320,2980)" to="(320,3250)"/>
-    <wire from="(290,3870)" to="(340,3870)"/>
-    <wire from="(220,4040)" to="(220,4050)"/>
-    <wire from="(230,4050)" to="(230,4070)"/>
-    <wire from="(240,4060)" to="(240,4080)"/>
-    <wire from="(200,3470)" to="(240,3470)"/>
-    <wire from="(80,1180)" to="(180,1180)"/>
-    <wire from="(200,1240)" to="(230,1240)"/>
-    <wire from="(230,2870)" to="(260,2870)"/>
-    <wire from="(160,3770)" to="(180,3770)"/>
-    <wire from="(240,3530)" to="(260,3530)"/>
-    <wire from="(360,3330)" to="(380,3330)"/>
-    <wire from="(240,330)" to="(260,330)"/>
-    <wire from="(240,650)" to="(260,650)"/>
-    <wire from="(310,1120)" to="(380,1120)"/>
-    <wire from="(200,1660)" to="(260,1660)"/>
-    <wire from="(120,2860)" to="(180,2860)"/>
-    <wire from="(330,1160)" to="(380,1160)"/>
-    <wire from="(100,910)" to="(100,1050)"/>
-    <wire from="(120,930)" to="(120,1070)"/>
-    <wire from="(140,950)" to="(140,1090)"/>
-    <wire from="(160,2890)" to="(160,3030)"/>
-    <wire from="(160,970)" to="(160,1120)"/>
-    <wire from="(200,2320)" to="(240,2320)"/>
-    <wire from="(80,1630)" to="(180,1630)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(230,1080)" to="(260,1080)"/>
-    <wire from="(230,3000)" to="(260,3000)"/>
-    <wire from="(240,990)" to="(240,1030)"/>
-    <wire from="(340,2740)" to="(340,3230)"/>
-    <wire from="(240,2910)" to="(240,2950)"/>
-    <wire from="(160,130)" to="(240,130)"/>
-    <wire from="(310,1060)" to="(310,1120)"/>
-    <wire from="(200,3710)" to="(260,3710)"/>
-    <wire from="(350,3320)" to="(350,4030)"/>
-    <wire from="(60,3640)" to="(180,3640)"/>
-    <wire from="(60,3960)" to="(180,3960)"/>
-    <wire from="(80,2940)" to="(80,3080)"/>
-    <wire from="(140,1400)" to="(140,1540)"/>
-    <wire from="(230,3670)" to="(230,3680)"/>
-    <wire from="(230,3990)" to="(230,4010)"/>
-    <wire from="(160,1420)" to="(160,1570)"/>
-    <wire from="(240,1440)" to="(240,1470)"/>
-    <wire from="(200,850)" to="(240,850)"/>
-    <wire from="(240,3360)" to="(240,3390)"/>
-    <wire from="(340,3230)" to="(380,3230)"/>
-    <wire from="(200,1180)" to="(230,1180)"/>
-    <wire from="(80,1020)" to="(80,1180)"/>
-    <wire from="(140,4070)" to="(230,4070)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(200,3740)" to="(230,3740)"/>
-    <wire from="(240,3150)" to="(260,3150)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(120,930)" to="(260,930)"/>
-    <wire from="(80,1790)" to="(80,1920)"/>
-    <wire from="(330,1100)" to="(380,1100)"/>
-    <wire from="(80,3390)" to="(80,3530)"/>
-    <wire from="(230,4120)" to="(230,4130)"/>
-    <wire from="(100,3410)" to="(100,3550)"/>
-    <wire from="(120,3430)" to="(120,3570)"/>
-    <wire from="(160,3470)" to="(160,3620)"/>
-    <wire from="(140,570)" to="(140,720)"/>
-    <wire from="(140,3450)" to="(140,3600)"/>
-    <wire from="(140,1240)" to="(180,1240)"/>
-    <wire from="(240,2210)" to="(240,2240)"/>
-    <wire from="(240,2530)" to="(240,2560)"/>
-    <wire from="(200,20)" to="(240,20)"/>
-    <wire from="(200,1300)" to="(240,1300)"/>
-    <wire from="(220,1960)" to="(260,1960)"/>
-    <wire from="(220,3880)" to="(260,3880)"/>
-    <wire from="(230,60)" to="(260,60)"/>
-    <wire from="(230,380)" to="(260,380)"/>
-    <wire from="(230,700)" to="(260,700)"/>
-    <wire from="(200,1630)" to="(230,1630)"/>
-    <wire from="(80,1470)" to="(80,1630)"/>
-    <wire from="(60,3050)" to="(60,3210)"/>
-    <wire from="(100,3260)" to="(260,3260)"/>
-    <wire from="(230,1340)" to="(260,1340)"/>
-    <wire from="(230,3580)" to="(260,3580)"/>
-    <wire from="(310,150)" to="(330,150)"/>
-    <wire from="(100,1490)" to="(100,1660)"/>
-    <wire from="(240,290)" to="(240,330)"/>
-    <wire from="(360,3330)" to="(360,4150)"/>
-    <wire from="(120,1510)" to="(120,1690)"/>
-    <wire from="(60,620)" to="(60,740)"/>
-    <wire from="(80,640)" to="(80,760)"/>
-    <wire from="(120,1970)" to="(180,1970)"/>
-    <wire from="(120,3570)" to="(180,3570)"/>
-    <wire from="(120,3890)" to="(180,3890)"/>
-    <wire from="(220,1680)" to="(220,1690)"/>
-    <wire from="(60,3500)" to="(60,3640)"/>
-    <wire from="(80,2240)" to="(80,2380)"/>
-    <wire from="(80,2560)" to="(80,2700)"/>
-    <wire from="(230,3290)" to="(230,3300)"/>
-    <wire from="(230,1690)" to="(230,1710)"/>
-    <wire from="(100,2260)" to="(100,2410)"/>
-    <wire from="(100,2580)" to="(100,2730)"/>
-    <wire from="(240,740)" to="(240,760)"/>
-    <wire from="(140,410)" to="(180,410)"/>
-    <wire from="(240,1700)" to="(240,1730)"/>
-    <wire from="(200,150)" to="(240,150)"/>
-    <wire from="(200,470)" to="(240,470)"/>
-    <wire from="(240,3300)" to="(240,3330)"/>
-    <wire from="(230,190)" to="(260,190)"/>
-    <wire from="(230,510)" to="(260,510)"/>
-    <wire from="(60,1900)" to="(60,2060)"/>
-    <wire from="(100,2110)" to="(260,2110)"/>
-    <wire from="(120,2280)" to="(120,2440)"/>
-    <wire from="(100,3860)" to="(100,4020)"/>
-    <wire from="(120,2600)" to="(120,2760)"/>
-    <wire from="(240,2450)" to="(260,2450)"/>
-    <wire from="(240,2770)" to="(260,2770)"/>
-    <wire from="(160,3330)" to="(180,3330)"/>
-    <wire from="(80,1920)" to="(80,2090)"/>
-    <wire from="(100,1940)" to="(100,2110)"/>
-    <wire from="(310,2200)" to="(330,2200)"/>
-    <wire from="(240,3090)" to="(260,3090)"/>
-    <wire from="(240,3730)" to="(260,3730)"/>
-    <wire from="(140,2300)" to="(140,2470)"/>
-    <wire from="(360,3210)" to="(380,3210)"/>
-    <wire from="(160,1730)" to="(180,1730)"/>
-    <wire from="(80,320)" to="(80,500)"/>
-    <wire from="(160,2320)" to="(160,2500)"/>
-    <wire from="(290,2590)" to="(350,2590)"/>
-    <wire from="(60,1150)" to="(180,1150)"/>
-    <wire from="(290,680)" to="(340,680)"/>
-    <wire from="(230,1180)" to="(230,1190)"/>
-    <wire from="(230,2140)" to="(230,2150)"/>
-    <wire from="(240,2150)" to="(240,2180)"/>
-    <wire from="(200,600)" to="(240,600)"/>
-    <wire from="(140,3740)" to="(180,3740)"/>
-    <wire from="(200,3800)" to="(240,3800)"/>
-    <wire from="(350,3320)" to="(380,3320)"/>
-    <wire from="(350,1080)" to="(380,1080)"/>
-    <wire from="(240,4180)" to="(260,4180)"/>
-    <wire from="(60,2800)" to="(60,2910)"/>
-    <wire from="(160,260)" to="(180,260)"/>
-    <wire from="(160,2180)" to="(180,2180)"/>
-    <wire from="(160,2500)" to="(180,2500)"/>
-    <wire from="(100,910)" to="(180,910)"/>
-    <wire from="(160,970)" to="(240,970)"/>
-    <wire from="(160,2890)" to="(240,2890)"/>
-    <wire from="(60,2350)" to="(60,2530)"/>
-    <wire from="(80,2820)" to="(80,2940)"/>
-    <wire from="(100,2840)" to="(100,2970)"/>
-    <wire from="(320,1150)" to="(380,1150)"/>
-    <wire from="(120,2860)" to="(120,2990)"/>
-    <wire from="(140,2880)" to="(140,3010)"/>
-    <wire from="(40,300)" to="(160,300)"/>
-    <wire from="(60,1600)" to="(180,1600)"/>
-    <wire from="(230,1630)" to="(230,1650)"/>
-    <wire from="(200,3930)" to="(240,3930)"/>
-    <wire from="(80,3240)" to="(180,3240)"/>
-    <wire from="(290,3700)" to="(330,3700)"/>
-    <wire from="(230,770)" to="(260,770)"/>
-    <wire from="(140,1710)" to="(230,1710)"/>
-    <wire from="(200,3300)" to="(230,3300)"/>
-    <wire from="(240,2390)" to="(260,2390)"/>
-    <wire from="(240,2710)" to="(260,2710)"/>
-    <wire from="(160,4230)" to="(180,4230)"/>
-    <wire from="(290,2120)" to="(310,2120)"/>
-    <wire from="(240,3670)" to="(260,3670)"/>
-    <wire from="(160,1420)" to="(240,1420)"/>
-    <wire from="(100,2970)" to="(100,3110)"/>
-    <wire from="(120,2990)" to="(120,3130)"/>
-    <wire from="(140,3010)" to="(140,3150)"/>
-    <wire from="(100,1050)" to="(100,1200)"/>
-    <wire from="(120,1070)" to="(120,1220)"/>
-    <wire from="(140,1090)" to="(140,1240)"/>
-    <wire from="(160,3030)" to="(160,3180)"/>
-    <wire from="(220,1840)" to="(260,1840)"/>
-    <wire from="(80,2090)" to="(180,2090)"/>
-    <wire from="(290,3270)" to="(380,3270)"/>
-    <wire from="(230,900)" to="(260,900)"/>
-    <wire from="(140,240)" to="(230,240)"/>
-    <wire from="(200,2150)" to="(230,2150)"/>
-    <wire from="(200,2470)" to="(230,2470)"/>
-    <wire from="(230,3140)" to="(260,3140)"/>
-    <wire from="(240,1240)" to="(260,1240)"/>
-    <wire from="(240,4120)" to="(260,4120)"/>
-    <wire from="(240,3050)" to="(240,3090)"/>
-    <wire from="(100,1820)" to="(100,1940)"/>
-    <wire from="(160,600)" to="(160,730)"/>
-    <wire from="(120,1850)" to="(180,1850)"/>
-    <wire from="(60,4100)" to="(180,4100)"/>
-    <wire from="(240,1900)" to="(240,1920)"/>
-    <wire from="(160,1880)" to="(160,2030)"/>
-    <wire from="(220,370)" to="(260,370)"/>
-    <wire from="(220,690)" to="(260,690)"/>
-    <wire from="(200,990)" to="(240,990)"/>
-    <wire from="(240,3500)" to="(240,3530)"/>
-    <wire from="(200,2910)" to="(240,2910)"/>
-    <wire from="(240,620)" to="(240,650)"/>
-    <wire from="(100,70)" to="(260,70)"/>
-    <wire from="(100,1350)" to="(260,1350)"/>
-    <wire from="(80,3080)" to="(80,3240)"/>
-    <wire from="(200,3240)" to="(230,3240)"/>
-    <wire from="(160,730)" to="(160,830)"/>
-    <wire from="(200,4200)" to="(230,4200)"/>
-    <wire from="(200,3890)" to="(220,3890)"/>
-    <wire from="(140,1540)" to="(140,1710)"/>
-    <wire from="(200,1970)" to="(220,1970)"/>
-    <wire from="(100,670)" to="(100,780)"/>
-    <wire from="(100,1940)" to="(180,1940)"/>
-    <wire from="(100,3860)" to="(180,3860)"/>
-    <wire from="(120,1070)" to="(260,1070)"/>
-    <wire from="(120,2990)" to="(260,2990)"/>
-    <wire from="(290,1830)" to="(350,1830)"/>
-    <wire from="(120,380)" to="(180,380)"/>
-    <wire from="(120,700)" to="(180,700)"/>
-    <wire from="(230,100)" to="(230,110)"/>
-    <wire from="(310,3120)" to="(310,3260)"/>
-    <wire from="(80,3530)" to="(80,3670)"/>
-    <wire from="(100,3550)" to="(100,3690)"/>
-    <wire from="(120,3570)" to="(120,3710)"/>
-    <wire from="(230,1380)" to="(230,1400)"/>
-    <wire from="(160,3930)" to="(160,4080)"/>
-    <wire from="(140,2630)" to="(140,2780)"/>
-    <wire from="(240,110)" to="(240,130)"/>
-    <wire from="(240,1390)" to="(240,1420)"/>
-    <wire from="(200,1120)" to="(240,1120)"/>
-    <wire from="(200,1440)" to="(240,1440)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(140,3300)" to="(180,3300)"/>
-    <wire from="(200,3360)" to="(240,3360)"/>
-    <wire from="(100,200)" to="(260,200)"/>
-    <wire from="(100,520)" to="(260,520)"/>
-    <wire from="(120,1970)" to="(120,2130)"/>
-    <wire from="(120,3890)" to="(120,4050)"/>
-    <wire from="(140,820)" to="(230,820)"/>
-    <wire from="(140,3910)" to="(140,4070)"/>
-    <wire from="(230,1480)" to="(260,1480)"/>
-    <wire from="(200,2090)" to="(230,2090)"/>
-    <wire from="(230,2440)" to="(260,2440)"/>
-    <wire from="(230,2760)" to="(260,2760)"/>
-    <wire from="(230,3400)" to="(260,3400)"/>
-    <wire from="(230,3720)" to="(260,3720)"/>
-    <wire from="(240,1180)" to="(260,1180)"/>
-    <wire from="(240,4060)" to="(260,4060)"/>
-    <wire from="(410,3270)" to="(430,3270)"/>
-    <wire from="(100,350)" to="(100,520)"/>
-    <wire from="(240,2350)" to="(240,2390)"/>
-    <wire from="(60,2680)" to="(60,2800)"/>
-    <wire from="(80,2700)" to="(80,2820)"/>
-    <wire from="(290,1950)" to="(360,1950)"/>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3270)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="13"/>
-    </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,300)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3080)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2740)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,2120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1360)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,2190)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2590)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,140)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2850)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,790)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1060)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,80)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,3120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3870)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,1130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2980)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(430,3270)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4200)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,2190)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1130)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="12"/>
-    </comp>
-    <comp lib="1" loc="(200,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4030)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,360)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-  </circuit>
-  <circuit name="Opcode_Decoder">
-    <a name="circuit" val="Opcode_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="235" stroke="#000000" stroke-width="2" width="31" x="50" y="55"/>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="136"/>
-      <circ-port height="10" pin="420,70" width="10" x="75" y="65"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="146"/>
-      <circ-port height="8" pin="40,140" width="8" x="46" y="156"/>
-      <circ-port height="10" pin="420,180" width="10" x="75" y="85"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="166"/>
-      <circ-port height="8" pin="40,250" width="8" x="46" y="176"/>
-      <circ-port height="8" pin="40,300" width="8" x="46" y="186"/>
-      <circ-port height="10" pin="420,750" width="10" x="75" y="105"/>
-      <circ-port height="10" pin="420,1490" width="10" x="75" y="125"/>
-      <circ-port height="10" pin="420,1690" width="10" x="75" y="145"/>
-      <circ-port height="10" pin="420,1900" width="10" x="75" y="165"/>
-      <circ-port height="10" pin="420,2130" width="10" x="75" y="185"/>
-      <circ-port height="10" pin="420,2970" width="10" x="75" y="205"/>
-      <circ-port height="10" pin="420,3790" width="10" x="75" y="225"/>
-      <circ-port height="10" pin="420,3930" width="10" x="75" y="245"/>
-      <circ-port height="10" pin="420,4130" width="10" x="75" y="265"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
-    </appear>
-    <wire from="(120,190)" to="(180,190)"/>
-    <wire from="(350,3020)" to="(350,3610)"/>
-    <wire from="(60,3720)" to="(180,3720)"/>
-    <wire from="(330,450)" to="(330,720)"/>
-    <wire from="(220,2140)" to="(220,2150)"/>
-    <wire from="(230,3750)" to="(230,3770)"/>
-    <wire from="(230,2150)" to="(230,2180)"/>
-    <wire from="(140,2790)" to="(180,2790)"/>
-    <wire from="(240,3120)" to="(240,3150)"/>
-    <wire from="(200,2210)" to="(240,2210)"/>
-    <wire from="(200,2850)" to="(240,2850)"/>
-    <wire from="(240,240)" to="(240,270)"/>
-    <wire from="(320,730)" to="(360,730)"/>
-    <wire from="(230,2890)" to="(260,2890)"/>
-    <wire from="(200,3820)" to="(230,3820)"/>
-    <wire from="(240,990)" to="(260,990)"/>
-    <wire from="(200,3510)" to="(220,3510)"/>
-    <wire from="(350,3020)" to="(370,3020)"/>
-    <wire from="(200,1590)" to="(220,1590)"/>
-    <wire from="(100,1560)" to="(180,1560)"/>
-    <wire from="(160,1620)" to="(240,1620)"/>
-    <wire from="(100,3480)" to="(180,3480)"/>
-    <wire from="(160,3540)" to="(240,3540)"/>
-    <wire from="(120,690)" to="(260,690)"/>
-    <wire from="(240,2160)" to="(240,2210)"/>
-    <wire from="(120,4210)" to="(260,4210)"/>
-    <wire from="(310,1910)" to="(310,1970)"/>
-    <wire from="(120,1590)" to="(120,1710)"/>
-    <wire from="(140,1610)" to="(140,1730)"/>
-    <wire from="(120,3510)" to="(120,3630)"/>
-    <wire from="(200,3600)" to="(260,3600)"/>
-    <wire from="(200,3920)" to="(260,3920)"/>
-    <wire from="(140,3530)" to="(140,3660)"/>
-    <wire from="(200,1680)" to="(260,1680)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(80,270)" to="(80,410)"/>
-    <wire from="(80,3150)" to="(80,3290)"/>
-    <wire from="(100,3170)" to="(100,3310)"/>
-    <wire from="(120,3190)" to="(120,3330)"/>
-    <wire from="(100,290)" to="(100,440)"/>
-    <wire from="(200,740)" to="(240,740)"/>
-    <wire from="(200,2980)" to="(240,2980)"/>
-    <wire from="(80,1650)" to="(180,1650)"/>
-    <wire from="(80,3890)" to="(180,3890)"/>
-    <wire from="(200,1070)" to="(230,1070)"/>
-    <wire from="(120,310)" to="(120,470)"/>
-    <wire from="(160,1310)" to="(160,1470)"/>
-    <wire from="(230,3020)" to="(260,3020)"/>
-    <wire from="(290,2760)" to="(320,2760)"/>
-    <wire from="(230,3340)" to="(260,3340)"/>
-    <wire from="(240,800)" to="(260,800)"/>
-    <wire from="(240,1440)" to="(260,1440)"/>
-    <wire from="(290,4050)" to="(310,4050)"/>
-    <wire from="(240,480)" to="(260,480)"/>
-    <wire from="(310,760)" to="(310,830)"/>
-    <wire from="(120,3330)" to="(180,3330)"/>
-    <wire from="(60,2060)" to="(180,2060)"/>
-    <wire from="(60,2700)" to="(180,2700)"/>
-    <wire from="(230,2730)" to="(230,2740)"/>
-    <wire from="(230,2090)" to="(230,2110)"/>
-    <wire from="(240,2420)" to="(240,2450)"/>
-    <wire from="(60,1340)" to="(60,1500)"/>
-    <wire from="(100,1230)" to="(260,1230)"/>
-    <wire from="(60,3260)" to="(60,3420)"/>
-    <wire from="(140,3660)" to="(140,3820)"/>
-    <wire from="(390,750)" to="(420,750)"/>
-    <wire from="(230,1550)" to="(260,1550)"/>
-    <wire from="(230,3470)" to="(260,3470)"/>
-    <wire from="(240,930)" to="(260,930)"/>
-    <wire from="(340,710)" to="(360,710)"/>
-    <wire from="(160,3090)" to="(180,3090)"/>
-    <wire from="(60,510)" to="(60,620)"/>
-    <wire from="(330,2630)" to="(330,2940)"/>
-    <wire from="(160,600)" to="(240,600)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(80,530)" to="(80,650)"/>
-    <wire from="(100,550)" to="(100,670)"/>
-    <wire from="(120,570)" to="(120,690)"/>
-    <wire from="(140,590)" to="(140,710)"/>
-    <wire from="(80,2450)" to="(80,2590)"/>
-    <wire from="(230,1260)" to="(230,1280)"/>
-    <wire from="(100,2470)" to="(100,2620)"/>
-    <wire from="(290,450)" to="(330,450)"/>
-    <wire from="(200,3560)" to="(240,3560)"/>
-    <wire from="(140,3820)" to="(180,3820)"/>
-    <wire from="(200,1650)" to="(230,1650)"/>
-    <wire from="(120,2490)" to="(120,2650)"/>
-    <wire from="(200,3890)" to="(230,3890)"/>
-    <wire from="(240,1380)" to="(260,1380)"/>
-    <wire from="(240,2340)" to="(260,2340)"/>
-    <wire from="(240,2660)" to="(260,2660)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,1270)" to="(240,1310)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,420)" to="(260,420)"/>
-    <wire from="(160,2210)" to="(160,2390)"/>
-    <wire from="(320,770)" to="(320,960)"/>
-    <wire from="(200,1110)" to="(260,1110)"/>
-    <wire from="(60,1040)" to="(180,1040)"/>
-    <wire from="(230,1070)" to="(230,1080)"/>
-    <wire from="(220,1700)" to="(220,1710)"/>
-    <wire from="(160,740)" to="(160,880)"/>
-    <wire from="(220,3620)" to="(220,3630)"/>
-    <wire from="(220,3940)" to="(220,3950)"/>
-    <wire from="(230,1710)" to="(230,1730)"/>
-    <wire from="(240,1720)" to="(240,1740)"/>
-    <wire from="(230,3950)" to="(230,3970)"/>
-    <wire from="(240,3960)" to="(240,3980)"/>
-    <wire from="(230,3630)" to="(230,3660)"/>
-    <wire from="(200,3690)" to="(240,3690)"/>
-    <wire from="(230,850)" to="(260,850)"/>
-    <wire from="(200,1140)" to="(230,1140)"/>
-    <wire from="(100,1960)" to="(100,2120)"/>
-    <wire from="(100,4050)" to="(260,4050)"/>
-    <wire from="(140,3070)" to="(230,3070)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(120,1980)" to="(120,2150)"/>
-    <wire from="(240,2790)" to="(260,2790)"/>
-    <wire from="(240,4070)" to="(260,4070)"/>
-    <wire from="(310,4140)" to="(330,4140)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(160,2390)" to="(180,2390)"/>
-    <wire from="(160,220)" to="(240,220)"/>
-    <wire from="(60,2240)" to="(60,2420)"/>
-    <wire from="(240,3640)" to="(240,3690)"/>
-    <wire from="(140,2000)" to="(140,2180)"/>
-    <wire from="(80,150)" to="(80,270)"/>
-    <wire from="(100,170)" to="(100,290)"/>
-    <wire from="(120,190)" to="(120,310)"/>
-    <wire from="(200,3480)" to="(260,3480)"/>
-    <wire from="(60,770)" to="(60,900)"/>
-    <wire from="(200,1560)" to="(260,1560)"/>
-    <wire from="(200,620)" to="(240,620)"/>
-    <wire from="(200,1900)" to="(240,1900)"/>
-    <wire from="(80,1210)" to="(180,1210)"/>
-    <wire from="(290,2630)" to="(330,2630)"/>
-    <wire from="(200,4140)" to="(240,4140)"/>
-    <wire from="(80,1530)" to="(180,1530)"/>
-    <wire from="(80,3450)" to="(180,3450)"/>
-    <wire from="(230,660)" to="(260,660)"/>
-    <wire from="(230,980)" to="(260,980)"/>
-    <wire from="(100,2900)" to="(260,2900)"/>
-    <wire from="(340,3010)" to="(370,3010)"/>
-    <wire from="(230,4180)" to="(260,4180)"/>
-    <wire from="(240,2280)" to="(260,2280)"/>
-    <wire from="(240,2600)" to="(260,2600)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(120,1980)" to="(260,1980)"/>
-    <wire from="(330,780)" to="(330,1100)"/>
-    <wire from="(120,970)" to="(180,970)"/>
-    <wire from="(60,3860)" to="(180,3860)"/>
-    <wire from="(60,900)" to="(60,1040)"/>
-    <wire from="(230,2930)" to="(230,2940)"/>
-    <wire from="(140,3220)" to="(140,3360)"/>
-    <wire from="(230,1650)" to="(230,1670)"/>
-    <wire from="(240,2940)" to="(240,2960)"/>
-    <wire from="(230,3890)" to="(230,3910)"/>
-    <wire from="(160,3240)" to="(160,3390)"/>
-    <wire from="(140,340)" to="(140,490)"/>
-    <wire from="(240,3260)" to="(240,3290)"/>
-    <wire from="(200,2030)" to="(240,2030)"/>
-    <wire from="(230,470)" to="(260,470)"/>
-    <wire from="(140,3970)" to="(230,3970)"/>
-    <wire from="(100,3030)" to="(260,3030)"/>
-    <wire from="(140,1730)" to="(230,1730)"/>
-    <wire from="(230,1430)" to="(260,1430)"/>
-    <wire from="(200,2360)" to="(230,2360)"/>
-    <wire from="(240,1130)" to="(260,1130)"/>
-    <wire from="(240,2730)" to="(260,2730)"/>
-    <wire from="(160,4250)" to="(180,4250)"/>
-    <wire from="(240,1340)" to="(240,1380)"/>
-    <wire from="(320,2760)" to="(320,2950)"/>
-    <wire from="(60,390)" to="(60,510)"/>
-    <wire from="(80,410)" to="(80,530)"/>
-    <wire from="(310,1410)" to="(310,1480)"/>
-    <wire from="(160,300)" to="(160,370)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(230,3060)" to="(230,3070)"/>
-    <wire from="(240,3070)" to="(240,3090)"/>
-    <wire from="(160,3690)" to="(160,3840)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(240,510)" to="(240,530)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(140,1140)" to="(180,1140)"/>
-    <wire from="(200,240)" to="(240,240)"/>
-    <wire from="(200,3120)" to="(240,3120)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(80,4030)" to="(180,4030)"/>
-    <wire from="(230,280)" to="(260,280)"/>
-    <wire from="(200,1210)" to="(230,1210)"/>
-    <wire from="(200,1530)" to="(230,1530)"/>
-    <wire from="(80,1370)" to="(80,1530)"/>
-    <wire from="(80,3290)" to="(80,3450)"/>
-    <wire from="(200,3450)" to="(230,3450)"/>
-    <wire from="(230,3160)" to="(260,3160)"/>
-    <wire from="(290,2910)" to="(310,2910)"/>
-    <wire from="(240,3820)" to="(260,3820)"/>
-    <wire from="(100,3310)" to="(100,3480)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(120,3330)" to="(120,3510)"/>
-    <wire from="(290,180)" to="(420,180)"/>
-    <wire from="(340,790)" to="(340,1240)"/>
-    <wire from="(60,1630)" to="(240,1630)"/>
-    <wire from="(220,1580)" to="(220,1590)"/>
-    <wire from="(60,3720)" to="(60,3860)"/>
-    <wire from="(220,3500)" to="(220,3510)"/>
-    <wire from="(230,1590)" to="(230,1610)"/>
-    <wire from="(240,1600)" to="(240,1620)"/>
-    <wire from="(230,3510)" to="(230,3530)"/>
-    <wire from="(240,3520)" to="(240,3540)"/>
-    <wire from="(140,2520)" to="(140,2670)"/>
-    <wire from="(200,370)" to="(240,370)"/>
-    <wire from="(200,1010)" to="(240,1010)"/>
-    <wire from="(290,1100)" to="(330,1100)"/>
-    <wire from="(80,2880)" to="(180,2880)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(140,4230)" to="(230,4230)"/>
-    <wire from="(230,2330)" to="(260,2330)"/>
-    <wire from="(230,2650)" to="(260,2650)"/>
-    <wire from="(200,2940)" to="(230,2940)"/>
-    <wire from="(240,1070)" to="(260,1070)"/>
-    <wire from="(290,3040)" to="(310,3040)"/>
-    <wire from="(240,2240)" to="(240,2280)"/>
-    <wire from="(160,1310)" to="(180,1310)"/>
-    <wire from="(100,1960)" to="(180,1960)"/>
-    <wire from="(60,2570)" to="(60,2700)"/>
-    <wire from="(80,2590)" to="(80,2730)"/>
-    <wire from="(240,130)" to="(240,150)"/>
-    <wire from="(240,770)" to="(240,800)"/>
-    <wire from="(140,2360)" to="(180,2360)"/>
-    <wire from="(200,2420)" to="(240,2420)"/>
-    <wire from="(80,3010)" to="(180,3010)"/>
-    <wire from="(230,540)" to="(260,540)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(230,2460)" to="(260,2460)"/>
-    <wire from="(230,2780)" to="(260,2780)"/>
-    <wire from="(200,4030)" to="(230,4030)"/>
-    <wire from="(230,4060)" to="(260,4060)"/>
-    <wire from="(240,2160)" to="(260,2160)"/>
-    <wire from="(290,1570)" to="(310,1570)"/>
-    <wire from="(310,1910)" to="(330,1910)"/>
-    <wire from="(240,3760)" to="(260,3760)"/>
-    <wire from="(80,2270)" to="(80,2450)"/>
-    <wire from="(160,2030)" to="(160,2210)"/>
-    <wire from="(120,840)" to="(120,970)"/>
-    <wire from="(140,860)" to="(140,990)"/>
-    <wire from="(160,880)" to="(160,1010)"/>
-    <wire from="(310,2960)" to="(370,2960)"/>
-    <wire from="(80,800)" to="(80,930)"/>
-    <wire from="(100,820)" to="(100,950)"/>
-    <wire from="(200,1250)" to="(260,1250)"/>
-    <wire from="(60,1180)" to="(180,1180)"/>
-    <wire from="(60,1500)" to="(180,1500)"/>
-    <wire from="(60,3420)" to="(180,3420)"/>
-    <wire from="(230,1210)" to="(230,1220)"/>
-    <wire from="(230,1850)" to="(230,1860)"/>
-    <wire from="(230,1530)" to="(230,1550)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(230,3450)" to="(230,3470)"/>
-    <wire from="(60,2700)" to="(60,2850)"/>
-    <wire from="(240,900)" to="(240,930)"/>
-    <wire from="(200,2550)" to="(240,2550)"/>
-    <wire from="(140,4090)" to="(180,4090)"/>
-    <wire from="(330,3000)" to="(370,3000)"/>
-    <wire from="(100,670)" to="(260,670)"/>
-    <wire from="(200,1280)" to="(230,1280)"/>
-    <wire from="(100,4190)" to="(260,4190)"/>
-    <wire from="(140,1610)" to="(230,1610)"/>
-    <wire from="(140,3530)" to="(230,3530)"/>
-    <wire from="(230,1950)" to="(260,1950)"/>
-    <wire from="(200,2880)" to="(230,2880)"/>
-    <wire from="(340,790)" to="(360,790)"/>
-    <wire from="(160,2210)" to="(180,2210)"/>
-    <wire from="(160,3240)" to="(240,3240)"/>
-    <wire from="(60,2060)" to="(60,2240)"/>
-    <wire from="(160,370)" to="(160,500)"/>
-    <wire from="(230,700)" to="(230,710)"/>
-    <wire from="(80,930)" to="(80,1070)"/>
-    <wire from="(100,950)" to="(100,1090)"/>
-    <wire from="(120,970)" to="(120,1110)"/>
-    <wire from="(230,3580)" to="(230,3590)"/>
-    <wire from="(230,4220)" to="(230,4230)"/>
-    <wire from="(240,4230)" to="(240,4250)"/>
-    <wire from="(140,990)" to="(140,1140)"/>
-    <wire from="(160,1010)" to="(160,1160)"/>
-    <wire from="(220,460)" to="(260,460)"/>
-    <wire from="(140,2940)" to="(180,2940)"/>
-    <wire from="(220,1420)" to="(260,1420)"/>
-    <wire from="(240,390)" to="(240,420)"/>
-    <wire from="(240,710)" to="(240,740)"/>
-    <wire from="(230,160)" to="(260,160)"/>
-    <wire from="(230,1120)" to="(260,1120)"/>
-    <wire from="(200,3010)" to="(230,3010)"/>
-    <wire from="(160,500)" to="(160,600)"/>
-    <wire from="(240,2100)" to="(260,2100)"/>
-    <wire from="(290,1830)" to="(310,1830)"/>
-    <wire from="(160,740)" to="(180,740)"/>
-    <wire from="(100,440)" to="(100,550)"/>
-    <wire from="(120,840)" to="(260,840)"/>
-    <wire from="(120,470)" to="(180,470)"/>
-    <wire from="(120,1110)" to="(180,1110)"/>
-    <wire from="(120,1430)" to="(180,1430)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(60,4000)" to="(180,4000)"/>
-    <wire from="(60,1040)" to="(60,1180)"/>
-    <wire from="(230,4030)" to="(230,4040)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(120,4070)" to="(230,4070)"/>
-    <wire from="(200,4090)" to="(240,4090)"/>
-    <wire from="(330,2940)" to="(370,2940)"/>
-    <wire from="(100,290)" to="(260,290)"/>
-    <wire from="(200,1860)" to="(230,1860)"/>
-    <wire from="(100,1400)" to="(100,1560)"/>
-    <wire from="(100,3170)" to="(260,3170)"/>
-    <wire from="(140,590)" to="(230,590)"/>
-    <wire from="(200,2180)" to="(230,2180)"/>
-    <wire from="(230,3810)" to="(260,3810)"/>
-    <wire from="(290,680)" to="(310,680)"/>
-    <wire from="(240,1270)" to="(260,1270)"/>
-    <wire from="(140,3360)" to="(140,3530)"/>
-    <wire from="(290,4200)" to="(310,4200)"/>
-    <wire from="(240,3720)" to="(240,3760)"/>
-    <wire from="(200,1960)" to="(260,1960)"/>
-    <wire from="(160,2550)" to="(160,2680)"/>
-    <wire from="(60,2850)" to="(180,2850)"/>
-    <wire from="(230,2880)" to="(230,2890)"/>
-    <wire from="(80,3750)" to="(80,3890)"/>
-    <wire from="(230,3200)" to="(230,3220)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(230,320)" to="(230,340)"/>
-    <wire from="(140,1280)" to="(180,1280)"/>
-    <wire from="(240,2570)" to="(240,2600)"/>
-    <wire from="(220,80)" to="(260,80)"/>
-    <wire from="(200,1340)" to="(240,1340)"/>
-    <wire from="(240,3210)" to="(240,3240)"/>
-    <wire from="(220,2320)" to="(260,2320)"/>
-    <wire from="(220,2640)" to="(260,2640)"/>
-    <wire from="(200,3260)" to="(240,3260)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(80,650)" to="(180,650)"/>
-    <wire from="(80,1930)" to="(180,1930)"/>
-    <wire from="(80,4170)" to="(180,4170)"/>
-    <wire from="(200,710)" to="(230,710)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(230,3300)" to="(260,3300)"/>
-    <wire from="(240,1720)" to="(260,1720)"/>
-    <wire from="(240,3640)" to="(260,3640)"/>
-    <wire from="(240,3960)" to="(260,3960)"/>
-    <wire from="(240,330)" to="(240,370)"/>
-    <wire from="(200,3050)" to="(260,3050)"/>
-    <wire from="(100,2620)" to="(100,2750)"/>
-    <wire from="(120,90)" to="(180,90)"/>
-    <wire from="(120,2330)" to="(180,2330)"/>
-    <wire from="(120,2650)" to="(180,2650)"/>
-    <wire from="(60,2980)" to="(180,2980)"/>
-    <wire from="(230,3010)" to="(230,3020)"/>
-    <wire from="(60,3860)" to="(60,4000)"/>
-    <wire from="(160,2680)" to="(160,2820)"/>
-    <wire from="(240,2700)" to="(240,2730)"/>
-    <wire from="(200,1470)" to="(240,1470)"/>
-    <wire from="(200,3390)" to="(240,3390)"/>
-    <wire from="(100,550)" to="(260,550)"/>
-    <wire from="(100,2470)" to="(260,2470)"/>
-    <wire from="(140,210)" to="(230,210)"/>
-    <wire from="(230,2150)" to="(260,2150)"/>
-    <wire from="(240,1210)" to="(260,1210)"/>
-    <wire from="(160,3690)" to="(180,3690)"/>
-    <wire from="(100,2300)" to="(100,2470)"/>
-    <wire from="(350,2920)" to="(370,2920)"/>
-    <wire from="(400,2970)" to="(420,2970)"/>
-    <wire from="(240,2060)" to="(240,2100)"/>
-    <wire from="(160,880)" to="(240,880)"/>
-    <wire from="(310,4050)" to="(310,4120)"/>
-    <wire from="(290,2310)" to="(350,2310)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(320,2990)" to="(370,2990)"/>
-    <wire from="(230,580)" to="(230,590)"/>
-    <wire from="(240,590)" to="(240,600)"/>
-    <wire from="(310,740)" to="(360,740)"/>
-    <wire from="(230,2500)" to="(230,2520)"/>
-    <wire from="(80,2730)" to="(80,2880)"/>
-    <wire from="(100,2750)" to="(100,2900)"/>
-    <wire from="(120,2770)" to="(120,2920)"/>
-    <wire from="(140,2790)" to="(140,2940)"/>
-    <wire from="(140,1860)" to="(180,1860)"/>
-    <wire from="(140,2180)" to="(180,2180)"/>
-    <wire from="(200,2240)" to="(240,2240)"/>
-    <wire from="(80,270)" to="(180,270)"/>
-    <wire from="(80,3150)" to="(180,3150)"/>
-    <wire from="(200,650)" to="(230,650)"/>
-    <wire from="(200,1930)" to="(230,1930)"/>
-    <wire from="(330,780)" to="(360,780)"/>
-    <wire from="(200,4170)" to="(230,4170)"/>
-    <wire from="(240,1660)" to="(260,1660)"/>
-    <wire from="(240,2940)" to="(260,2940)"/>
-    <wire from="(240,3580)" to="(260,3580)"/>
-    <wire from="(240,3900)" to="(260,3900)"/>
-    <wire from="(240,2510)" to="(240,2550)"/>
-    <wire from="(80,2090)" to="(80,2270)"/>
-    <wire from="(60,3560)" to="(180,3560)"/>
-    <wire from="(230,1990)" to="(230,2000)"/>
-    <wire from="(140,710)" to="(180,710)"/>
-    <wire from="(240,1040)" to="(240,1070)"/>
-    <wire from="(240,2000)" to="(240,2030)"/>
-    <wire from="(200,770)" to="(240,770)"/>
-    <wire from="(100,170)" to="(260,170)"/>
-    <wire from="(230,810)" to="(260,810)"/>
-    <wire from="(200,3660)" to="(230,3660)"/>
-    <wire from="(120,470)" to="(120,570)"/>
-    <wire from="(140,490)" to="(140,590)"/>
-    <wire from="(240,3070)" to="(260,3070)"/>
-    <wire from="(240,4030)" to="(260,4030)"/>
-    <wire from="(200,470)" to="(220,470)"/>
-    <wire from="(200,1430)" to="(220,1430)"/>
-    <wire from="(160,2030)" to="(180,2030)"/>
-    <wire from="(100,440)" to="(180,440)"/>
-    <wire from="(160,500)" to="(240,500)"/>
-    <wire from="(100,1400)" to="(180,1400)"/>
-    <wire from="(120,2770)" to="(260,2770)"/>
-    <wire from="(290,70)" to="(420,70)"/>
-    <wire from="(230,200)" to="(230,210)"/>
-    <wire from="(240,210)" to="(240,220)"/>
-    <wire from="(80,1070)" to="(80,1210)"/>
-    <wire from="(100,1090)" to="(100,1230)"/>
-    <wire from="(120,1110)" to="(120,1250)"/>
-    <wire from="(160,3390)" to="(160,3540)"/>
-    <wire from="(160,1470)" to="(160,1620)"/>
-    <wire from="(200,900)" to="(240,900)"/>
-    <wire from="(200,2820)" to="(240,2820)"/>
-    <wire from="(80,530)" to="(180,530)"/>
-    <wire from="(80,2450)" to="(180,2450)"/>
-    <wire from="(200,270)" to="(230,270)"/>
-    <wire from="(230,940)" to="(260,940)"/>
-    <wire from="(120,1430)" to="(120,1590)"/>
-    <wire from="(140,1450)" to="(140,1610)"/>
-    <wire from="(230,1260)" to="(260,1260)"/>
-    <wire from="(200,3150)" to="(230,3150)"/>
-    <wire from="(330,720)" to="(360,720)"/>
-    <wire from="(240,1600)" to="(260,1600)"/>
-    <wire from="(290,1970)" to="(310,1970)"/>
-    <wire from="(240,2880)" to="(260,2880)"/>
-    <wire from="(240,3520)" to="(260,3520)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(360,1490)" to="(420,1490)"/>
-    <wire from="(60,1500)" to="(60,1630)"/>
-    <wire from="(120,1250)" to="(180,1250)"/>
-    <wire from="(160,3840)" to="(160,3980)"/>
-    <wire from="(60,620)" to="(180,620)"/>
-    <wire from="(230,650)" to="(230,660)"/>
-    <wire from="(60,1900)" to="(180,1900)"/>
-    <wire from="(60,4140)" to="(180,4140)"/>
-    <wire from="(60,3420)" to="(60,3560)"/>
-    <wire from="(100,3780)" to="(100,3920)"/>
-    <wire from="(230,4170)" to="(230,4180)"/>
-    <wire from="(230,1930)" to="(230,1950)"/>
-    <wire from="(120,3800)" to="(120,3950)"/>
-    <wire from="(140,3820)" to="(140,3970)"/>
-    <wire from="(340,300)" to="(340,710)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(60,1180)" to="(60,1340)"/>
-    <wire from="(100,3310)" to="(260,3310)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(230,1390)" to="(260,1390)"/>
-    <wire from="(230,1710)" to="(260,1710)"/>
-    <wire from="(200,2000)" to="(230,2000)"/>
-    <wire from="(140,110)" to="(140,210)"/>
-    <wire from="(230,3630)" to="(260,3630)"/>
-    <wire from="(230,3950)" to="(260,3950)"/>
-    <wire from="(200,2330)" to="(220,2330)"/>
-    <wire from="(200,2650)" to="(220,2650)"/>
-    <wire from="(310,1480)" to="(330,1480)"/>
-    <wire from="(240,3010)" to="(260,3010)"/>
-    <wire from="(240,3860)" to="(240,3900)"/>
-    <wire from="(160,370)" to="(180,370)"/>
-    <wire from="(160,1010)" to="(180,1010)"/>
-    <wire from="(200,90)" to="(220,90)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(100,2300)" to="(180,2300)"/>
-    <wire from="(100,2620)" to="(180,2620)"/>
-    <wire from="(160,2680)" to="(240,2680)"/>
-    <wire from="(120,2650)" to="(120,2770)"/>
-    <wire from="(140,2670)" to="(140,2790)"/>
-    <wire from="(60,1630)" to="(60,1760)"/>
-    <wire from="(290,1240)" to="(340,1240)"/>
-    <wire from="(80,1650)" to="(80,1790)"/>
-    <wire from="(80,3890)" to="(80,4030)"/>
-    <wire from="(230,3340)" to="(230,3360)"/>
-    <wire from="(140,3660)" to="(180,3660)"/>
-    <wire from="(220,2140)" to="(260,2140)"/>
-    <wire from="(200,3720)" to="(240,3720)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(200,530)" to="(230,530)"/>
-    <wire from="(120,2330)" to="(120,2490)"/>
-    <wire from="(200,2450)" to="(230,2450)"/>
-    <wire from="(290,3180)" to="(320,3180)"/>
-    <wire from="(240,1540)" to="(260,1540)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,3460)" to="(260,3460)"/>
-    <wire from="(240,3350)" to="(240,3390)"/>
-    <wire from="(120,3800)" to="(260,3800)"/>
-    <wire from="(200,3190)" to="(260,3190)"/>
-    <wire from="(310,2980)" to="(370,2980)"/>
-    <wire from="(310,1500)" to="(310,1570)"/>
-    <wire from="(120,2150)" to="(180,2150)"/>
-    <wire from="(200,310)" to="(260,310)"/>
-    <wire from="(60,240)" to="(180,240)"/>
-    <wire from="(230,270)" to="(230,280)"/>
-    <wire from="(60,3120)" to="(180,3120)"/>
-    <wire from="(60,1760)" to="(60,1900)"/>
-    <wire from="(60,4000)" to="(60,4140)"/>
-    <wire from="(230,3150)" to="(230,3160)"/>
-    <wire from="(160,2820)" to="(160,2960)"/>
-    <wire from="(320,770)" to="(360,770)"/>
-    <wire from="(100,140)" to="(100,170)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(200,340)" to="(230,340)"/>
-    <wire from="(140,990)" to="(230,990)"/>
-    <wire from="(230,2290)" to="(260,2290)"/>
-    <wire from="(230,2610)" to="(260,2610)"/>
-    <wire from="(230,2930)" to="(260,2930)"/>
-    <wire from="(200,3220)" to="(230,3220)"/>
-    <wire from="(240,4230)" to="(260,4230)"/>
-    <wire from="(240,710)" to="(260,710)"/>
-    <wire from="(160,2550)" to="(180,2550)"/>
-    <wire from="(310,2910)" to="(310,2960)"/>
-    <wire from="(100,2120)" to="(100,2300)"/>
-    <wire from="(290,3790)" to="(420,3790)"/>
-    <wire from="(60,2850)" to="(60,2980)"/>
-    <wire from="(340,2480)" to="(340,2930)"/>
-    <wire from="(200,440)" to="(260,440)"/>
-    <wire from="(200,1400)" to="(260,1400)"/>
-    <wire from="(140,2000)" to="(180,2000)"/>
-    <wire from="(200,2060)" to="(240,2060)"/>
-    <wire from="(200,2700)" to="(240,2700)"/>
-    <wire from="(80,410)" to="(180,410)"/>
-    <wire from="(80,1370)" to="(180,1370)"/>
-    <wire from="(80,3290)" to="(180,3290)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(100,820)" to="(260,820)"/>
-    <wire from="(290,560)" to="(320,560)"/>
-    <wire from="(230,2740)" to="(260,2740)"/>
-    <wire from="(230,3060)" to="(260,3060)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(200,2490)" to="(260,2490)"/>
-    <wire from="(200,570)" to="(260,570)"/>
-    <wire from="(120,3050)" to="(180,3050)"/>
-    <wire from="(230,530)" to="(230,540)"/>
-    <wire from="(230,850)" to="(230,860)"/>
-    <wire from="(60,2420)" to="(180,2420)"/>
-    <wire from="(230,2450)" to="(230,2460)"/>
-    <wire from="(60,2980)" to="(60,3120)"/>
-    <wire from="(140,1140)" to="(140,1280)"/>
-    <wire from="(240,860)" to="(240,880)"/>
-    <wire from="(160,1160)" to="(160,1310)"/>
-    <wire from="(240,1180)" to="(240,1210)"/>
-    <wire from="(100,950)" to="(260,950)"/>
-    <wire from="(230,1590)" to="(260,1590)"/>
-    <wire from="(200,2520)" to="(230,2520)"/>
-    <wire from="(230,3510)" to="(260,3510)"/>
-    <wire from="(240,3210)" to="(260,3210)"/>
-    <wire from="(240,4170)" to="(260,4170)"/>
-    <wire from="(240,1500)" to="(240,1540)"/>
-    <wire from="(240,3420)" to="(240,3460)"/>
-    <wire from="(240,330)" to="(260,330)"/>
-    <wire from="(240,650)" to="(260,650)"/>
-    <wire from="(100,3780)" to="(180,3780)"/>
-    <wire from="(160,3840)" to="(240,3840)"/>
-    <wire from="(80,1530)" to="(80,1650)"/>
-    <wire from="(290,2130)" to="(420,2130)"/>
-    <wire from="(200,2300)" to="(260,2300)"/>
-    <wire from="(200,2620)" to="(260,2620)"/>
-    <wire from="(80,3450)" to="(80,3580)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(230,980)" to="(230,990)"/>
-    <wire from="(240,990)" to="(240,1010)"/>
-    <wire from="(140,340)" to="(180,340)"/>
-    <wire from="(240,1630)" to="(240,1660)"/>
-    <wire from="(200,1040)" to="(240,1040)"/>
-    <wire from="(140,3220)" to="(180,3220)"/>
-    <wire from="(220,1700)" to="(260,1700)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(220,3620)" to="(260,3620)"/>
-    <wire from="(220,3940)" to="(260,3940)"/>
-    <wire from="(80,2270)" to="(180,2270)"/>
-    <wire from="(80,2590)" to="(180,2590)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(200,1370)" to="(230,1370)"/>
-    <wire from="(80,1210)" to="(80,1370)"/>
-    <wire from="(230,1080)" to="(260,1080)"/>
-    <wire from="(200,3290)" to="(230,3290)"/>
-    <wire from="(290,830)" to="(310,830)"/>
-    <wire from="(100,1230)" to="(100,1400)"/>
-    <wire from="(120,1250)" to="(120,1430)"/>
-    <wire from="(310,2980)" to="(310,3040)"/>
-    <wire from="(100,3920)" to="(100,4050)"/>
-    <wire from="(120,1710)" to="(180,1710)"/>
-    <wire from="(200,190)" to="(260,190)"/>
-    <wire from="(120,3630)" to="(180,3630)"/>
-    <wire from="(120,3950)" to="(180,3950)"/>
-    <wire from="(290,3490)" to="(340,3490)"/>
-    <wire from="(230,150)" to="(230,160)"/>
-    <wire from="(220,460)" to="(220,470)"/>
-    <wire from="(60,510)" to="(240,510)"/>
-    <wire from="(220,1420)" to="(220,1430)"/>
-    <wire from="(100,1680)" to="(100,1820)"/>
-    <wire from="(160,1740)" to="(160,1880)"/>
-    <wire from="(230,1430)" to="(230,1450)"/>
-    <wire from="(230,470)" to="(230,490)"/>
-    <wire from="(240,480)" to="(240,500)"/>
-    <wire from="(140,250)" to="(140,340)"/>
-    <wire from="(240,1440)" to="(240,1470)"/>
-    <wire from="(240,4000)" to="(240,4030)"/>
-    <wire from="(200,3090)" to="(240,3090)"/>
-    <wire from="(80,800)" to="(180,800)"/>
-    <wire from="(200,860)" to="(230,860)"/>
-    <wire from="(60,3560)" to="(60,3720)"/>
-    <wire from="(140,2360)" to="(140,2520)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(230,3770)" to="(260,3770)"/>
-    <wire from="(200,2150)" to="(220,2150)"/>
-    <wire from="(240,2510)" to="(260,2510)"/>
-    <wire from="(160,3390)" to="(180,3390)"/>
-    <wire from="(80,3580)" to="(80,3750)"/>
-    <wire from="(240,3150)" to="(260,3150)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(240,270)" to="(260,270)"/>
-    <wire from="(240,590)" to="(260,590)"/>
-    <wire from="(160,1470)" to="(180,1470)"/>
-    <wire from="(100,2120)" to="(180,2120)"/>
-    <wire from="(100,3600)" to="(100,3780)"/>
-    <wire from="(310,1830)" to="(310,1890)"/>
-    <wire from="(290,3610)" to="(350,3610)"/>
-    <wire from="(140,4090)" to="(140,4230)"/>
-    <wire from="(310,760)" to="(360,760)"/>
-    <wire from="(80,1790)" to="(80,1930)"/>
-    <wire from="(120,4070)" to="(120,4210)"/>
-    <wire from="(100,4050)" to="(100,4190)"/>
-    <wire from="(80,4030)" to="(80,4170)"/>
-    <wire from="(140,2520)" to="(180,2520)"/>
-    <wire from="(240,2850)" to="(240,2880)"/>
-    <wire from="(200,3860)" to="(240,3860)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(80,930)" to="(180,930)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(230,700)" to="(260,700)"/>
-    <wire from="(200,2270)" to="(230,2270)"/>
-    <wire from="(200,2590)" to="(230,2590)"/>
-    <wire from="(230,4220)" to="(260,4220)"/>
-    <wire from="(240,2000)" to="(260,2000)"/>
-    <wire from="(290,1410)" to="(310,1410)"/>
-    <wire from="(120,2150)" to="(120,2330)"/>
-    <wire from="(320,2990)" to="(320,3180)"/>
-    <wire from="(310,680)" to="(310,740)"/>
-    <wire from="(200,3330)" to="(260,3330)"/>
-    <wire from="(80,2880)" to="(80,3010)"/>
-    <wire from="(100,2900)" to="(100,3030)"/>
-    <wire from="(120,2920)" to="(120,3050)"/>
-    <wire from="(140,2940)" to="(140,3070)"/>
-    <wire from="(160,2960)" to="(160,3090)"/>
-    <wire from="(360,4130)" to="(420,4130)"/>
-    <wire from="(220,80)" to="(220,90)"/>
-    <wire from="(60,1340)" to="(180,1340)"/>
-    <wire from="(60,3260)" to="(180,3260)"/>
-    <wire from="(160,3980)" to="(160,4250)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(220,2320)" to="(220,2330)"/>
-    <wire from="(220,2640)" to="(220,2650)"/>
-    <wire from="(230,3290)" to="(230,3300)"/>
-    <wire from="(230,1370)" to="(230,1390)"/>
-    <wire from="(230,2650)" to="(230,2670)"/>
-    <wire from="(240,2660)" to="(240,2680)"/>
-    <wire from="(230,90)" to="(230,110)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(230,410)" to="(230,430)"/>
-    <wire from="(60,620)" to="(60,770)"/>
-    <wire from="(230,2330)" to="(230,2360)"/>
-    <wire from="(240,2980)" to="(240,3010)"/>
-    <wire from="(200,2390)" to="(240,2390)"/>
-    <wire from="(200,800)" to="(230,800)"/>
-    <wire from="(60,1900)" to="(60,2060)"/>
-    <wire from="(100,2750)" to="(260,2750)"/>
-    <wire from="(140,490)" to="(230,490)"/>
-    <wire from="(140,1450)" to="(230,1450)"/>
-    <wire from="(230,2110)" to="(260,2110)"/>
-    <wire from="(200,3360)" to="(230,3360)"/>
-    <wire from="(240,2450)" to="(260,2450)"/>
-    <wire from="(310,4120)" to="(330,4120)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(320,560)" to="(320,730)"/>
-    <wire from="(240,530)" to="(260,530)"/>
-    <wire from="(160,1160)" to="(240,1160)"/>
-    <wire from="(240,2340)" to="(240,2390)"/>
-    <wire from="(290,3930)" to="(420,3930)"/>
-    <wire from="(290,1690)" to="(420,1690)"/>
-    <wire from="(200,3780)" to="(260,3780)"/>
-    <wire from="(320,2950)" to="(370,2950)"/>
-    <wire from="(230,2780)" to="(230,2790)"/>
-    <wire from="(80,3010)" to="(80,3150)"/>
-    <wire from="(100,3030)" to="(100,3170)"/>
-    <wire from="(120,3050)" to="(120,3190)"/>
-    <wire from="(230,4060)" to="(230,4070)"/>
-    <wire from="(240,4070)" to="(240,4090)"/>
-    <wire from="(140,3070)" to="(140,3220)"/>
-    <wire from="(160,3090)" to="(160,3240)"/>
-    <wire from="(140,860)" to="(180,860)"/>
-    <wire from="(240,2790)" to="(240,2820)"/>
-    <wire from="(220,1580)" to="(260,1580)"/>
-    <wire from="(220,3500)" to="(260,3500)"/>
-    <wire from="(80,3750)" to="(180,3750)"/>
-    <wire from="(230,320)" to="(260,320)"/>
-    <wire from="(200,930)" to="(230,930)"/>
-    <wire from="(230,3200)" to="(260,3200)"/>
-    <wire from="(240,1940)" to="(260,1940)"/>
-    <wire from="(160,2820)" to="(180,2820)"/>
-    <wire from="(120,2920)" to="(260,2920)"/>
-    <wire from="(100,1560)" to="(100,1680)"/>
-    <wire from="(310,4140)" to="(310,4200)"/>
-    <wire from="(100,3480)" to="(100,3600)"/>
-    <wire from="(160,1620)" to="(160,1740)"/>
-    <wire from="(120,310)" to="(180,310)"/>
-    <wire from="(120,1590)" to="(180,1590)"/>
-    <wire from="(330,3000)" to="(330,3320)"/>
-    <wire from="(120,3190)" to="(180,3190)"/>
-    <wire from="(120,3510)" to="(180,3510)"/>
-    <wire from="(40,300)" to="(160,300)"/>
-    <wire from="(60,2240)" to="(180,2240)"/>
-    <wire from="(60,390)" to="(240,390)"/>
-    <wire from="(60,3120)" to="(60,3260)"/>
-    <wire from="(230,2270)" to="(230,2290)"/>
-    <wire from="(230,2590)" to="(230,2610)"/>
-    <wire from="(240,3560)" to="(240,3580)"/>
-    <wire from="(160,3540)" to="(160,3690)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(60,240)" to="(60,390)"/>
-    <wire from="(200,4250)" to="(240,4250)"/>
-    <wire from="(100,1090)" to="(260,1090)"/>
-    <wire from="(140,110)" to="(230,110)"/>
-    <wire from="(140,2670)" to="(230,2670)"/>
-    <wire from="(200,3630)" to="(220,3630)"/>
-    <wire from="(200,3950)" to="(220,3950)"/>
-    <wire from="(140,1280)" to="(140,1450)"/>
-    <wire from="(310,1500)" to="(330,1500)"/>
-    <wire from="(240,3350)" to="(260,3350)"/>
-    <wire from="(240,150)" to="(260,150)"/>
-    <wire from="(200,1710)" to="(220,1710)"/>
-    <wire from="(100,1680)" to="(180,1680)"/>
-    <wire from="(160,1740)" to="(240,1740)"/>
-    <wire from="(100,3600)" to="(180,3600)"/>
-    <wire from="(100,3920)" to="(180,3920)"/>
-    <wire from="(160,3980)" to="(240,3980)"/>
-    <wire from="(120,3950)" to="(120,4070)"/>
-    <wire from="(140,3970)" to="(140,4090)"/>
-    <wire from="(200,2120)" to="(260,2120)"/>
-    <wire from="(120,1710)" to="(120,1840)"/>
-    <wire from="(140,1730)" to="(140,1860)"/>
-    <wire from="(60,770)" to="(180,770)"/>
-    <wire from="(230,800)" to="(230,810)"/>
-    <wire from="(290,300)" to="(340,300)"/>
-    <wire from="(230,1120)" to="(230,1140)"/>
-    <wire from="(240,1130)" to="(240,1160)"/>
-    <wire from="(200,1180)" to="(240,1180)"/>
-    <wire from="(200,1500)" to="(240,1500)"/>
-    <wire from="(140,3360)" to="(180,3360)"/>
-    <wire from="(200,3420)" to="(240,3420)"/>
-    <wire from="(80,2090)" to="(180,2090)"/>
-    <wire from="(80,2730)" to="(180,2730)"/>
-    <wire from="(230,580)" to="(260,580)"/>
-    <wire from="(160,2390)" to="(160,2550)"/>
-    <wire from="(350,2310)" to="(350,2920)"/>
-    <wire from="(340,2930)" to="(370,2930)"/>
-    <wire from="(290,960)" to="(320,960)"/>
-    <wire from="(230,1220)" to="(260,1220)"/>
-    <wire from="(230,2500)" to="(260,2500)"/>
-    <wire from="(200,2790)" to="(230,2790)"/>
-    <wire from="(200,3750)" to="(230,3750)"/>
-    <wire from="(120,3630)" to="(120,3800)"/>
-    <wire from="(120,570)" to="(180,570)"/>
-    <wire from="(200,970)" to="(260,970)"/>
-    <wire from="(120,2490)" to="(180,2490)"/>
-    <wire from="(60,900)" to="(180,900)"/>
-    <wire from="(230,930)" to="(230,940)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(60,2570)" to="(240,2570)"/>
-    <wire from="(100,1820)" to="(100,1960)"/>
-    <wire from="(120,1840)" to="(120,1980)"/>
-    <wire from="(160,600)" to="(160,740)"/>
-    <wire from="(230,3810)" to="(230,3820)"/>
-    <wire from="(140,1860)" to="(140,2000)"/>
-    <wire from="(240,3820)" to="(240,3840)"/>
-    <wire from="(60,2420)" to="(60,2570)"/>
-    <wire from="(160,1880)" to="(160,2030)"/>
-    <wire from="(200,1310)" to="(240,1310)"/>
-    <wire from="(240,4140)" to="(240,4170)"/>
-    <wire from="(240,620)" to="(240,650)"/>
-    <wire from="(290,3320)" to="(330,3320)"/>
-    <wire from="(230,1670)" to="(260,1670)"/>
-    <wire from="(230,1990)" to="(260,1990)"/>
-    <wire from="(340,3010)" to="(340,3490)"/>
-    <wire from="(230,3590)" to="(260,3590)"/>
-    <wire from="(230,3910)" to="(260,3910)"/>
-    <wire from="(240,3290)" to="(260,3290)"/>
-    <wire from="(80,3580)" to="(230,3580)"/>
-    <wire from="(240,1900)" to="(240,1940)"/>
-    <wire from="(160,2960)" to="(240,2960)"/>
-    <wire from="(140,2180)" to="(140,2360)"/>
-    <wire from="(360,1900)" to="(420,1900)"/>
-    <wire from="(290,2480)" to="(340,2480)"/>
-    <wire from="(160,220)" to="(160,300)"/>
-    <wire from="(120,690)" to="(120,840)"/>
-    <wire from="(140,710)" to="(140,860)"/>
-    <wire from="(80,650)" to="(80,800)"/>
-    <wire from="(100,670)" to="(100,820)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(200,4000)" to="(240,4000)"/>
-    <wire from="(80,1070)" to="(180,1070)"/>
-    <wire from="(230,200)" to="(260,200)"/>
-    <wire from="(80,1930)" to="(80,2090)"/>
-    <wire from="(200,2090)" to="(230,2090)"/>
-    <wire from="(200,2730)" to="(230,2730)"/>
-    <wire from="(230,4040)" to="(260,4040)"/>
-    <wire from="(240,860)" to="(260,860)"/>
-    <wire from="(310,1890)" to="(330,1890)"/>
-    <wire from="(120,1840)" to="(260,1840)"/>
-    <comp lib="0" loc="(420,1690)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoReg"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1900)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2590)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(390,750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="1" loc="(290,3930)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2130)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,2970)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWrite"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(400,2970)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(290,4200)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2630)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Jump"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,4130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ZeroExtend"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4050)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="0" loc="(420,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWrite"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(360,4130)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1100)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2760)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,750)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrc"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,2130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegDst"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2480)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1490)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1590)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,3930)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJAL"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,3790)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneBeq"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2910)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,1900)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Branch"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,3790)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,300)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1240)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,300)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3920)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,960)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,3180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,70)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemRead"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(1309,1055)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
+    </comp>
+    <comp loc="(1080,130)" name="ID/EX"/>
   </circuit>
   <circuit name="Syscall_Decoder">
     <a name="circuit" val="Syscall_Decoder"/>
@@ -5925,27 +1457,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(480,290)" to="(480,320)"/>
     <wire from="(170,440)" to="(300,440)"/>
     <wire from="(640,420)" to="(650,420)"/>
-    <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
-    <comp lib="0" loc="(440,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(310,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(500,270)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
     <comp lib="0" loc="(480,320)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(270,460)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0xa"/>
-    </comp>
-    <comp lib="0" loc="(510,480)" name="Tunnel">
+    <comp lib="0" loc="(470,130)" name="Tunnel">
       <a name="label" val="Enable"/>
     </comp>
     <comp lib="0" loc="(420,270)" name="Pin">
@@ -5953,10 +1469,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="a0"/>
     </comp>
-    <comp lib="0" loc="(470,130)" name="Tunnel">
+    <comp lib="0" loc="(440,130)" name="Pin">
+      <a name="tristate" val="false"/>
       <a name="label" val="Enable"/>
     </comp>
-    <comp lib="0" loc="(320,130)" name="Tunnel">
+    <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
+    <comp lib="0" loc="(470,430)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(580,420)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(650,420)" name="Pin">
@@ -5965,23 +1487,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Halt"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(470,430)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(170,440)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="3" loc="(340,450)" name="Comparator">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(580,420)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
     <comp lib="2" loc="(510,440)" name="Multiplexer">
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(500,270)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(310,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(660,270)" name="Pin">
       <a name="facing" val="west"/>
@@ -5990,8 +1504,26 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Hex"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(270,460)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0xa"/>
+    </comp>
+    <comp lib="0" loc="(170,440)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="v0"/>
+    </comp>
     <comp lib="0" loc="(440,320)" name="Tunnel">
       <a name="facing" val="north"/>
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(320,130)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="3" loc="(340,450)" name="Comparator">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(510,480)" name="Tunnel">
       <a name="label" val="Enable"/>
     </comp>
   </circuit>
@@ -6379,47 +1911,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(80,1450)" to="(80,1630)"/>
     <wire from="(120,320)" to="(260,320)"/>
     <wire from="(120,1330)" to="(120,1510)"/>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
+    <comp lib="1" loc="(200,300)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
+    <comp lib="1" loc="(200,90)" name="NOT Gate">
       <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(290,1180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,880)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
     </comp>
     <comp lib="0" loc="(420,670)" name="Pin">
       <a name="facing" val="west"/>
@@ -6427,81 +1923,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="i"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
+    <comp lib="0" loc="(40,30)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
+      <a name="label" val="op0"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,660)" name="NOT Gate">
+    <comp lib="1" loc="(200,380)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(420,1750)" name="Pin">
@@ -6510,126 +1937,206 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="j"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
+    <comp lib="1" loc="(200,1540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,180)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
+    <comp lib="1" loc="(200,410)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
+    <comp lib="1" loc="(200,570)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(290,750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,480)" name="NOT Gate">
+    <comp lib="1" loc="(200,1850)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(200,190)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
+    <comp lib="1" loc="(200,660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1490)" name="AND Gate">
+    <comp lib="1" loc="(290,600)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(360,1750)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,1600)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,140)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="op2"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="0" loc="(40,190)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="op3"/>
       <a name="labelloc" val="north"/>
     </comp>
+    <comp lib="1" loc="(200,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(200,1820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
+    <comp lib="1" loc="(200,820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1450)" name="NOT Gate">
+    <comp lib="1" loc="(200,780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
+    <comp lib="0" loc="(40,250)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
+      <a name="label" val="op4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(290,1320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,890)" name="NOT Gate">
+    <comp lib="1" loc="(200,270)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(400,670)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="10"/>
     </comp>
-    <comp lib="1" loc="(200,630)" name="NOT Gate">
+    <comp lib="1" loc="(200,60)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,70)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1570)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(290,1830)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,1390)" name="NOT Gate">
+    <comp lib="1" loc="(290,310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1630)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1730)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,30)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,890)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
     <comp lib="0" loc="(420,1490)" name="Pin">
       <a name="facing" val="west"/>
@@ -6637,16 +2144,41 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="r"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,510)" name="NOT Gate">
+    <comp lib="0" loc="(40,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,990)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
+    <comp lib="1" loc="(200,930)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,820)" name="NOT Gate">
+    <comp lib="1" loc="(200,1290)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,780)" name="NOT Gate">
+    <comp lib="1" loc="(200,1090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,880)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1480)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
   </circuit>
@@ -6686,28 +2218,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(310,470)" to="(350,470)"/>
     <wire from="(370,520)" to="(570,520)"/>
     <wire from="(370,420)" to="(570,420)"/>
-    <comp lib="0" loc="(410,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="InstID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(310,470)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
     <comp lib="0" loc="(310,370)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="InstIF"/>
     </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
+    <comp lib="4" loc="(380,370)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(160,350)" name="Pin">
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
+      <a name="label" val="clk"/>
       <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(410,470)" name="Pin">
@@ -6718,8 +2240,22 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlus4IF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(380,370)" name="Register">
+    <comp lib="0" loc="(410,370)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="InstID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(380,470)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(570,350)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(340,590)" name="Pin">
       <a name="facing" val="north"/>
@@ -6727,14 +2263,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(160,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
+    <comp lib="0" loc="(310,470)" name="Pin">
       <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
     </comp>
   </circuit>
   <circuit name="ID/EX">
@@ -7016,205 +2548,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(900,630)" to="(980,630)"/>
     <wire from="(900,390)" to="(980,390)"/>
     <wire from="(1230,410)" to="(1250,410)"/>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(240,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ImmEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(860,420)" name="Pin">
-      <a name="label" val="IsShamtID"/>
-    </comp>
-    <comp lib="0" loc="(240,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R2EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
-    </comp>
-    <comp lib="0" loc="(240,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R1EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
-    </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(520,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
-    </comp>
     <comp lib="0" loc="(930,600)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
-    </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
-    </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,590)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
-    </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1240,650)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopEX"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(930,540)" name="Pin">
@@ -7223,13 +2560,123 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RegWriteEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1180,470)" name="Pin">
-      <a name="label" val="BranchID"/>
+    <comp lib="0" loc="(860,780)" name="Pin">
+      <a name="label" val="MemReadID"/>
     </comp>
     <comp lib="0" loc="(930,480)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="MemtoRegEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,480)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(170,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(170,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ImmID"/>
+    </comp>
+    <comp lib="0" loc="(1180,350)" name="Pin">
+      <a name="label" val="MemWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1180,410)" name="Pin">
+      <a name="label" val="JumpID"/>
+    </comp>
+    <comp lib="4" loc="(570,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(220,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(60,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1250,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJREX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1240,650)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,470)" name="Pin">
+      <a name="label" val="BranchID"/>
+    </comp>
+    <comp lib="0" loc="(240,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R2EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="JumpEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,540)" name="Pin">
+      <a name="label" val="RegWriteID"/>
+    </comp>
+    <comp lib="4" loc="(910,720)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(520,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="4" loc="(910,780)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(910,420)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,530)" name="Pin">
+      <a name="label" val="IsJRID"/>
+    </comp>
+    <comp lib="0" loc="(240,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R1EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(520,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="JumpAddr"/>
+    </comp>
+    <comp lib="4" loc="(570,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1250,590)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallEX"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(180,640)" name="Pin">
@@ -7238,37 +2685,29 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
+    <comp lib="0" loc="(930,720)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,420)" name="Pin">
+      <a name="label" val="IsShamtID"/>
+    </comp>
+    <comp lib="0" loc="(860,480)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
+    </comp>
+    <comp lib="0" loc="(100,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(1230,710)" name="Register">
       <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="0" loc="(930,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
-      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(590,560)" name="Pin">
       <a name="facing" val="west"/>
@@ -7280,8 +2719,114 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="4" loc="(1230,350)" name="Register">
       <a name="width" val="1"/>
     </comp>
+    <comp lib="4" loc="(1230,650)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="4" loc="(910,660)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1240,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(570,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1250,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BranchEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(240,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ImmEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(920,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,660)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
+    </comp>
     <comp lib="0" loc="(860,720)" name="Pin">
       <a name="label" val="IsExceptionID"/>
+    </comp>
+    <comp lib="0" loc="(170,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2ID"/>
+    </comp>
+    <comp lib="4" loc="(910,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(910,600)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(520,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ShamtID"/>
+    </comp>
+    <comp lib="0" loc="(590,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(590,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,530)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,600)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="0" loc="(1180,590)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="4" loc="(1230,590)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,780)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,360)" name="Pin">
+      <a name="label" val="IsJALID"/>
+    </comp>
+    <comp lib="0" loc="(1180,710)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#ID"/>
+    </comp>
+    <comp lib="0" loc="(1250,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(930,660)" name="Pin">
       <a name="facing" val="west"/>
@@ -7289,25 +2834,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUSrcEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
+    <comp lib="0" loc="(1180,650)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
     </comp>
     <comp lib="4" loc="(910,540)" name="Register">
       <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
     </comp>
   </circuit>
   <circuit name="EX/MEM">
@@ -7409,11 +2941,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,360)" to="(860,390)"/>
     <wire from="(860,160)" to="(860,190)"/>
     <wire from="(560,70)" to="(980,70)"/>
+    <wire from="(870,240)" to="(890,240)"/>
+    <wire from="(470,140)" to="(560,140)"/>
     <wire from="(470,380)" to="(560,380)"/>
     <wire from="(470,260)" to="(560,260)"/>
     <wire from="(470,500)" to="(560,500)"/>
-    <wire from="(470,140)" to="(560,140)"/>
-    <wire from="(870,240)" to="(890,240)"/>
     <wire from="(640,290)" to="(850,290)"/>
     <wire from="(300,80)" to="(640,80)"/>
     <wire from="(980,190)" to="(980,290)"/>
@@ -7436,10 +2968,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(300,320)" to="(300,380)"/>
     <wire from="(300,200)" to="(300,260)"/>
     <wire from="(300,80)" to="(300,140)"/>
+    <wire from="(440,420)" to="(440,480)"/>
     <wire from="(830,250)" to="(840,250)"/>
     <wire from="(440,180)" to="(440,240)"/>
     <wire from="(440,300)" to="(440,360)"/>
-    <wire from="(440,420)" to="(440,480)"/>
     <wire from="(440,580)" to="(830,580)"/>
     <wire from="(860,390)" to="(980,390)"/>
     <wire from="(860,190)" to="(980,190)"/>
@@ -7461,63 +2993,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(430,530)" to="(450,530)"/>
     <wire from="(430,410)" to="(450,410)"/>
     <wire from="(830,350)" to="(830,580)"/>
-    <comp lib="0" loc="(890,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="4" loc="(870,340)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(350,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(500,530)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="5"/>
       <a name="label" val="WriteReg#MEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(890,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(500,290)" name="Pin">
@@ -7526,27 +3013,17 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsExceptionMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,170)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="4" loc="(480,530)" name="Register">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
+    <comp lib="4" loc="(480,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,470)" name="Pin">
+      <a name="label" val="IsSyscallEX"/>
+    </comp>
+    <comp lib="0" loc="(430,350)" name="Pin">
+      <a name="label" val="MemReadEX"/>
     </comp>
     <comp lib="0" loc="(500,170)" name="Pin">
       <a name="facing" val="west"/>
@@ -7554,36 +3031,33 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemtoRegMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Pin">
+    <comp lib="0" loc="(500,470)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="MemReadMEM"/>
+      <a name="label" val="IsSyscallMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(500,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
+    <comp lib="4" loc="(480,290)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
+    <comp lib="4" loc="(870,340)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(820,240)" name="Pin">
       <a name="width" val="32"/>
       <a name="label" val="WriteDataEX"/>
     </comp>
-    <comp lib="0" loc="(500,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALMEM"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(430,170)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
+    </comp>
+    <comp lib="0" loc="(430,230)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(480,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,290)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
     </comp>
     <comp lib="0" loc="(440,590)" name="Pin">
       <a name="facing" val="north"/>
@@ -7591,34 +3065,92 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
+    <comp lib="0" loc="(890,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
+    <comp lib="4" loc="(480,110)" name="Register">
+      <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
+    <comp lib="0" loc="(350,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(480,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(300,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(430,410)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
     </comp>
     <comp lib="0" loc="(430,530)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="WriteReg#EX"/>
     </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
+    <comp lib="0" loc="(500,230)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
+      <a name="label" val="RegWriteMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
+    <comp lib="0" loc="(820,340)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrEX"/>
     </comp>
     <comp lib="4" loc="(870,140)" name="Register">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(890,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(820,140)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="4" loc="(480,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,110)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="4" loc="(870,240)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,170)" name="Register">
+      <a name="width" val="1"/>
     </comp>
   </circuit>
   <circuit name="MEM/WB">
@@ -7748,68 +3280,36 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(250,290)" to="(390,290)"/>
     <wire from="(290,200)" to="(490,200)"/>
     <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
+    <comp lib="0" loc="(290,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
+    <comp lib="4" loc="(410,320)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(720,500)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(360,380)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="4" loc="(410,560)" name="Register">
+      <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(720,390)" name="Pin">
       <a name="width" val="32"/>
       <a name="label" val="ReadDataMEM"/>
     </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="0" loc="(360,500)" name="Pin">
+      <a name="label" val="IsSyscallMEM"/>
     </comp>
     <comp lib="0" loc="(430,380)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="RegWriteWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(790,290)" name="Pin">
@@ -7819,14 +3319,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUResultWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(250,180)" name="Pin">
+      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(370,620)" name="Pin">
       <a name="facing" val="north"/>
@@ -7834,20 +3331,44 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(290,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="0" loc="(430,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(770,290)" name="Register">
+    <comp lib="4" loc="(410,260)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(770,390)" name="Register">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(790,390)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(410,500)" name="Register">
+      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(360,440)" name="Pin">
       <a name="label" val="IsExceptionMEM"/>
     </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(430,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,260)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
+    <comp lib="0" loc="(720,290)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
     </comp>
     <comp lib="0" loc="(430,320)" name="Pin">
       <a name="facing" val="west"/>
@@ -7855,20 +3376,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemtoRegWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
+    <comp lib="0" loc="(430,260)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(410,560)" name="Register">
+    <comp lib="4" loc="(410,440)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(360,560)" name="Pin">
       <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
-      <a name="width" val="32"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="0" loc="(790,500)" name="Pin">
       <a name="facing" val="west"/>
@@ -7877,11 +3397,23 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(430,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(770,500)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
     <comp lib="4" loc="(410,380)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="4" loc="(770,290)" name="Register">
+      <a name="width" val="32"/>
     </comp>
   </circuit>
   <circuit name="Regfile_Wrapper">
@@ -7928,20 +3460,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(240,190)" to="(280,190)"/>
     <wire from="(240,230)" to="(280,230)"/>
     <wire from="(320,90)" to="(320,180)"/>
-    <comp lib="8" loc="(370,210)" name="main"/>
-    <comp lib="0" loc="(400,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="a0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2#"/>
-    </comp>
     <comp lib="0" loc="(240,190)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
@@ -7955,11 +3473,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R1"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(350,290)" name="Pin">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(300,80)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="south"/>
+      <a name="label" val="v0"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,230)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RW"/>
     </comp>
     <comp lib="0" loc="(400,260)" name="Pin">
       <a name="facing" val="west"/>
@@ -7969,13 +3494,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R2"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(300,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(300,350)" name="Pin">
+      <a name="facing" val="north"/>
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="v0"/>
-      <a name="labelloc" val="east"/>
+      <a name="label" val="Din"/>
     </comp>
     <comp lib="0" loc="(320,290)" name="Pin">
       <a name="facing" val="north"/>
@@ -7983,16 +3506,25 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="WE"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(240,230)" name="Pin">
+    <comp lib="0" loc="(350,290)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="8" loc="(370,210)" name="main"/>
+    <comp lib="0" loc="(240,210)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="RW"/>
+      <a name="label" val="R2#"/>
     </comp>
-    <comp lib="0" loc="(300,350)" name="Pin">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(400,80)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
+      <a name="label" val="a0"/>
+      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="ALU_Wrapper">
@@ -8028,12 +3560,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(670,430)" to="(750,430)"/>
     <wire from="(630,490)" to="(630,540)"/>
     <wire from="(650,480)" to="(650,500)"/>
-    <comp lib="0" loc="(630,540)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="AluOP"/>
-      <a name="labelloc" val="south"/>
+    <comp lib="0" loc="(750,430)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="7" loc="(640,440)" name="ALU"/>
     <comp lib="0" loc="(560,480)" name="Pin">
@@ -8046,18 +3578,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="X"/>
     </comp>
-    <comp lib="0" loc="(750,430)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(680,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="Equal"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(630,540)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="AluOP"/>
+      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="Immediate_Extend">
@@ -8087,6 +3619,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(560,280)" to="(560,310)"/>
     <wire from="(410,300)" to="(410,330)"/>
     <wire from="(490,340)" to="(490,370)"/>
+    <comp lib="0" loc="(480,370)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(380,330)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Input"/>
+    </comp>
     <comp lib="0" loc="(480,300)" name="Bit Extender">
       <a name="in_width" val="16"/>
       <a name="out_width" val="32"/>
@@ -8101,15 +3642,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
       <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(480,370)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(380,330)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Input"/>
     </comp>
     <comp lib="0" loc="(630,330)" name="Pin">
       <a name="facing" val="west"/>
@@ -8240,18 +3772,24 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,390)" to="(610,390)"/>
     <wire from="(600,470)" to="(610,470)"/>
     <wire from="(600,510)" to="(610,510)"/>
-    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
-    <comp lib="0" loc="(1100,440)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(600,350)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(410,300)" name="Constant">
+    <comp lib="3" loc="(470,390)" name="Comparator">
       <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(320,460)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(820,390)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteEX"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="3" loc="(470,430)" name="Comparator">
+      <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(1060,340)" name="Pin">
       <a name="facing" val="west"/>
@@ -8259,17 +3797,37 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="StallID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(660,490)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(470,310)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="1" loc="(740,450)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
     <comp lib="3" loc="(470,350)" name="Comparator">
       <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(540,270)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(820,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(510,270)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(50,300)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RT"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1060,300)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="StallIF"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(140,300)" name="Pin">
       <a name="facing" val="south"/>
@@ -8278,34 +3836,108 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RS"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(410,420)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(730,150)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
     </comp>
-    <comp lib="1" loc="(980,320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
+    <comp lib="0" loc="(1030,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(730,130)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(320,340)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="3" loc="(470,430)" name="Comparator">
+    <comp lib="0" loc="(410,300)" name="Constant">
       <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(320,460)" name="Pin">
-      <a name="width" val="5"/>
+    <comp lib="1" loc="(660,370)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1100,440)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(980,320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(340,130)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(730,150)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
+    <comp lib="1" loc="(600,510)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(600,390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(1120,400)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="3" loc="(470,310)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
+    <comp lib="1" loc="(920,120)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate0" val="true"/>
     </comp>
     <comp lib="0" loc="(380,130)" name="Tunnel">
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="3" loc="(470,390)" name="Comparator">
+    <comp lib="1" loc="(600,470)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(870,320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
+    <comp lib="1" loc="(870,400)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(410,420)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(930,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(740,450)" name="AND Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1190,230)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(760,330)" name="AND Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1210,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="3" loc="(470,510)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(1180,400)" name="Pin">
@@ -8315,115 +3947,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="BubbleNum"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(820,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(600,470)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(870,400)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(920,120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate0" val="true"/>
-    </comp>
-    <comp lib="0" loc="(820,390)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(760,330)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(600,510)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1210,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1120,400)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(510,270)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(540,270)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(50,300)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RT"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1030,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(340,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(870,320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
     <comp lib="3" loc="(470,470)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
-    <comp lib="0" loc="(1060,300)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(600,390)" name="AND Gate">
+    <comp lib="1" loc="(600,350)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(1190,230)" name="AND Gate">
-      <a name="size" val="30"/>
+    <comp lib="1" loc="(660,490)" name="OR Gate">
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(930,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(660,370)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(470,510)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(730,130)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
     </comp>
   </circuit>
   <circuit name="Hazard_Detector">
@@ -9399,234 +4931,33 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(100,2410)" to="(490,2410)"/>
     <wire from="(160,2470)" to="(550,2470)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,250)" name="AND Gate">
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(730,1960)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(600,2020)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
       <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,3640)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,530)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(510,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(730,4470)" name="Pin">
@@ -9635,101 +4966,52 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ReadRt"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,2450)" name="NOT Gate">
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(510,2140)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(710,1960)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="10"/>
     </comp>
-    <comp lib="1" loc="(510,2560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,3500)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(690,4470)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,30)" name="Pin">
@@ -9737,222 +5019,245 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op0"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,580)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="Funct5"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,2100)" name="NOT Gate">
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2600)" name="NOT Gate">
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,2910)" name="NOT Gate">
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
       <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
     </comp>
     <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,210)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2420)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,830)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="9"/>
-    </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,1290)" name="AND Gate">
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2130)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4470)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,430)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+      <a name="inputs" val="7"/>
     </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(600,1750)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,250)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,2410)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,4540)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+    <comp lib="1" loc="(510,2600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -9960,55 +5265,129 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,910)" name="NOT Gate">
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,2630)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,2720)" name="NOT Gate">
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(600,2550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(600,2260)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(600,2130)" name="AND Gate">
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,230)" name="Pin">
@@ -10016,14 +5395,167 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,530)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,1620)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2450)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
   </circuit>
 </project>

--- a/src/single_cycle_cpu.circ
+++ b/src/single_cycle_cpu.circ
@@ -97,6 +97,7 @@
   </lib>
   <lib desc="file#common/alu.circ" name="7"/>
   <lib desc="file#common/regfile.circ" name="8"/>
+  <lib desc="file#common/control.circ" name="9"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -276,7 +277,6 @@
     <wire from="(750,1020)" to="(760,1020)"/>
     <wire from="(280,140)" to="(350,140)"/>
     <wire from="(1100,380)" to="(1340,380)"/>
-    <wire from="(660,460)" to="(660,470)"/>
     <wire from="(1460,330)" to="(1460,410)"/>
     <wire from="(850,570)" to="(850,580)"/>
     <wire from="(40,920)" to="(610,920)"/>
@@ -325,7 +325,6 @@
     <wire from="(790,670)" to="(810,670)"/>
     <wire from="(630,510)" to="(650,510)"/>
     <wire from="(600,240)" to="(620,240)"/>
-    <wire from="(660,460)" to="(680,460)"/>
     <wire from="(650,360)" to="(680,360)"/>
     <wire from="(650,440)" to="(680,440)"/>
     <wire from="(570,80)" to="(570,240)"/>
@@ -337,7 +336,7 @@
     <wire from="(690,130)" to="(1230,130)"/>
     <wire from="(360,210)" to="(510,210)"/>
     <wire from="(330,540)" to="(340,540)"/>
-    <wire from="(650,460)" to="(660,460)"/>
+    <wire from="(690,500)" to="(700,500)"/>
     <wire from="(720,530)" to="(730,530)"/>
     <wire from="(310,270)" to="(380,270)"/>
     <wire from="(580,790)" to="(590,790)"/>
@@ -397,6 +396,7 @@
     <wire from="(1350,220)" to="(1360,220)"/>
     <wire from="(1340,330)" to="(1340,380)"/>
     <wire from="(650,380)" to="(680,380)"/>
+    <wire from="(650,460)" to="(680,460)"/>
     <wire from="(1280,140)" to="(1350,140)"/>
     <wire from="(340,480)" to="(360,480)"/>
     <wire from="(590,320)" to="(620,320)"/>
@@ -420,196 +420,16 @@
     <wire from="(830,620)" to="(830,670)"/>
     <wire from="(40,40)" to="(40,550)"/>
     <wire from="(560,550)" to="(570,550)"/>
-    <comp lib="0" loc="(1290,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(690,990)" name="Tunnel">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(1550,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="2" loc="(140,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(220,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
     <comp lib="4" loc="(180,200)" name="Counter">
       <a name="width" val="32"/>
       <a name="max" val="0xffffffff"/>
       <a name="label" val="Cycle"/>
     </comp>
-    <comp lib="8" loc="(870,540)" name="main"/>
-    <comp lib="0" loc="(110,750)" name="Tunnel">
+    <comp lib="0" loc="(1350,770)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="IsCOP0"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(1440,200)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp loc="(540,210)" name="Statistics"/>
-    <comp lib="2" loc="(300,550)" name="Demultiplexer">
-      <a name="width" val="9"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(190,650)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,620)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="0" loc="(660,840)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="1" loc="(1440,160)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(630,840)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="1" loc="(120,580)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(380,280)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(720,960)" name="Tunnel">
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(660,600)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="0" loc="(1300,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(1340,520)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1020,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(730,740)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(680,440)" name="Tunnel">
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(1390,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(1060,790)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(560,220)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="4" loc="(330,190)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(280,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(680,180)" name="Tunnel">
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="0" loc="(580,240)" name="Splitter">
+    <comp lib="0" loc="(570,550)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -629,211 +449,11 @@
       <a name="bit13" val="none"/>
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="5" loc="(1180,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(60,750)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(1250,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(680,320)" name="Tunnel">
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="5" loc="(1340,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="2" loc="(790,720)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(800,890)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(1040,320)" name="Syscall_Decoder"/>
-    <comp lib="0" loc="(720,860)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="4" loc="(500,610)" name="ROM">
-      <a name="addrWidth" val="9"/>
-      <a name="dataWidth" val="32"/>
-      <a name="contents">addr/data: 9 32
-201a0001 409a0800 201c0040 39df020 401a0000 afda0000 23de0004 23bd0004
-afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
-23de0004 afd60000 23bd0004 23de0004 afc40000 23bd0004 23de0004 afc20000
-23bd0004 23de0004 40161000 22d60001 201a0000 409a0800 20140005 20150001
-168020 102020 20020022 c 108100 1600fffb 295a022 1680fff8
-201a0001 409a0800 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc 8fc40000
-23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc 23bdfffc
-8fd40000 23defffc 23bdfffc 8fd00000 23defffc 23bdfffc 8fda0000 409a0000
-201a0000 409a0800 42000018
-</a>
-    </comp>
-    <comp lib="0" loc="(870,580)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(90,1040)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="1" loc="(660,500)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(720,530)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(130,630)" name="Tunnel">
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(110,1010)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(570,80)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
       <a name="bit16" val="0"/>
       <a name="bit17" val="0"/>
       <a name="bit18" val="0"/>
       <a name="bit19" val="0"/>
       <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(690,130)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1350,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(1100,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="2" loc="(80,990)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(700,70)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(1380,130)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(570,720)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
       <a name="bit21" val="none"/>
       <a name="bit22" val="none"/>
       <a name="bit23" val="none"/>
@@ -846,200 +466,16 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(680,240)" name="Tunnel">
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(1070,310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(90,510)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x800"/>
-    </comp>
-    <comp lib="1" loc="(1180,230)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(730,700)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-      <a name="type" val="sign"/>
-    </comp>
-    <comp lib="0" loc="(810,740)" name="Tunnel">
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(690,840)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="1" loc="(160,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1230,610)" name="Tunnel">
+    <comp lib="2" loc="(190,650)" name="Multiplexer">
       <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-    </comp>
-    <comp lib="0" loc="(1250,580)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Equal"/>
-    </comp>
-    <comp lib="2" loc="(630,580)" name="Multiplexer">
-      <a name="width" val="5"/>
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(570,530)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(480,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="5" loc="(1380,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(1250,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="5" loc="(1350,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(570,940)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(1120,240)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="BneOrBeq"/>
     </comp>
-    <comp lib="4" loc="(210,550)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="2" loc="(1610,130)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1120,220)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Equal"/>
-    </comp>
-    <comp lib="0" loc="(600,970)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(280,660)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(850,610)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(1430,560)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(700,590)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(790,1020)" name="NOT Gate"/>
-    <comp lib="2" loc="(1460,120)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,260)" name="Tunnel">
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(750,1020)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="2" loc="(1570,510)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(610,870)" name="CP0"/>
-    <comp lib="0" loc="(160,240)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(760,540)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
+    <comp lib="5" loc="(1300,760)" name="Button">
+      <a name="facing" val="south"/>
     </comp>
     <comp lib="4" loc="(500,480)" name="ROM">
       <a name="addrWidth" val="9"/>
@@ -1089,24 +525,267 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="0" loc="(80,980)" name="Tunnel">
+    <comp lib="5" loc="(1350,760)" name="Button">
       <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(680,420)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="4" loc="(430,890)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC Buffer"/>
-    </comp>
-    <comp lib="0" loc="(680,220)" name="Tunnel">
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="2" loc="(820,590)" name="Multiplexer">
+    <comp lib="2" loc="(80,990)" name="Multiplexer">
       <a name="facing" val="north"/>
       <a name="selloc" val="tr"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(700,590)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(570,320)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="1" loc="(200,690)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(680,280)" name="Tunnel">
+      <a name="label" val="IsJR"/>
+    </comp>
+    <comp lib="0" loc="(1020,410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(110,1010)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(720,960)" name="Tunnel">
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="4" loc="(330,190)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(870,580)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1250,580)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="2" loc="(140,550)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(790,720)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(810,740)" name="Tunnel">
+      <a name="label" val="ZeroExtend"/>
+    </comp>
+    <comp lib="0" loc="(730,700)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
+      <a name="type" val="sign"/>
+    </comp>
+    <comp lib="1" loc="(120,580)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(840,670)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(650,1010)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(180,750)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(910,910)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(130,630)" name="Tunnel">
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(1120,220)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="9" loc="(620,140)" name="Control"/>
+    <comp lib="2" loc="(630,580)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1160,530)" name="Tunnel">
+      <a name="label" val="IsShamt"/>
+    </comp>
+    <comp lib="0" loc="(570,80)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(580,240)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1230,610)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ALUop"/>
+    </comp>
+    <comp lib="0" loc="(280,660)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(680,340)" name="Tunnel">
+      <a name="label" val="Jump"/>
+    </comp>
+    <comp lib="0" loc="(370,1050)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="2" loc="(1570,510)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1300,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(690,840)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(480,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(570,790)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1145,49 +824,9 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(680,460)" name="Tunnel">
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="4" loc="(1500,520)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="2" loc="(810,1000)" name="Multiplexer">
-      <a name="facing" val="north"/>
+    <comp lib="4" loc="(470,160)" name="Counter">
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(1260,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="1" loc="(1350,220)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1170,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="3" loc="(390,130)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1070,440)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(840,670)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(680,300)" name="Tunnel">
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(680,160)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
     <comp lib="0" loc="(410,320)" name="Probe">
       <a name="facing" val="north"/>
@@ -1195,25 +834,95 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(320,120)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="2" loc="(1120,560)" name="Multiplexer">
+    <comp lib="2" loc="(1170,490)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(680,260)" name="Tunnel">
+      <a name="label" val="MemRead"/>
+    </comp>
+    <comp lib="2" loc="(300,550)" name="Demultiplexer">
+      <a name="width" val="9"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(680,300)" name="Tunnel">
+      <a name="label" val="Branch"/>
+    </comp>
+    <comp lib="0" loc="(630,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(700,70)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(680,400)" name="Tunnel">
+      <a name="label" val="IsShamt"/>
+    </comp>
+    <comp lib="4" loc="(210,550)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="1" loc="(790,1020)" name="NOT Gate"/>
+    <comp lib="0" loc="(220,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1440,200)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="Jump"/>
+    </comp>
+    <comp lib="2" loc="(560,550)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="7" loc="(1240,530)" name="ALU"/>
+    <comp lib="5" loc="(1380,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(820,590)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(410,950)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="2" loc="(90,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1440,160)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(680,420)" name="Tunnel">
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="5" loc="(1220,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(680,440)" name="Tunnel">
+      <a name="label" val="RegDst"/>
+    </comp>
+    <comp lib="0" loc="(680,200)" name="Tunnel">
+      <a name="label" val="MemtoReg"/>
     </comp>
     <comp lib="0" loc="(610,640)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="RegDst"/>
     </comp>
-    <comp lib="0" loc="(680,360)" name="Tunnel">
-      <a name="label" val="BneOrBeq"/>
+    <comp lib="0" loc="(1390,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemWrite"/>
     </comp>
-    <comp lib="3" loc="(1280,140)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="2" loc="(1170,490)" name="Multiplexer">
+    <comp lib="2" loc="(1610,130)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
@@ -1254,112 +963,13 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(680,400)" name="Tunnel">
-      <a name="label" val="IsJR"/>
+    <comp lib="0" loc="(680,180)" name="Tunnel">
+      <a name="label" val="RegWrite"/>
     </comp>
-    <comp lib="4" loc="(470,160)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
+    <comp lib="0" loc="(680,460)" name="Tunnel">
+      <a name="label" val="ZeroExtend"/>
     </comp>
-    <comp lib="0" loc="(650,1010)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="5" loc="(1460,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(1420,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="4" loc="(400,180)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="3" loc="(1180,150)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="5" loc="(1300,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1120,160)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(680,280)" name="Tunnel">
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(340,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="1" loc="(70,700)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(680,340)" name="Tunnel">
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="2" loc="(560,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(70,1040)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(180,750)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="5" loc="(1300,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(1220,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="7" loc="(1240,530)" name="ALU"/>
-    <comp lib="1" loc="(740,580)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1450,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(910,910)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(740,620)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(370,1050)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(1590,200)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="0" loc="(680,200)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="3" loc="(430,1040)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp loc="(620,140)" name="Control">
-      <a name="labelfont" val="Dialog plain 16"/>
-    </comp>
-    <comp lib="0" loc="(570,320)" name="Splitter">
+    <comp lib="0" loc="(570,720)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -1368,11 +978,196 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit3" val="0"/>
       <a name="bit4" val="0"/>
       <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1460,120)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(680,620)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="0" loc="(600,970)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="4" loc="(500,610)" name="ROM">
+      <a name="addrWidth" val="9"/>
+      <a name="dataWidth" val="32"/>
+      <a name="contents">addr/data: 9 32
+201a0001 409a0800 201c0040 39df020 401a0000 afda0000 23de0004 23bd0004
+afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
+23de0004 afd60000 23bd0004 23de0004 afc40000 23bd0004 23de0004 afc20000
+23bd0004 23de0004 40161000 22d60001 201a0000 409a0800 20140005 20150001
+168020 102020 20020022 c 108100 1600fffb 295a022 1680fff8
+201a0001 409a0800 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc 8fc40000
+23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc 23bdfffc
+8fd40000 23defffc 23bdfffc 8fd00000 23defffc 23bdfffc 8fda0000 409a0000
+201a0000 409a0800 42000018
+</a>
+    </comp>
+    <comp lib="1" loc="(860,910)" name="NOT Gate">
+      <a name="facing" val="west"/>
+    </comp>
+    <comp lib="2" loc="(1120,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(1040,320)" name="Syscall_Decoder"/>
+    <comp loc="(610,870)" name="CP0"/>
+    <comp lib="0" loc="(570,940)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(400,180)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(680,220)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="8" loc="(870,540)" name="main"/>
+    <comp lib="1" loc="(660,500)" name="NOT Gate">
+      <a name="facing" val="west"/>
+    </comp>
+    <comp lib="0" loc="(790,670)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="0" loc="(750,1020)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="3" loc="(1280,140)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1340,520)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(660,840)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="5" loc="(1460,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(160,240)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(430,890)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC Buffer"/>
+    </comp>
+    <comp lib="3" loc="(430,1040)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(80,980)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1450,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemRead"/>
+    </comp>
+    <comp lib="0" loc="(720,530)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="1" loc="(70,700)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(680,360)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUop"/>
+    </comp>
+    <comp lib="0" loc="(1120,160)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(1060,790)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(280,550)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
       <a name="bit11" val="none"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
@@ -1395,65 +1190,72 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1160,530)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(630,510)" name="Constant">
+    <comp lib="2" loc="(760,540)" name="Multiplexer">
       <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="2" loc="(680,520)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="5"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
+    <comp lib="0" loc="(70,1040)" name="Clock">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(570,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+    <comp lib="1" loc="(740,580)" name="NOT Gate">
+      <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(790,670)" name="Tunnel">
+    <comp lib="0" loc="(1070,440)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(1550,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemtoReg"/>
+    </comp>
+    <comp lib="0" loc="(60,750)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="5" loc="(1260,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="1" loc="(1350,220)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="3" loc="(390,130)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="2" loc="(1170,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(1180,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(680,240)" name="Tunnel">
+      <a name="label" val="MemWrite"/>
+    </comp>
+    <comp lib="0" loc="(1100,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ALUSrc"/>
+    </comp>
+    <comp lib="0" loc="(630,510)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(680,320)" name="Tunnel">
+      <a name="label" val="BneOrBeq"/>
+    </comp>
+    <comp lib="0" loc="(1290,210)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(410,950)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
+      <a name="label" val="Branch"/>
     </comp>
     <comp lib="0" loc="(740,80)" name="Splitter">
       <a name="facing" val="west"/>
@@ -1492,4415 +1294,214 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="2"/>
       <a name="bit31" val="2"/>
     </comp>
-    <comp lib="1" loc="(860,910)" name="NOT Gate">
+    <comp lib="1" loc="(160,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(740,620)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="0" loc="(680,160)" name="Tunnel">
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="0" loc="(1590,200)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsJR"/>
+    </comp>
+    <comp lib="0" loc="(560,220)" name="Splitter">
       <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="4" loc="(1500,520)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="0" loc="(1250,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(1430,560)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(660,600)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="2" loc="(800,890)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(720,860)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp loc="(540,210)" name="Statistics"/>
+    <comp lib="0" loc="(690,990)" name="Tunnel">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(380,280)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(320,120)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(730,740)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
     </comp>
     <comp lib="0" loc="(680,380)" name="Tunnel">
       <a name="label" val="ALUSrc"/>
     </comp>
-    <comp lib="2" loc="(90,560)" name="Multiplexer">
+    <comp lib="5" loc="(1340,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1070,310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="5" loc="(1300,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(690,130)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="2" loc="(810,1000)" name="Multiplexer">
+      <a name="facing" val="north"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-  </circuit>
-  <circuit name="Control">
-    <a name="circuit" val="Control"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#4b00ff" height="342" stroke="#ffffff" stroke-width="2" width="33" x="60" y="160"/>
-      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="74" y="300">Ctrl</text>
-      <text fill="#ffffff" font-family="Dialog" font-size="16" text-anchor="middle" x="75" y="323">Unit</text>
-      <circ-port height="8" pin="240,130" width="8" x="56" y="256"/>
-      <circ-port height="8" pin="460,130" width="8" x="56" y="336"/>
-      <circ-port height="10" pin="980,360" width="10" x="85" y="175"/>
-      <circ-port height="10" pin="260,170" width="10" x="85" y="195"/>
-      <circ-port height="10" pin="260,210" width="10" x="85" y="215"/>
-      <circ-port height="10" pin="260,250" width="10" x="85" y="235"/>
-      <circ-port height="10" pin="260,290" width="10" x="85" y="255"/>
-      <circ-port height="10" pin="480,170" width="10" x="85" y="275"/>
-      <circ-port height="10" pin="480,210" width="10" x="85" y="295"/>
-      <circ-port height="10" pin="480,250" width="10" x="85" y="315"/>
-      <circ-port height="10" pin="480,290" width="10" x="85" y="335"/>
-      <circ-port height="10" pin="480,330" width="10" x="85" y="355"/>
-      <circ-port height="10" pin="260,330" width="10" x="85" y="375"/>
-      <circ-port height="10" pin="260,370" width="10" x="85" y="395"/>
-      <circ-port height="10" pin="480,370" width="10" x="85" y="415"/>
-      <circ-port height="10" pin="260,410" width="10" x="85" y="475"/>
-      <circ-port height="10" pin="480,410" width="10" x="85" y="435"/>
-      <circ-port height="10" pin="260,450" width="10" x="85" y="455"/>
-      <circ-anchor facing="east" height="6" width="6" x="57" y="157"/>
-    </appear>
-    <wire from="(910,470)" to="(910,480)"/>
-    <wire from="(140,50)" to="(580,50)"/>
-    <wire from="(140,850)" to="(580,850)"/>
-    <wire from="(140,490)" to="(580,490)"/>
-    <wire from="(750,220)" to="(750,310)"/>
-    <wire from="(800,690)" to="(840,690)"/>
-    <wire from="(930,170)" to="(930,190)"/>
-    <wire from="(820,370)" to="(820,450)"/>
-    <wire from="(800,710)" to="(820,710)"/>
-    <wire from="(230,170)" to="(260,170)"/>
-    <wire from="(910,300)" to="(930,300)"/>
-    <wire from="(1080,50)" to="(1080,550)"/>
-    <wire from="(760,710)" to="(780,710)"/>
-    <wire from="(460,250)" to="(480,250)"/>
-    <wire from="(460,130)" to="(480,130)"/>
-    <wire from="(460,170)" to="(480,170)"/>
-    <wire from="(460,210)" to="(480,210)"/>
-    <wire from="(460,290)" to="(480,290)"/>
-    <wire from="(460,330)" to="(480,330)"/>
-    <wire from="(460,370)" to="(480,370)"/>
-    <wire from="(460,410)" to="(480,410)"/>
-    <wire from="(950,130)" to="(980,130)"/>
-    <wire from="(950,210)" to="(980,210)"/>
-    <wire from="(800,700)" to="(830,700)"/>
-    <wire from="(800,740)" to="(830,740)"/>
-    <wire from="(900,440)" to="(930,440)"/>
-    <wire from="(310,710)" to="(320,710)"/>
-    <wire from="(250,250)" to="(260,250)"/>
-    <wire from="(250,290)" to="(260,290)"/>
-    <wire from="(250,330)" to="(260,330)"/>
-    <wire from="(800,720)" to="(810,720)"/>
-    <wire from="(870,710)" to="(880,710)"/>
-    <wire from="(710,430)" to="(720,430)"/>
-    <wire from="(710,470)" to="(720,470)"/>
-    <wire from="(600,50)" to="(600,550)"/>
-    <wire from="(930,300)" to="(930,310)"/>
-    <wire from="(800,350)" to="(920,350)"/>
-    <wire from="(820,710)" to="(820,720)"/>
-    <wire from="(800,730)" to="(800,740)"/>
-    <wire from="(1080,570)" to="(1080,850)"/>
-    <wire from="(730,140)" to="(920,140)"/>
-    <wire from="(600,570)" to="(600,850)"/>
-    <wire from="(750,220)" to="(920,220)"/>
-    <wire from="(810,730)" to="(830,730)"/>
-    <wire from="(860,460)" to="(880,460)"/>
-    <wire from="(900,460)" to="(920,460)"/>
-    <wire from="(660,450)" to="(690,450)"/>
-    <wire from="(350,750)" to="(370,750)"/>
-    <wire from="(350,670)" to="(370,670)"/>
-    <wire from="(350,790)" to="(370,790)"/>
-    <wire from="(350,630)" to="(370,630)"/>
-    <wire from="(600,50)" to="(1080,50)"/>
-    <wire from="(600,570)" to="(1080,570)"/>
-    <wire from="(600,850)" to="(1080,850)"/>
-    <wire from="(350,710)" to="(370,710)"/>
-    <wire from="(950,260)" to="(980,260)"/>
-    <wire from="(900,450)" to="(930,450)"/>
-    <wire from="(900,490)" to="(930,490)"/>
-    <wire from="(900,170)" to="(930,170)"/>
-    <wire from="(580,50)" to="(580,490)"/>
-    <wire from="(310,680)" to="(320,680)"/>
-    <wire from="(310,720)" to="(320,720)"/>
-    <wire from="(970,460)" to="(980,460)"/>
-    <wire from="(140,50)" to="(140,490)"/>
-    <wire from="(900,470)" to="(910,470)"/>
-    <wire from="(910,200)" to="(920,200)"/>
-    <wire from="(910,120)" to="(920,120)"/>
-    <wire from="(710,440)" to="(720,440)"/>
-    <wire from="(920,460)" to="(920,470)"/>
-    <wire from="(900,480)" to="(900,490)"/>
-    <wire from="(140,510)" to="(580,510)"/>
-    <wire from="(140,510)" to="(140,850)"/>
-    <wire from="(930,150)" to="(930,170)"/>
-    <wire from="(580,510)" to="(580,850)"/>
-    <wire from="(800,450)" to="(820,450)"/>
-    <wire from="(770,270)" to="(920,270)"/>
-    <wire from="(910,480)" to="(930,480)"/>
-    <wire from="(770,270)" to="(770,310)"/>
-    <wire from="(670,350)" to="(700,350)"/>
-    <wire from="(800,680)" to="(830,680)"/>
-    <wire from="(240,130)" to="(260,130)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(240,370)" to="(260,370)"/>
-    <wire from="(240,410)" to="(260,410)"/>
-    <wire from="(240,450)" to="(260,450)"/>
-    <wire from="(310,690)" to="(320,690)"/>
-    <wire from="(310,730)" to="(320,730)"/>
-    <wire from="(820,720)" to="(830,720)"/>
-    <wire from="(910,250)" to="(920,250)"/>
-    <wire from="(710,450)" to="(720,450)"/>
-    <wire from="(810,720)" to="(810,730)"/>
-    <wire from="(820,370)" to="(920,370)"/>
-    <wire from="(930,280)" to="(930,300)"/>
-    <wire from="(730,140)" to="(730,310)"/>
-    <wire from="(260,710)" to="(290,710)"/>
-    <wire from="(350,690)" to="(370,690)"/>
-    <wire from="(350,610)" to="(370,610)"/>
-    <wire from="(350,650)" to="(370,650)"/>
-    <wire from="(600,550)" to="(1080,550)"/>
-    <wire from="(350,770)" to="(370,770)"/>
-    <wire from="(350,730)" to="(370,730)"/>
-    <wire from="(350,810)" to="(370,810)"/>
-    <wire from="(950,360)" to="(980,360)"/>
-    <wire from="(900,430)" to="(930,430)"/>
-    <wire from="(310,700)" to="(320,700)"/>
-    <wire from="(920,470)" to="(930,470)"/>
-    <wire from="(710,420)" to="(720,420)"/>
-    <wire from="(710,460)" to="(720,460)"/>
-    <comp lib="0" loc="(480,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Jump"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(110,750)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsCOP0"/>
     </comp>
-    <comp lib="0" loc="(240,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(980,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(800,450)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="3"/>
-      <a name="bit1" val="2"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="0" loc="(240,370)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(480,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemRead"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp loc="(770,430)" name="ALU_Decoder"/>
-    <comp loc="(720,320)" name="Funct_Decoder"/>
-    <comp lib="2" loc="(950,360)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="4"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(690,450)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(910,120)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="6" loc="(840,609)" name="Text">
-      <a name="text" val="Exception Handler"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="6" loc="(371,553)" name="Text">
-      <a name="text" val="OP Decoding Area"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(260,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(260,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(980,210)" name="Tunnel">
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="6" loc="(851,85)" name="Text">
-      <a name="text" val="ALU Decoding Area"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(260,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscall"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(930,340)" name="NOT Gate">
+    <comp lib="5" loc="(1250,760)" name="Button">
       <a name="facing" val="south"/>
     </comp>
-    <comp lib="0" loc="(460,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(660,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(480,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Branch"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(480,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJR"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(250,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(670,350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(980,260)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="0" loc="(480,130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(260,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJAL"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(370,670)" name="Tunnel">
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(370,710)" name="Tunnel">
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(910,200)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(260,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeq"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(260,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrc"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(880,460)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(460,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(980,460)" name="Tunnel">
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(370,790)" name="Tunnel">
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="0" loc="(480,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsCOP0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(950,130)" name="Multiplexer">
+    <comp lib="2" loc="(1380,130)" name="Multiplexer">
+      <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(460,370)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJR"/>
+    <comp lib="0" loc="(90,510)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x800"/>
     </comp>
-    <comp lib="0" loc="(910,300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="0" loc="(860,460)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(480,210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(370,610)" name="Tunnel">
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(370,630)" name="Tunnel">
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(240,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(250,250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="0" loc="(910,250)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(290,710)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(370,810)" name="Tunnel">
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(900,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsSpecial"/>
-    </comp>
-    <comp lib="6" loc="(353,93)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp loc="(320,600)" name="Opcode_Decoder"/>
-    <comp lib="0" loc="(780,710)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(460,250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="0" loc="(880,710)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(460,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="0" loc="(700,350)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(460,130)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct"/>
-    </comp>
-    <comp lib="2" loc="(950,260)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(250,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="0" loc="(760,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="2" loc="(950,210)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(870,710)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate2" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(230,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="0" loc="(370,750)" name="Tunnel">
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(240,130)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(260,210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(260,130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="op"/>
-    </comp>
-    <comp lib="0" loc="(260,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ZeroExtend"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(800,350)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="3"/>
-      <a name="bit1" val="2"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="0" loc="(370,650)" name="Tunnel">
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(480,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegDst"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(970,460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-      <a name="negate0" val="true"/>
-      <a name="negate1" val="true"/>
-      <a name="negate2" val="true"/>
-      <a name="negate3" val="true"/>
-      <a name="negate4" val="true"/>
-      <a name="negate5" val="true"/>
-    </comp>
-    <comp lib="0" loc="(370,770)" name="Tunnel">
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="0" loc="(370,730)" name="Tunnel">
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(980,130)" name="Tunnel">
+    <comp lib="0" loc="(700,500)" name="Tunnel">
       <a name="label" val="IsSyscall"/>
     </comp>
-    <comp lib="0" loc="(370,690)" name="Tunnel">
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="0" loc="(460,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(460,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="MemWrite"/>
-    </comp>
-    <comp lib="0" loc="(260,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoReg"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-  </circuit>
-  <circuit name="Funct_Decoder">
-    <a name="circuit" val="Funct_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="71" stroke="#000000" stroke-width="2" width="60" x="50" y="50"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="81" y="82">Funct</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="101">Decoder</text>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
-      <circ-port height="8" pin="40,140" width="8" x="46" y="76"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
-      <circ-port height="10" pin="390,240" width="10" x="105" y="65"/>
-      <circ-port height="8" pin="40,250" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="40,310" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="390,700" width="10" x="105" y="75"/>
-      <circ-port height="10" pin="390,1310" width="10" x="105" y="85"/>
-      <circ-port height="10" pin="390,1870" width="10" x="105" y="95"/>
-      <circ-port height="10" pin="390,2210" width="10" x="75" y="45"/>
-      <circ-port height="10" pin="390,2370" width="10" x="55" y="45"/>
-      <circ-port height="10" pin="390,2670" width="10" x="95" y="45"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
-    </appear>
-    <wire from="(160,700)" to="(160,830)"/>
-    <wire from="(100,640)" to="(100,770)"/>
-    <wire from="(200,910)" to="(260,910)"/>
-    <wire from="(230,870)" to="(230,880)"/>
-    <wire from="(220,1020)" to="(220,1030)"/>
-    <wire from="(60,2600)" to="(180,2600)"/>
-    <wire from="(60,2760)" to="(180,2760)"/>
-    <wire from="(60,590)" to="(240,590)"/>
-    <wire from="(210,770)" to="(260,770)"/>
-    <wire from="(60,1390)" to="(240,1390)"/>
-    <wire from="(230,2630)" to="(230,2650)"/>
-    <wire from="(230,2790)" to="(230,2810)"/>
-    <wire from="(240,240)" to="(240,260)"/>
-    <wire from="(230,1030)" to="(230,1050)"/>
-    <wire from="(60,1240)" to="(60,1390)"/>
-    <wire from="(290,2210)" to="(390,2210)"/>
-    <wire from="(290,2370)" to="(390,2370)"/>
-    <wire from="(240,1040)" to="(240,1070)"/>
-    <wire from="(240,720)" to="(240,750)"/>
-    <wire from="(80,1520)" to="(180,1520)"/>
-    <wire from="(230,170)" to="(260,170)"/>
-    <wire from="(230,650)" to="(260,650)"/>
-    <wire from="(140,2710)" to="(230,2710)"/>
-    <wire from="(290,70)" to="(320,70)"/>
-    <wire from="(310,250)" to="(340,250)"/>
-    <wire from="(230,1130)" to="(260,1130)"/>
-    <wire from="(230,1290)" to="(260,1290)"/>
-    <wire from="(230,1930)" to="(260,1930)"/>
-    <wire from="(230,2090)" to="(260,2090)"/>
-    <wire from="(240,1790)" to="(260,1790)"/>
-    <wire from="(200,2550)" to="(220,2550)"/>
-    <wire from="(310,2660)" to="(330,2660)"/>
-    <wire from="(160,830)" to="(160,940)"/>
-    <wire from="(160,1070)" to="(180,1070)"/>
-    <wire from="(210,480)" to="(230,480)"/>
-    <wire from="(210,800)" to="(230,800)"/>
-    <wire from="(100,2520)" to="(180,2520)"/>
-    <wire from="(160,2580)" to="(240,2580)"/>
-    <wire from="(100,770)" to="(100,890)"/>
-    <wire from="(120,2080)" to="(180,2080)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(40,310)" to="(160,310)"/>
-    <wire from="(60,240)" to="(240,240)"/>
-    <wire from="(60,720)" to="(240,720)"/>
-    <wire from="(120,2550)" to="(120,2690)"/>
-    <wire from="(140,2570)" to="(140,2710)"/>
-    <wire from="(240,850)" to="(240,870)"/>
-    <wire from="(140,2250)" to="(140,2400)"/>
-    <wire from="(160,2430)" to="(160,2580)"/>
-    <wire from="(230,520)" to="(230,540)"/>
-    <wire from="(220,2680)" to="(260,2680)"/>
-    <wire from="(220,2840)" to="(260,2840)"/>
-    <wire from="(230,780)" to="(260,780)"/>
-    <wire from="(100,2060)" to="(260,2060)"/>
-    <wire from="(140,440)" to="(230,440)"/>
-    <wire from="(360,2670)" to="(390,2670)"/>
-    <wire from="(240,2240)" to="(260,2240)"/>
-    <wire from="(240,1280)" to="(260,1280)"/>
-    <wire from="(240,1120)" to="(260,1120)"/>
-    <wire from="(240,1920)" to="(260,1920)"/>
-    <wire from="(240,2400)" to="(260,2400)"/>
-    <wire from="(240,2560)" to="(260,2560)"/>
-    <wire from="(320,720)" to="(340,720)"/>
-    <wire from="(290,1810)" to="(310,1810)"/>
-    <wire from="(240,530)" to="(240,570)"/>
-    <wire from="(240,160)" to="(260,160)"/>
-    <wire from="(240,320)" to="(260,320)"/>
-    <wire from="(320,510)" to="(320,680)"/>
-    <wire from="(210,610)" to="(230,610)"/>
-    <wire from="(200,1720)" to="(220,1720)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(100,1690)" to="(180,1690)"/>
-    <wire from="(160,1750)" to="(240,1750)"/>
-    <wire from="(120,1460)" to="(260,1460)"/>
-    <wire from="(310,1880)" to="(310,1940)"/>
-    <wire from="(120,1720)" to="(120,1840)"/>
-    <wire from="(140,1740)" to="(140,1870)"/>
-    <wire from="(60,1500)" to="(60,1630)"/>
-    <wire from="(120,2690)" to="(180,2690)"/>
-    <wire from="(120,2850)" to="(180,2850)"/>
-    <wire from="(140,800)" to="(190,800)"/>
-    <wire from="(60,850)" to="(240,850)"/>
-    <wire from="(80,1520)" to="(80,1660)"/>
-    <wire from="(230,2090)" to="(230,2100)"/>
-    <wire from="(60,2460)" to="(60,2600)"/>
-    <wire from="(240,2100)" to="(240,2120)"/>
-    <wire from="(100,1540)" to="(100,1690)"/>
-    <wire from="(160,1600)" to="(160,1750)"/>
-    <wire from="(230,650)" to="(230,670)"/>
-    <wire from="(230,970)" to="(230,990)"/>
-    <wire from="(140,2250)" to="(180,2250)"/>
-    <wire from="(200,2150)" to="(240,2150)"/>
-    <wire from="(200,2310)" to="(240,2310)"/>
-    <wire from="(230,270)" to="(260,270)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(210,570)" to="(240,570)"/>
-    <wire from="(200,1520)" to="(230,1520)"/>
-    <wire from="(100,2660)" to="(100,2820)"/>
-    <wire from="(120,1560)" to="(120,1720)"/>
-    <wire from="(140,1580)" to="(140,1740)"/>
-    <wire from="(140,1050)" to="(230,1050)"/>
-    <wire from="(100,1810)" to="(190,1810)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(230,2190)" to="(260,2190)"/>
-    <wire from="(230,2350)" to="(260,2350)"/>
-    <wire from="(230,2510)" to="(260,2510)"/>
-    <wire from="(140,1870)" to="(140,1970)"/>
-    <wire from="(240,930)" to="(260,930)"/>
-    <wire from="(240,1730)" to="(260,1730)"/>
-    <wire from="(320,1330)" to="(340,1330)"/>
-    <wire from="(290,1940)" to="(310,1940)"/>
-    <wire from="(240,660)" to="(240,700)"/>
-    <wire from="(310,250)" to="(310,290)"/>
-    <wire from="(210,740)" to="(230,740)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(60,1630)" to="(60,1760)"/>
-    <wire from="(120,420)" to="(180,420)"/>
-    <wire from="(200,180)" to="(260,180)"/>
-    <wire from="(200,1140)" to="(260,1140)"/>
-    <wire from="(200,1300)" to="(260,1300)"/>
-    <wire from="(140,1470)" to="(260,1470)"/>
-    <wire from="(120,190)" to="(120,200)"/>
-    <wire from="(310,2680)" to="(310,2830)"/>
-    <wire from="(230,780)" to="(230,800)"/>
-    <wire from="(240,950)" to="(240,980)"/>
-    <wire from="(220,1020)" to="(260,1020)"/>
-    <wire from="(200,2120)" to="(240,2120)"/>
-    <wire from="(200,2280)" to="(240,2280)"/>
-    <wire from="(200,2600)" to="(240,2600)"/>
-    <wire from="(200,2760)" to="(240,2760)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(80,1110)" to="(180,1110)"/>
-    <wire from="(80,1270)" to="(180,1270)"/>
-    <wire from="(100,400)" to="(260,400)"/>
-    <wire from="(210,700)" to="(240,700)"/>
-    <wire from="(230,880)" to="(260,880)"/>
-    <wire from="(100,1940)" to="(190,1940)"/>
-    <wire from="(230,1680)" to="(260,1680)"/>
-    <wire from="(240,2180)" to="(260,2180)"/>
-    <wire from="(240,2340)" to="(260,2340)"/>
-    <wire from="(240,2500)" to="(260,2500)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,790)" to="(240,830)"/>
-    <wire from="(160,340)" to="(180,340)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,260)" to="(260,260)"/>
-    <wire from="(320,1890)" to="(320,2070)"/>
-    <wire from="(120,540)" to="(190,540)"/>
-    <wire from="(80,1780)" to="(80,1910)"/>
-    <wire from="(120,540)" to="(120,670)"/>
-    <wire from="(60,1760)" to="(60,1890)"/>
-    <wire from="(120,1030)" to="(180,1030)"/>
-    <wire from="(230,430)" to="(230,440)"/>
-    <wire from="(240,440)" to="(240,450)"/>
-    <wire from="(60,950)" to="(240,950)"/>
-    <wire from="(100,1000)" to="(100,1140)"/>
-    <wire from="(320,260)" to="(320,410)"/>
-    <wire from="(320,1700)" to="(320,1850)"/>
-    <wire from="(200,2730)" to="(240,2730)"/>
-    <wire from="(80,2040)" to="(180,2040)"/>
-    <wire from="(160,1480)" to="(260,1480)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(210,830)" to="(240,830)"/>
-    <wire from="(230,1170)" to="(260,1170)"/>
-    <wire from="(230,1330)" to="(260,1330)"/>
-    <wire from="(290,1550)" to="(320,1550)"/>
-    <wire from="(240,870)" to="(260,870)"/>
-    <wire from="(240,1670)" to="(260,1670)"/>
-    <wire from="(240,1830)" to="(260,1830)"/>
-    <wire from="(100,140)" to="(100,180)"/>
-    <wire from="(310,190)" to="(310,230)"/>
-    <wire from="(240,1240)" to="(240,1280)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(80,150)" to="(80,260)"/>
-    <wire from="(100,1440)" to="(180,1440)"/>
-    <wire from="(120,670)" to="(190,670)"/>
-    <wire from="(160,450)" to="(160,700)"/>
-    <wire from="(200,2520)" to="(260,2520)"/>
-    <wire from="(80,1910)" to="(80,2040)"/>
-    <wire from="(140,1970)" to="(140,2100)"/>
-    <wire from="(60,1890)" to="(60,2020)"/>
-    <wire from="(200,1560)" to="(260,1560)"/>
-    <wire from="(80,1270)" to="(80,1410)"/>
-    <wire from="(230,1520)" to="(230,1530)"/>
-    <wire from="(320,70)" to="(320,220)"/>
-    <wire from="(60,1090)" to="(60,1240)"/>
-    <wire from="(80,2490)" to="(180,2490)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(230,500)" to="(260,500)"/>
-    <wire from="(200,1110)" to="(230,1110)"/>
-    <wire from="(200,1270)" to="(230,1270)"/>
-    <wire from="(80,1110)" to="(80,1270)"/>
-    <wire from="(140,320)" to="(230,320)"/>
-    <wire from="(310,1860)" to="(340,1860)"/>
-    <wire from="(240,1960)" to="(260,1960)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(310,640)" to="(310,690)"/>
-    <wire from="(160,1480)" to="(160,1600)"/>
-    <wire from="(60,2020)" to="(60,2150)"/>
-    <wire from="(200,1690)" to="(260,1690)"/>
-    <wire from="(220,1320)" to="(220,1330)"/>
-    <wire from="(290,1310)" to="(340,1310)"/>
-    <wire from="(230,1170)" to="(230,1180)"/>
-    <wire from="(80,2040)" to="(80,2180)"/>
-    <wire from="(100,2060)" to="(100,2200)"/>
-    <wire from="(120,2080)" to="(120,2220)"/>
-    <wire from="(230,1330)" to="(230,1350)"/>
-    <wire from="(240,1500)" to="(240,1520)"/>
-    <wire from="(310,1150)" to="(310,1300)"/>
-    <wire from="(140,2100)" to="(140,2250)"/>
-    <wire from="(160,2280)" to="(160,2430)"/>
-    <wire from="(240,1180)" to="(240,1210)"/>
-    <wire from="(240,1340)" to="(240,1370)"/>
-    <wire from="(200,1070)" to="(240,1070)"/>
-    <wire from="(80,380)" to="(180,380)"/>
-    <wire from="(80,1660)" to="(180,1660)"/>
-    <wire from="(230,310)" to="(260,310)"/>
-    <wire from="(230,630)" to="(260,630)"/>
-    <wire from="(160,2000)" to="(190,2000)"/>
-    <wire from="(160,2120)" to="(160,2280)"/>
-    <wire from="(140,930)" to="(230,930)"/>
-    <wire from="(310,230)" to="(340,230)"/>
-    <wire from="(290,1010)" to="(320,1010)"/>
-    <wire from="(230,1430)" to="(260,1430)"/>
-    <wire from="(200,2040)" to="(230,2040)"/>
-    <wire from="(230,2230)" to="(260,2230)"/>
-    <wire from="(230,2390)" to="(260,2390)"/>
-    <wire from="(230,2550)" to="(260,2550)"/>
-    <wire from="(310,710)" to="(340,710)"/>
-    <wire from="(200,2690)" to="(220,2690)"/>
-    <wire from="(200,2850)" to="(220,2850)"/>
-    <wire from="(320,1850)" to="(340,1850)"/>
-    <wire from="(240,2460)" to="(240,2500)"/>
-    <wire from="(240,490)" to="(260,490)"/>
-    <wire from="(160,1210)" to="(180,1210)"/>
-    <wire from="(160,1370)" to="(180,1370)"/>
-    <wire from="(100,2660)" to="(180,2660)"/>
-    <wire from="(100,2820)" to="(180,2820)"/>
-    <wire from="(120,670)" to="(120,910)"/>
-    <wire from="(120,300)" to="(180,300)"/>
-    <wire from="(120,2220)" to="(180,2220)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(60,1500)" to="(240,1500)"/>
-    <wire from="(80,2490)" to="(80,2630)"/>
-    <wire from="(230,1780)" to="(230,1800)"/>
-    <wire from="(80,1780)" to="(190,1780)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(60,2310)" to="(60,2460)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(100,280)" to="(260,280)"/>
-    <wire from="(230,760)" to="(260,760)"/>
-    <wire from="(230,920)" to="(260,920)"/>
-    <wire from="(60,2150)" to="(60,2310)"/>
-    <wire from="(100,2200)" to="(260,2200)"/>
-    <wire from="(100,2360)" to="(260,2360)"/>
-    <wire from="(120,2690)" to="(120,2850)"/>
-    <wire from="(60,360)" to="(60,460)"/>
-    <wire from="(80,380)" to="(80,480)"/>
-    <wire from="(230,1720)" to="(260,1720)"/>
-    <wire from="(200,2490)" to="(230,2490)"/>
-    <wire from="(310,1320)" to="(340,1320)"/>
-    <wire from="(320,220)" to="(340,220)"/>
-    <wire from="(290,190)" to="(310,190)"/>
-    <wire from="(290,1150)" to="(310,1150)"/>
-    <wire from="(240,1420)" to="(260,1420)"/>
-    <wire from="(240,1580)" to="(260,1580)"/>
-    <wire from="(240,2700)" to="(260,2700)"/>
-    <wire from="(240,2860)" to="(260,2860)"/>
-    <wire from="(140,2710)" to="(140,2880)"/>
-    <wire from="(370,1870)" to="(390,1870)"/>
-    <wire from="(240,1630)" to="(240,1670)"/>
-    <wire from="(240,620)" to="(260,620)"/>
-    <wire from="(100,400)" to="(100,510)"/>
-    <wire from="(160,450)" to="(240,450)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(160,2730)" to="(160,2910)"/>
-    <wire from="(80,1660)" to="(80,1780)"/>
-    <wire from="(120,420)" to="(120,540)"/>
-    <wire from="(140,440)" to="(140,570)"/>
-    <wire from="(160,940)" to="(160,1070)"/>
-    <wire from="(140,250)" to="(140,320)"/>
-    <wire from="(120,910)" to="(180,910)"/>
-    <wire from="(310,2530)" to="(310,2660)"/>
-    <wire from="(230,310)" to="(230,320)"/>
-    <wire from="(60,1240)" to="(180,1240)"/>
-    <wire from="(210,1810)" to="(260,1810)"/>
-    <wire from="(230,2390)" to="(230,2400)"/>
-    <wire from="(220,2540)" to="(220,2550)"/>
-    <wire from="(230,1270)" to="(230,1290)"/>
-    <wire from="(230,1110)" to="(230,1130)"/>
-    <wire from="(230,1910)" to="(230,1930)"/>
-    <wire from="(80,1910)" to="(190,1910)"/>
-    <wire from="(230,2230)" to="(230,2250)"/>
-    <wire from="(230,2550)" to="(230,2570)"/>
-    <wire from="(240,2560)" to="(240,2580)"/>
-    <wire from="(230,150)" to="(230,170)"/>
-    <wire from="(240,320)" to="(240,340)"/>
-    <wire from="(240,1760)" to="(240,1790)"/>
-    <wire from="(240,2400)" to="(240,2430)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(200,380)" to="(230,380)"/>
-    <wire from="(200,1180)" to="(230,1180)"/>
-    <wire from="(200,1660)" to="(230,1660)"/>
-    <wire from="(100,890)" to="(260,890)"/>
-    <wire from="(60,2600)" to="(60,2760)"/>
-    <wire from="(140,1350)" to="(230,1350)"/>
-    <wire from="(230,1530)" to="(260,1530)"/>
-    <wire from="(230,2650)" to="(260,2650)"/>
-    <wire from="(230,2810)" to="(260,2810)"/>
-    <wire from="(100,510)" to="(190,510)"/>
-    <wire from="(290,2070)" to="(320,2070)"/>
-    <wire from="(290,640)" to="(310,640)"/>
-    <wire from="(240,750)" to="(260,750)"/>
-    <wire from="(210,1840)" to="(230,1840)"/>
-    <wire from="(370,240)" to="(390,240)"/>
-    <wire from="(240,2240)" to="(240,2280)"/>
-    <wire from="(200,1030)" to="(220,1030)"/>
-    <wire from="(160,2430)" to="(180,2430)"/>
-    <wire from="(160,2910)" to="(180,2910)"/>
-    <wire from="(100,1000)" to="(180,1000)"/>
-    <wire from="(310,710)" to="(310,770)"/>
-    <wire from="(200,2080)" to="(260,2080)"/>
-    <wire from="(100,1810)" to="(100,1940)"/>
-    <wire from="(120,1030)" to="(120,1160)"/>
-    <wire from="(140,1050)" to="(140,1180)"/>
-    <wire from="(200,1440)" to="(260,1440)"/>
-    <wire from="(230,920)" to="(230,930)"/>
-    <wire from="(210,1940)" to="(260,1940)"/>
-    <wire from="(60,1760)" to="(240,1760)"/>
-    <wire from="(140,1870)" to="(190,1870)"/>
-    <wire from="(240,930)" to="(240,940)"/>
-    <wire from="(220,1710)" to="(220,1720)"/>
-    <wire from="(230,2040)" to="(230,2050)"/>
-    <wire from="(160,1070)" to="(160,1210)"/>
-    <wire from="(230,1720)" to="(230,1740)"/>
-    <wire from="(240,1730)" to="(240,1750)"/>
-    <wire from="(240,1090)" to="(240,1120)"/>
-    <wire from="(240,1890)" to="(240,1920)"/>
-    <wire from="(200,340)" to="(240,340)"/>
-    <wire from="(220,1320)" to="(260,1320)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(240,130)" to="(240,160)"/>
-    <wire from="(80,1410)" to="(180,1410)"/>
-    <wire from="(290,2670)" to="(330,2670)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(100,180)" to="(100,280)"/>
-    <wire from="(120,200)" to="(120,300)"/>
-    <wire from="(230,1820)" to="(260,1820)"/>
-    <wire from="(100,640)" to="(190,640)"/>
-    <wire from="(290,290)" to="(310,290)"/>
-    <wire from="(240,1520)" to="(260,1520)"/>
-    <wire from="(240,2640)" to="(260,2640)"/>
-    <wire from="(240,1040)" to="(260,1040)"/>
-    <wire from="(210,1970)" to="(230,1970)"/>
-    <wire from="(290,770)" to="(310,770)"/>
-    <wire from="(290,2530)" to="(310,2530)"/>
-    <wire from="(240,2800)" to="(260,2800)"/>
-    <wire from="(160,1600)" to="(180,1600)"/>
-    <wire from="(100,1940)" to="(100,2060)"/>
-    <wire from="(160,2000)" to="(160,2120)"/>
-    <wire from="(60,460)" to="(60,590)"/>
-    <wire from="(80,480)" to="(80,610)"/>
-    <wire from="(120,1330)" to="(180,1330)"/>
-    <wire from="(230,90)" to="(230,100)"/>
-    <wire from="(60,2460)" to="(180,2460)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(60,1090)" to="(240,1090)"/>
-    <wire from="(60,1890)" to="(240,1890)"/>
-    <wire from="(100,1300)" to="(100,1440)"/>
-    <wire from="(240,2020)" to="(240,2040)"/>
-    <wire from="(230,2490)" to="(230,2510)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(80,260)" to="(180,260)"/>
-    <wire from="(80,2180)" to="(180,2180)"/>
-    <wire from="(80,2340)" to="(180,2340)"/>
-    <wire from="(230,990)" to="(260,990)"/>
-    <wire from="(100,1140)" to="(100,1300)"/>
-    <wire from="(140,570)" to="(140,800)"/>
-    <wire from="(140,2570)" to="(230,2570)"/>
-    <wire from="(290,410)" to="(320,410)"/>
-    <wire from="(230,1950)" to="(260,1950)"/>
-    <wire from="(200,2400)" to="(230,2400)"/>
-    <wire from="(200,2880)" to="(230,2880)"/>
-    <wire from="(100,770)" to="(190,770)"/>
-    <wire from="(210,1780)" to="(230,1780)"/>
-    <wire from="(120,1160)" to="(120,1330)"/>
-    <wire from="(140,1180)" to="(140,1350)"/>
-    <wire from="(320,1890)" to="(340,1890)"/>
-    <wire from="(310,2680)" to="(330,2680)"/>
-    <wire from="(140,1470)" to="(140,1580)"/>
-    <wire from="(240,530)" to="(260,530)"/>
-    <wire from="(60,1390)" to="(60,1500)"/>
-    <wire from="(80,1410)" to="(80,1520)"/>
-    <wire from="(320,720)" to="(320,900)"/>
-    <wire from="(200,2660)" to="(260,2660)"/>
-    <wire from="(200,2820)" to="(260,2820)"/>
-    <wire from="(60,590)" to="(60,720)"/>
-    <wire from="(80,610)" to="(80,740)"/>
-    <wire from="(200,420)" to="(260,420)"/>
-    <wire from="(310,1320)" to="(310,1450)"/>
-    <wire from="(230,380)" to="(230,390)"/>
-    <wire from="(60,1630)" to="(180,1630)"/>
-    <wire from="(140,1970)" to="(190,1970)"/>
-    <wire from="(60,2020)" to="(240,2020)"/>
-    <wire from="(230,1660)" to="(230,1680)"/>
-    <wire from="(230,1820)" to="(230,1840)"/>
-    <wire from="(140,1180)" to="(180,1180)"/>
-    <wire from="(240,2150)" to="(240,2180)"/>
-    <wire from="(240,2310)" to="(240,2340)"/>
-    <wire from="(200,1240)" to="(240,1240)"/>
-    <wire from="(220,2540)" to="(260,2540)"/>
-    <wire from="(160,310)" to="(160,340)"/>
-    <wire from="(80,870)" to="(180,870)"/>
-    <wire from="(80,2630)" to="(180,2630)"/>
-    <wire from="(80,2790)" to="(180,2790)"/>
-    <wire from="(200,1410)" to="(230,1410)"/>
-    <wire from="(140,1580)" to="(230,1580)"/>
-    <wire from="(140,1740)" to="(230,1740)"/>
-    <wire from="(320,260)" to="(340,260)"/>
-    <wire from="(240,980)" to="(260,980)"/>
-    <wire from="(210,1910)" to="(230,1910)"/>
-    <wire from="(240,2100)" to="(260,2100)"/>
-    <wire from="(240,1830)" to="(240,1870)"/>
-    <wire from="(160,340)" to="(160,450)"/>
-    <wire from="(240,660)" to="(260,660)"/>
-    <wire from="(120,200)" to="(260,200)"/>
-    <wire from="(120,1160)" to="(260,1160)"/>
-    <wire from="(60,240)" to="(60,360)"/>
-    <wire from="(80,260)" to="(80,380)"/>
-    <wire from="(100,280)" to="(100,400)"/>
-    <wire from="(120,300)" to="(120,420)"/>
-    <wire from="(140,320)" to="(140,440)"/>
-    <wire from="(140,800)" to="(140,930)"/>
-    <wire from="(60,720)" to="(60,850)"/>
-    <wire from="(80,740)" to="(80,870)"/>
-    <wire from="(120,2550)" to="(180,2550)"/>
-    <wire from="(100,2520)" to="(100,2660)"/>
-    <wire from="(230,1950)" to="(230,1970)"/>
-    <wire from="(80,2340)" to="(80,2490)"/>
-    <wire from="(160,2580)" to="(160,2730)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(240,360)" to="(240,380)"/>
-    <wire from="(320,1330)" to="(320,1550)"/>
-    <wire from="(200,1210)" to="(240,1210)"/>
-    <wire from="(200,1370)" to="(240,1370)"/>
-    <wire from="(220,1710)" to="(260,1710)"/>
-    <wire from="(160,700)" to="(190,700)"/>
-    <wire from="(200,100)" to="(230,100)"/>
-    <wire from="(200,260)" to="(230,260)"/>
-    <wire from="(80,2180)" to="(80,2340)"/>
-    <wire from="(100,2200)" to="(100,2360)"/>
-    <wire from="(100,2360)" to="(100,2520)"/>
-    <wire from="(120,2220)" to="(120,2380)"/>
-    <wire from="(60,850)" to="(60,950)"/>
-    <wire from="(80,870)" to="(80,970)"/>
-    <wire from="(230,1570)" to="(260,1570)"/>
-    <wire from="(290,510)" to="(320,510)"/>
-    <wire from="(210,1870)" to="(240,1870)"/>
-    <wire from="(230,2050)" to="(260,2050)"/>
-    <wire from="(200,2180)" to="(230,2180)"/>
-    <wire from="(200,2340)" to="(230,2340)"/>
-    <wire from="(230,2690)" to="(260,2690)"/>
-    <wire from="(230,2850)" to="(260,2850)"/>
-    <wire from="(310,690)" to="(340,690)"/>
-    <wire from="(240,790)" to="(260,790)"/>
-    <wire from="(120,2380)" to="(120,2550)"/>
-    <wire from="(140,2400)" to="(140,2570)"/>
-    <wire from="(240,1960)" to="(240,2000)"/>
-    <wire from="(240,2600)" to="(240,2640)"/>
-    <wire from="(240,2760)" to="(240,2800)"/>
-    <wire from="(100,890)" to="(100,1000)"/>
-    <wire from="(160,940)" to="(240,940)"/>
-    <wire from="(100,1690)" to="(100,1810)"/>
-    <wire from="(120,910)" to="(120,1030)"/>
-    <wire from="(140,930)" to="(140,1050)"/>
-    <wire from="(120,1560)" to="(180,1560)"/>
-    <wire from="(120,1720)" to="(180,1720)"/>
-    <wire from="(200,1000)" to="(260,1000)"/>
-    <wire from="(140,210)" to="(260,210)"/>
-    <wire from="(60,360)" to="(240,360)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(80,480)" to="(190,480)"/>
-    <wire from="(230,480)" to="(230,500)"/>
-    <wire from="(140,2400)" to="(180,2400)"/>
-    <wire from="(140,2880)" to="(180,2880)"/>
-    <wire from="(200,2460)" to="(240,2460)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(320,1010)" to="(320,1290)"/>
-    <wire from="(80,970)" to="(180,970)"/>
-    <wire from="(160,830)" to="(190,830)"/>
-    <wire from="(200,870)" to="(230,870)"/>
-    <wire from="(100,1540)" to="(260,1540)"/>
-    <wire from="(80,2630)" to="(80,2790)"/>
-    <wire from="(210,2000)" to="(240,2000)"/>
-    <wire from="(200,2630)" to="(230,2630)"/>
-    <wire from="(200,2790)" to="(230,2790)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(310,1300)" to="(340,1300)"/>
-    <wire from="(240,2040)" to="(260,2040)"/>
-    <wire from="(320,680)" to="(340,680)"/>
-    <wire from="(290,1450)" to="(310,1450)"/>
-    <wire from="(140,100)" to="(140,210)"/>
-    <wire from="(240,440)" to="(260,440)"/>
-    <wire from="(160,2120)" to="(180,2120)"/>
-    <wire from="(160,2280)" to="(180,2280)"/>
-    <wire from="(120,80)" to="(120,190)"/>
-    <wire from="(120,2380)" to="(260,2380)"/>
-    <wire from="(120,1840)" to="(190,1840)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(210,510)" to="(260,510)"/>
-    <wire from="(230,1570)" to="(230,1580)"/>
-    <wire from="(220,2680)" to="(220,2690)"/>
-    <wire from="(220,2840)" to="(220,2850)"/>
-    <wire from="(230,1410)" to="(230,1430)"/>
-    <wire from="(240,1580)" to="(240,1600)"/>
-    <wire from="(230,2690)" to="(230,2710)"/>
-    <wire from="(80,610)" to="(190,610)"/>
-    <wire from="(230,610)" to="(230,630)"/>
-    <wire from="(240,2700)" to="(240,2730)"/>
-    <wire from="(230,2850)" to="(230,2880)"/>
-    <wire from="(200,1630)" to="(240,1630)"/>
-    <wire from="(200,2430)" to="(240,2430)"/>
-    <wire from="(200,2910)" to="(240,2910)"/>
-    <wire from="(240,460)" to="(240,490)"/>
-    <wire from="(160,220)" to="(260,220)"/>
-    <wire from="(230,390)" to="(260,390)"/>
-    <wire from="(230,1030)" to="(260,1030)"/>
-    <wire from="(370,700)" to="(390,700)"/>
-    <wire from="(320,1290)" to="(340,1290)"/>
-    <wire from="(160,1370)" to="(160,1480)"/>
-    <wire from="(210,540)" to="(230,540)"/>
-    <wire from="(200,1330)" to="(220,1330)"/>
-    <wire from="(160,2730)" to="(180,2730)"/>
-    <wire from="(100,180)" to="(180,180)"/>
-    <wire from="(100,1140)" to="(180,1140)"/>
-    <wire from="(100,1300)" to="(180,1300)"/>
-    <wire from="(310,1810)" to="(310,1860)"/>
-    <wire from="(240,2860)" to="(240,2910)"/>
-    <wire from="(160,1750)" to="(160,2000)"/>
-    <wire from="(140,1350)" to="(140,1470)"/>
-    <wire from="(200,2220)" to="(260,2220)"/>
-    <wire from="(120,1330)" to="(120,1460)"/>
-    <wire from="(100,510)" to="(100,640)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(200,300)" to="(260,300)"/>
-    <wire from="(230,260)" to="(230,270)"/>
-    <wire from="(60,2150)" to="(180,2150)"/>
-    <wire from="(60,2310)" to="(180,2310)"/>
-    <wire from="(140,570)" to="(190,570)"/>
-    <wire from="(60,460)" to="(240,460)"/>
-    <wire from="(210,640)" to="(260,640)"/>
-    <wire from="(60,950)" to="(60,1090)"/>
-    <wire from="(80,970)" to="(80,1110)"/>
-    <wire from="(230,2180)" to="(230,2190)"/>
-    <wire from="(230,2340)" to="(230,2350)"/>
-    <wire from="(80,740)" to="(190,740)"/>
-    <wire from="(230,740)" to="(230,760)"/>
-    <wire from="(160,220)" to="(160,310)"/>
-    <wire from="(140,100)" to="(180,100)"/>
-    <wire from="(240,1390)" to="(240,1420)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(240,590)" to="(240,620)"/>
-    <wire from="(230,520)" to="(260,520)"/>
-    <wire from="(200,970)" to="(230,970)"/>
-    <wire from="(160,1210)" to="(160,1370)"/>
-    <wire from="(140,2100)" to="(230,2100)"/>
-    <wire from="(290,900)" to="(320,900)"/>
-    <wire from="(230,1800)" to="(260,1800)"/>
-    <wire from="(200,2250)" to="(230,2250)"/>
-    <wire from="(100,1440)" to="(100,1540)"/>
-    <wire from="(120,1460)" to="(120,1560)"/>
-    <wire from="(290,1700)" to="(320,1700)"/>
-    <wire from="(310,1880)" to="(340,1880)"/>
-    <wire from="(240,1180)" to="(260,1180)"/>
-    <wire from="(240,1340)" to="(260,1340)"/>
-    <wire from="(290,2830)" to="(310,2830)"/>
-    <wire from="(370,1310)" to="(390,1310)"/>
-    <wire from="(240,380)" to="(260,380)"/>
-    <wire from="(210,670)" to="(230,670)"/>
-    <wire from="(120,1840)" to="(120,2080)"/>
-    <wire from="(120,80)" to="(260,80)"/>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,1870)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2070)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1940)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(290,640)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(290,290)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(370,700)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(200,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,1310)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,2670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1010)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,240)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(200,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,510)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,610)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(210,770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,770)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2370)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(210,670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1810)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,1310)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(210,1970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(390,700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALU1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(390,2210)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJR"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(360,2670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(200,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(390,2370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscall"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,190)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2080)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(210,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(370,1870)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-  </circuit>
-  <circuit name="ALU_Decoder">
-    <a name="circuit" val="ALU_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="66" stroke="#000000" stroke-width="2" width="60" x="50" y="55"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="88">ALU</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="80" y="104">Decoder</text>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="66"/>
-      <circ-port height="8" pin="40,130" width="8" x="46" y="76"/>
-      <circ-port height="10" pin="430,140" width="10" x="105" y="65"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="86"/>
-      <circ-port height="8" pin="40,240" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="40,300" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="430,1130" width="10" x="105" y="75"/>
-      <circ-port height="10" pin="430,2190" width="10" x="105" y="85"/>
-      <circ-port height="10" pin="430,3270" width="10" x="105" y="95"/>
-      <circ-anchor facing="east" height="6" width="6" x="97" y="67"/>
-    </appear>
-    <wire from="(310,1140)" to="(310,1210)"/>
-    <wire from="(200,910)" to="(260,910)"/>
-    <wire from="(120,3710)" to="(180,3710)"/>
-    <wire from="(230,230)" to="(230,240)"/>
-    <wire from="(60,3960)" to="(60,4100)"/>
-    <wire from="(240,2800)" to="(240,2820)"/>
-    <wire from="(240,240)" to="(240,260)"/>
-    <wire from="(230,550)" to="(230,570)"/>
-    <wire from="(200,290)" to="(240,290)"/>
-    <wire from="(200,1570)" to="(240,1570)"/>
-    <wire from="(140,2150)" to="(180,2150)"/>
-    <wire from="(140,2470)" to="(180,2470)"/>
-    <wire from="(200,2210)" to="(240,2210)"/>
-    <wire from="(200,2530)" to="(240,2530)"/>
-    <wire from="(80,880)" to="(180,880)"/>
-    <wire from="(340,3310)" to="(380,3310)"/>
-    <wire from="(60,3640)" to="(60,3800)"/>
-    <wire from="(230,1930)" to="(260,1930)"/>
-    <wire from="(230,2250)" to="(260,2250)"/>
-    <wire from="(230,2570)" to="(260,2570)"/>
-    <wire from="(230,3850)" to="(260,3850)"/>
-    <wire from="(230,4170)" to="(260,4170)"/>
-    <wire from="(290,80)" to="(310,80)"/>
-    <wire from="(80,1920)" to="(230,1920)"/>
-    <wire from="(160,3470)" to="(180,3470)"/>
-    <wire from="(240,560)" to="(240,600)"/>
-    <wire from="(80,2380)" to="(80,2560)"/>
-    <wire from="(310,1140)" to="(380,1140)"/>
-    <wire from="(60,3210)" to="(180,3210)"/>
-    <wire from="(290,2740)" to="(340,2740)"/>
-    <wire from="(230,3240)" to="(230,3250)"/>
-    <wire from="(200,2660)" to="(240,2660)"/>
-    <wire from="(140,4200)" to="(180,4200)"/>
-    <wire from="(80,50)" to="(180,50)"/>
-    <wire from="(80,1330)" to="(180,1330)"/>
-    <wire from="(200,110)" to="(230,110)"/>
-    <wire from="(100,780)" to="(260,780)"/>
-    <wire from="(80,80)" to="(80,180)"/>
-    <wire from="(290,210)" to="(310,210)"/>
-    <wire from="(240,4000)" to="(260,4000)"/>
-    <wire from="(160,2320)" to="(180,2320)"/>
-    <wire from="(100,1050)" to="(180,1050)"/>
-    <wire from="(100,2970)" to="(180,2970)"/>
-    <wire from="(160,3030)" to="(240,3030)"/>
-    <wire from="(230,810)" to="(230,820)"/>
-    <wire from="(60,2060)" to="(180,2060)"/>
-    <wire from="(240,820)" to="(240,830)"/>
-    <wire from="(230,2090)" to="(230,2100)"/>
-    <wire from="(160,1120)" to="(160,1270)"/>
-    <wire from="(320,1150)" to="(320,1360)"/>
-    <wire from="(80,180)" to="(180,180)"/>
-    <wire from="(80,500)" to="(180,500)"/>
-    <wire from="(200,880)" to="(230,880)"/>
-    <wire from="(350,530)" to="(350,1080)"/>
-    <wire from="(140,3450)" to="(230,3450)"/>
-    <wire from="(230,1230)" to="(260,1230)"/>
-    <wire from="(230,2830)" to="(260,2830)"/>
-    <wire from="(200,1850)" to="(220,1850)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(120,1850)" to="(120,1970)"/>
-    <wire from="(200,1940)" to="(260,1940)"/>
-    <wire from="(200,3860)" to="(260,3860)"/>
-    <wire from="(140,1870)" to="(140,2000)"/>
-    <wire from="(230,940)" to="(230,950)"/>
-    <wire from="(240,950)" to="(240,970)"/>
-    <wire from="(100,3110)" to="(100,3260)"/>
-    <wire from="(120,3130)" to="(120,3280)"/>
-    <wire from="(140,3150)" to="(140,3300)"/>
-    <wire from="(60,1150)" to="(60,1300)"/>
-    <wire from="(80,3830)" to="(180,3830)"/>
-    <wire from="(120,190)" to="(120,220)"/>
-    <wire from="(200,50)" to="(230,50)"/>
-    <wire from="(200,1330)" to="(230,1330)"/>
-    <wire from="(160,1570)" to="(160,1730)"/>
-    <wire from="(140,2300)" to="(230,2300)"/>
-    <wire from="(230,1040)" to="(260,1040)"/>
-    <wire from="(230,2960)" to="(260,2960)"/>
-    <wire from="(120,700)" to="(120,800)"/>
-    <wire from="(140,720)" to="(140,820)"/>
-    <wire from="(240,1700)" to="(260,1700)"/>
-    <wire from="(240,3300)" to="(260,3300)"/>
-    <wire from="(200,380)" to="(220,380)"/>
-    <wire from="(200,700)" to="(220,700)"/>
-    <wire from="(100,350)" to="(180,350)"/>
-    <wire from="(100,670)" to="(180,670)"/>
-    <wire from="(160,730)" to="(240,730)"/>
-    <wire from="(160,2660)" to="(160,2790)"/>
-    <wire from="(140,3600)" to="(140,3740)"/>
-    <wire from="(330,1160)" to="(330,1500)"/>
-    <wire from="(160,3620)" to="(160,3770)"/>
-    <wire from="(140,2000)" to="(140,2150)"/>
-    <wire from="(140,110)" to="(180,110)"/>
-    <wire from="(240,2680)" to="(240,2710)"/>
-    <wire from="(240,3640)" to="(240,3670)"/>
-    <wire from="(220,2430)" to="(260,2430)"/>
-    <wire from="(220,2750)" to="(260,2750)"/>
-    <wire from="(200,3050)" to="(240,3050)"/>
-    <wire from="(80,760)" to="(180,760)"/>
-    <wire from="(200,180)" to="(230,180)"/>
-    <wire from="(200,500)" to="(230,500)"/>
-    <wire from="(60,1600)" to="(60,1760)"/>
-    <wire from="(100,1490)" to="(260,1490)"/>
-    <wire from="(120,380)" to="(120,540)"/>
-    <wire from="(100,3410)" to="(260,3410)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(230,4050)" to="(260,4050)"/>
-    <wire from="(160,2790)" to="(160,2890)"/>
-    <wire from="(240,2150)" to="(260,2150)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(100,2730)" to="(100,2840)"/>
-    <wire from="(240,3960)" to="(240,4000)"/>
-    <wire from="(120,3130)" to="(260,3130)"/>
-    <wire from="(310,3260)" to="(380,3260)"/>
-    <wire from="(290,360)" to="(360,360)"/>
-    <wire from="(80,3990)" to="(80,4120)"/>
-    <wire from="(120,2440)" to="(180,2440)"/>
-    <wire from="(120,2760)" to="(180,2760)"/>
-    <wire from="(330,3300)" to="(380,3300)"/>
-    <wire from="(60,850)" to="(180,850)"/>
-    <wire from="(230,3440)" to="(230,3450)"/>
-    <wire from="(230,1520)" to="(230,1540)"/>
-    <wire from="(240,3450)" to="(240,3470)"/>
-    <wire from="(230,880)" to="(230,900)"/>
-    <wire from="(200,1900)" to="(240,1900)"/>
-    <wire from="(200,3180)" to="(240,3180)"/>
-    <wire from="(200,3500)" to="(240,3500)"/>
-    <wire from="(220,4160)" to="(260,4160)"/>
-    <wire from="(230,340)" to="(260,340)"/>
-    <wire from="(200,950)" to="(230,950)"/>
-    <wire from="(230,660)" to="(260,660)"/>
-    <wire from="(100,2260)" to="(260,2260)"/>
-    <wire from="(100,2580)" to="(260,2580)"/>
-    <wire from="(80,3670)" to="(80,3830)"/>
-    <wire from="(140,2880)" to="(230,2880)"/>
-    <wire from="(200,3830)" to="(230,3830)"/>
-    <wire from="(290,1360)" to="(320,1360)"/>
-    <wire from="(230,3540)" to="(260,3540)"/>
-    <wire from="(240,1640)" to="(260,1640)"/>
-    <wire from="(100,2410)" to="(100,2580)"/>
-    <wire from="(240,3240)" to="(260,3240)"/>
-    <wire from="(100,3690)" to="(100,3860)"/>
-    <wire from="(240,1530)" to="(240,1570)"/>
-    <wire from="(160,600)" to="(180,600)"/>
-    <wire from="(120,3710)" to="(120,3890)"/>
-    <wire from="(200,2970)" to="(260,2970)"/>
-    <wire from="(200,1050)" to="(260,1050)"/>
-    <wire from="(200,1370)" to="(260,1370)"/>
-    <wire from="(120,4170)" to="(180,4170)"/>
-    <wire from="(60,20)" to="(180,20)"/>
-    <wire from="(230,50)" to="(230,60)"/>
-    <wire from="(60,1300)" to="(180,1300)"/>
-    <wire from="(230,1330)" to="(230,1340)"/>
-    <wire from="(220,1960)" to="(220,1970)"/>
-    <wire from="(230,2290)" to="(230,2300)"/>
-    <wire from="(220,3880)" to="(220,3890)"/>
-    <wire from="(240,2300)" to="(240,2320)"/>
-    <wire from="(230,2610)" to="(230,2630)"/>
-    <wire from="(230,3890)" to="(230,3910)"/>
-    <wire from="(230,1970)" to="(230,2000)"/>
-    <wire from="(240,3900)" to="(240,3930)"/>
-    <wire from="(200,2030)" to="(240,2030)"/>
-    <wire from="(200,2350)" to="(240,2350)"/>
-    <wire from="(80,1020)" to="(180,1020)"/>
-    <wire from="(80,2940)" to="(180,2940)"/>
-    <wire from="(200,760)" to="(230,760)"/>
-    <wire from="(200,1400)" to="(230,1400)"/>
-    <wire from="(240,2090)" to="(260,2090)"/>
-    <wire from="(160,3930)" to="(180,3930)"/>
-    <wire from="(290,3420)" to="(310,3420)"/>
-    <wire from="(240,2620)" to="(240,2660)"/>
-    <wire from="(340,1170)" to="(340,1670)"/>
-    <wire from="(240,1980)" to="(240,2030)"/>
-    <wire from="(200,220)" to="(260,220)"/>
-    <wire from="(200,540)" to="(260,540)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(330,3240)" to="(380,3240)"/>
-    <wire from="(60,150)" to="(180,150)"/>
-    <wire from="(230,180)" to="(230,190)"/>
-    <wire from="(60,470)" to="(180,470)"/>
-    <wire from="(230,500)" to="(230,510)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(240,1150)" to="(240,1180)"/>
-    <wire from="(80,1470)" to="(180,1470)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(80,3390)" to="(180,3390)"/>
-    <wire from="(200,570)" to="(230,570)"/>
-    <wire from="(100,2840)" to="(260,2840)"/>
-    <wire from="(290,2270)" to="(310,2270)"/>
-    <wire from="(100,3110)" to="(180,3110)"/>
-    <wire from="(320,1110)" to="(380,1110)"/>
-    <wire from="(200,350)" to="(260,350)"/>
-    <wire from="(200,670)" to="(260,670)"/>
-    <wire from="(60,3800)" to="(180,3800)"/>
-    <wire from="(230,2870)" to="(230,2880)"/>
-    <wire from="(160,300)" to="(160,440)"/>
-    <wire from="(240,2880)" to="(240,2890)"/>
-    <wire from="(230,3830)" to="(230,3850)"/>
-    <wire from="(100,1200)" to="(100,1350)"/>
-    <wire from="(120,1220)" to="(120,1370)"/>
-    <wire from="(160,3180)" to="(160,3330)"/>
-    <wire from="(80,1180)" to="(80,1330)"/>
-    <wire from="(140,950)" to="(180,950)"/>
-    <wire from="(80,320)" to="(180,320)"/>
-    <wire from="(80,640)" to="(180,640)"/>
-    <wire from="(80,2240)" to="(180,2240)"/>
-    <wire from="(80,2560)" to="(180,2560)"/>
-    <wire from="(200,1020)" to="(230,1020)"/>
-    <wire from="(140,3910)" to="(230,3910)"/>
-    <wire from="(140,1240)" to="(140,1400)"/>
-    <wire from="(230,1690)" to="(260,1690)"/>
-    <wire from="(200,2940)" to="(230,2940)"/>
-    <wire from="(230,3290)" to="(260,3290)"/>
-    <wire from="(240,1390)" to="(260,1390)"/>
-    <wire from="(360,1190)" to="(380,1190)"/>
-    <wire from="(240,1600)" to="(240,1640)"/>
-    <wire from="(240,110)" to="(260,110)"/>
-    <wire from="(160,3620)" to="(240,3620)"/>
-    <wire from="(200,800)" to="(260,800)"/>
-    <wire from="(230,760)" to="(230,770)"/>
-    <wire from="(230,1080)" to="(230,1090)"/>
-    <wire from="(230,3000)" to="(230,3010)"/>
-    <wire from="(350,1180)" to="(350,1830)"/>
-    <wire from="(240,3010)" to="(240,3030)"/>
-    <wire from="(60,3210)" to="(60,3360)"/>
-    <wire from="(160,2030)" to="(160,2180)"/>
-    <wire from="(240,1090)" to="(240,1120)"/>
-    <wire from="(140,1400)" to="(180,1400)"/>
-    <wire from="(220,4040)" to="(260,4040)"/>
-    <wire from="(200,1470)" to="(230,1470)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(80,1630)" to="(80,1790)"/>
-    <wire from="(140,410)" to="(140,570)"/>
-    <wire from="(350,3220)" to="(380,3220)"/>
-    <wire from="(290,920)" to="(320,920)"/>
-    <wire from="(230,2140)" to="(260,2140)"/>
-    <wire from="(200,3390)" to="(230,3390)"/>
-    <wire from="(230,3100)" to="(260,3100)"/>
-    <wire from="(120,2760)" to="(120,2860)"/>
-    <wire from="(140,2780)" to="(140,2880)"/>
-    <wire from="(200,2440)" to="(220,2440)"/>
-    <wire from="(200,2760)" to="(220,2760)"/>
-    <wire from="(160,1120)" to="(180,1120)"/>
-    <wire from="(240,240)" to="(260,240)"/>
-    <wire from="(240,560)" to="(260,560)"/>
-    <wire from="(350,2590)" to="(350,3220)"/>
-    <wire from="(100,2410)" to="(180,2410)"/>
-    <wire from="(100,2730)" to="(180,2730)"/>
-    <wire from="(160,2790)" to="(240,2790)"/>
-    <wire from="(120,1220)" to="(260,1220)"/>
-    <wire from="(310,2120)" to="(310,2180)"/>
-    <wire from="(100,4020)" to="(100,4140)"/>
-    <wire from="(320,3290)" to="(380,3290)"/>
-    <wire from="(40,130)" to="(100,130)"/>
-    <wire from="(120,4050)" to="(180,4050)"/>
-    <wire from="(290,1670)" to="(340,1670)"/>
-    <wire from="(220,1840)" to="(220,1850)"/>
-    <wire from="(230,1850)" to="(230,1870)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(240,4100)" to="(240,4120)"/>
-    <wire from="(160,4080)" to="(160,4230)"/>
-    <wire from="(60,2060)" to="(60,2210)"/>
-    <wire from="(140,570)" to="(180,570)"/>
-    <wire from="(200,1270)" to="(240,1270)"/>
-    <wire from="(340,1090)" to="(380,1090)"/>
-    <wire from="(80,2820)" to="(180,2820)"/>
-    <wire from="(200,320)" to="(230,320)"/>
-    <wire from="(200,640)" to="(230,640)"/>
-    <wire from="(100,3550)" to="(260,3550)"/>
-    <wire from="(120,2440)" to="(120,2600)"/>
-    <wire from="(200,2240)" to="(230,2240)"/>
-    <wire from="(200,2560)" to="(230,2560)"/>
-    <wire from="(290,1060)" to="(310,1060)"/>
-    <wire from="(240,1330)" to="(260,1330)"/>
-    <wire from="(200,4170)" to="(220,4170)"/>
-    <wire from="(140,3740)" to="(140,3910)"/>
-    <wire from="(240,50)" to="(260,50)"/>
-    <wire from="(160,1570)" to="(180,1570)"/>
-    <wire from="(330,790)" to="(330,1100)"/>
-    <wire from="(100,4140)" to="(180,4140)"/>
-    <wire from="(360,1190)" to="(360,1950)"/>
-    <wire from="(290,2420)" to="(360,2420)"/>
-    <wire from="(290,4030)" to="(350,4030)"/>
-    <wire from="(360,360)" to="(360,1070)"/>
-    <wire from="(220,370)" to="(220,380)"/>
-    <wire from="(220,690)" to="(220,700)"/>
-    <wire from="(60,990)" to="(180,990)"/>
-    <wire from="(60,2910)" to="(180,2910)"/>
-    <wire from="(60,740)" to="(240,740)"/>
-    <wire from="(230,2940)" to="(230,2960)"/>
-    <wire from="(230,3580)" to="(230,3600)"/>
-    <wire from="(230,700)" to="(230,720)"/>
-    <wire from="(240,710)" to="(240,730)"/>
-    <wire from="(230,1020)" to="(230,1040)"/>
-    <wire from="(200,440)" to="(240,440)"/>
-    <wire from="(240,3590)" to="(240,3620)"/>
-    <wire from="(200,3640)" to="(240,3640)"/>
-    <wire from="(200,3960)" to="(240,3960)"/>
-    <wire from="(230,380)" to="(230,410)"/>
-    <wire from="(200,1090)" to="(230,1090)"/>
-    <wire from="(230,2400)" to="(260,2400)"/>
-    <wire from="(230,2720)" to="(260,2720)"/>
-    <wire from="(200,3010)" to="(230,3010)"/>
-    <wire from="(230,3680)" to="(260,3680)"/>
-    <wire from="(240,820)" to="(260,820)"/>
-    <wire from="(240,180)" to="(260,180)"/>
-    <wire from="(240,500)" to="(260,500)"/>
-    <wire from="(160,2660)" to="(180,2660)"/>
-    <wire from="(240,390)" to="(240,440)"/>
-    <wire from="(290,4150)" to="(360,4150)"/>
-    <wire from="(200,3110)" to="(260,3110)"/>
-    <wire from="(200,3430)" to="(260,3430)"/>
-    <wire from="(200,1510)" to="(260,1510)"/>
-    <wire from="(60,1440)" to="(180,1440)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(60,3360)" to="(180,3360)"/>
-    <wire from="(60,20)" to="(60,30)"/>
-    <wire from="(230,1470)" to="(230,1480)"/>
-    <wire from="(230,3390)" to="(230,3400)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(200,3770)" to="(240,3770)"/>
-    <wire from="(80,3080)" to="(180,3080)"/>
-    <wire from="(200,1540)" to="(230,1540)"/>
-    <wire from="(140,1870)" to="(230,1870)"/>
-    <wire from="(200,2820)" to="(230,2820)"/>
-    <wire from="(230,4130)" to="(260,4130)"/>
-    <wire from="(240,950)" to="(260,950)"/>
-    <wire from="(360,1070)" to="(380,1070)"/>
-    <wire from="(80,4120)" to="(230,4120)"/>
-    <wire from="(200,2280)" to="(260,2280)"/>
-    <wire from="(200,2600)" to="(260,2600)"/>
-    <wire from="(60,290)" to="(180,290)"/>
-    <wire from="(60,2210)" to="(180,2210)"/>
-    <wire from="(60,2530)" to="(180,2530)"/>
-    <wire from="(60,850)" to="(60,990)"/>
-    <wire from="(230,1920)" to="(230,1930)"/>
-    <wire from="(230,2240)" to="(230,2250)"/>
-    <wire from="(230,2560)" to="(230,2570)"/>
-    <wire from="(160,1270)" to="(160,1420)"/>
-    <wire from="(230,320)" to="(230,340)"/>
-    <wire from="(230,640)" to="(230,660)"/>
-    <wire from="(240,3210)" to="(240,3240)"/>
-    <wire from="(290,790)" to="(330,790)"/>
-    <wire from="(220,1680)" to="(260,1680)"/>
-    <wire from="(80,3530)" to="(180,3530)"/>
-    <wire from="(230,100)" to="(260,100)"/>
-    <wire from="(140,720)" to="(230,720)"/>
-    <wire from="(230,1380)" to="(260,1380)"/>
-    <wire from="(200,2630)" to="(230,2630)"/>
-    <wire from="(350,1180)" to="(380,1180)"/>
-    <wire from="(240,760)" to="(260,760)"/>
-    <wire from="(310,80)" to="(310,130)"/>
-    <wire from="(200,2410)" to="(260,2410)"/>
-    <wire from="(200,2730)" to="(260,2730)"/>
-    <wire from="(120,1370)" to="(180,1370)"/>
-    <wire from="(120,1690)" to="(180,1690)"/>
-    <wire from="(60,1300)" to="(60,1440)"/>
-    <wire from="(80,3240)" to="(80,3390)"/>
-    <wire from="(100,3260)" to="(100,3410)"/>
-    <wire from="(120,3280)" to="(120,3430)"/>
-    <wire from="(140,3300)" to="(140,3450)"/>
-    <wire from="(140,1090)" to="(180,1090)"/>
-    <wire from="(240,2060)" to="(240,2090)"/>
-    <wire from="(200,1150)" to="(240,1150)"/>
-    <wire from="(140,3010)" to="(180,3010)"/>
-    <wire from="(80,2380)" to="(180,2380)"/>
-    <wire from="(80,2700)" to="(180,2700)"/>
-    <wire from="(230,230)" to="(260,230)"/>
-    <wire from="(230,550)" to="(260,550)"/>
-    <wire from="(100,1660)" to="(100,1820)"/>
-    <wire from="(160,440)" to="(160,600)"/>
-    <wire from="(230,1190)" to="(260,1190)"/>
-    <wire from="(200,3080)" to="(230,3080)"/>
-    <wire from="(240,890)" to="(260,890)"/>
-    <wire from="(240,1530)" to="(260,1530)"/>
-    <wire from="(240,3450)" to="(260,3450)"/>
-    <wire from="(200,4050)" to="(220,4050)"/>
-    <wire from="(100,4020)" to="(180,4020)"/>
-    <wire from="(160,4080)" to="(240,4080)"/>
-    <wire from="(320,920)" to="(320,1110)"/>
-    <wire from="(120,4050)" to="(120,4170)"/>
-    <wire from="(310,3280)" to="(380,3280)"/>
-    <wire from="(200,2860)" to="(260,2860)"/>
-    <wire from="(200,4140)" to="(260,4140)"/>
-    <wire from="(120,220)" to="(180,220)"/>
-    <wire from="(120,540)" to="(180,540)"/>
-    <wire from="(140,4070)" to="(140,4200)"/>
-    <wire from="(310,3280)" to="(310,3420)"/>
-    <wire from="(60,150)" to="(60,290)"/>
-    <wire from="(60,620)" to="(240,620)"/>
-    <wire from="(230,2820)" to="(230,2830)"/>
-    <wire from="(230,3140)" to="(230,3150)"/>
-    <wire from="(80,2090)" to="(80,2240)"/>
-    <wire from="(100,2110)" to="(100,2260)"/>
-    <wire from="(120,2130)" to="(120,2280)"/>
-    <wire from="(140,2150)" to="(140,2300)"/>
-    <wire from="(60,470)" to="(60,620)"/>
-    <wire from="(140,1540)" to="(180,1540)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(240,3150)" to="(240,3180)"/>
-    <wire from="(140,2470)" to="(140,2630)"/>
-    <wire from="(160,3770)" to="(160,3930)"/>
-    <wire from="(200,3530)" to="(230,3530)"/>
-    <wire from="(290,2980)" to="(320,2980)"/>
-    <wire from="(310,130)" to="(330,130)"/>
-    <wire from="(240,1980)" to="(260,1980)"/>
-    <wire from="(240,2300)" to="(260,2300)"/>
-    <wire from="(240,2620)" to="(260,2620)"/>
-    <wire from="(240,3900)" to="(260,3900)"/>
-    <wire from="(160,3180)" to="(180,3180)"/>
-    <wire from="(120,3280)" to="(260,3280)"/>
-    <wire from="(100,130)" to="(100,200)"/>
-    <wire from="(200,1730)" to="(240,1730)"/>
-    <wire from="(140,2630)" to="(180,2630)"/>
-    <wire from="(200,3330)" to="(240,3330)"/>
-    <wire from="(290,1500)" to="(330,1500)"/>
-    <wire from="(340,680)" to="(340,1090)"/>
-    <wire from="(230,810)" to="(260,810)"/>
-    <wire from="(60,3800)" to="(60,3960)"/>
-    <wire from="(100,3690)" to="(260,3690)"/>
-    <wire from="(200,2380)" to="(230,2380)"/>
-    <wire from="(200,2700)" to="(230,2700)"/>
-    <wire from="(230,4010)" to="(260,4010)"/>
-    <wire from="(240,1470)" to="(260,1470)"/>
-    <wire from="(310,2180)" to="(330,2180)"/>
-    <wire from="(290,3120)" to="(310,3120)"/>
-    <wire from="(240,3390)" to="(260,3390)"/>
-    <wire from="(160,2030)" to="(180,2030)"/>
-    <wire from="(120,2130)" to="(260,2130)"/>
-    <wire from="(310,150)" to="(310,210)"/>
-    <wire from="(120,800)" to="(180,800)"/>
-    <wire from="(320,3290)" to="(320,3560)"/>
-    <wire from="(60,3050)" to="(180,3050)"/>
-    <wire from="(220,2430)" to="(220,2440)"/>
-    <wire from="(220,2750)" to="(220,2760)"/>
-    <wire from="(60,2800)" to="(240,2800)"/>
-    <wire from="(160,830)" to="(160,970)"/>
-    <wire from="(230,2760)" to="(230,2780)"/>
-    <wire from="(240,2770)" to="(240,2790)"/>
-    <wire from="(230,3080)" to="(230,3100)"/>
-    <wire from="(230,3720)" to="(230,3740)"/>
-    <wire from="(230,2440)" to="(230,2470)"/>
-    <wire from="(200,260)" to="(240,260)"/>
-    <wire from="(200,2180)" to="(240,2180)"/>
-    <wire from="(200,2500)" to="(240,2500)"/>
-    <wire from="(200,4100)" to="(240,4100)"/>
-    <wire from="(80,50)" to="(80,80)"/>
-    <wire from="(230,940)" to="(260,940)"/>
-    <wire from="(290,3560)" to="(320,3560)"/>
-    <wire from="(200,3150)" to="(230,3150)"/>
-    <wire from="(240,1920)" to="(260,1920)"/>
-    <wire from="(240,2240)" to="(260,2240)"/>
-    <wire from="(240,2560)" to="(260,2560)"/>
-    <wire from="(240,2880)" to="(260,2880)"/>
-    <wire from="(240,3840)" to="(260,3840)"/>
-    <wire from="(410,1130)" to="(430,1130)"/>
-    <wire from="(240,850)" to="(240,890)"/>
-    <wire from="(240,3730)" to="(240,3770)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(240,2450)" to="(240,2500)"/>
-    <wire from="(100,70)" to="(100,130)"/>
-    <wire from="(330,2850)" to="(330,3240)"/>
-    <wire from="(200,3570)" to="(260,3570)"/>
-    <wire from="(310,2200)" to="(310,2270)"/>
-    <wire from="(60,1900)" to="(180,1900)"/>
-    <wire from="(60,3500)" to="(180,3500)"/>
-    <wire from="(80,880)" to="(80,1020)"/>
-    <wire from="(230,3530)" to="(230,3540)"/>
-    <wire from="(220,4160)" to="(220,4170)"/>
-    <wire from="(360,2420)" to="(360,3210)"/>
-    <wire from="(240,1300)" to="(240,1330)"/>
-    <wire from="(230,4170)" to="(230,4200)"/>
-    <wire from="(240,20)" to="(240,50)"/>
-    <wire from="(340,1170)" to="(380,1170)"/>
-    <wire from="(200,4230)" to="(240,4230)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(200,2000)" to="(230,2000)"/>
-    <wire from="(200,3600)" to="(230,3600)"/>
-    <wire from="(240,1090)" to="(260,1090)"/>
-    <wire from="(240,3010)" to="(260,3010)"/>
-    <wire from="(160,260)" to="(160,300)"/>
-    <wire from="(200,1690)" to="(220,1690)"/>
-    <wire from="(100,1660)" to="(180,1660)"/>
-    <wire from="(240,4180)" to="(240,4230)"/>
-    <wire from="(60,30)" to="(60,150)"/>
-    <wire from="(140,110)" to="(140,240)"/>
-    <wire from="(160,130)" to="(160,260)"/>
-    <wire from="(200,4020)" to="(260,4020)"/>
-    <wire from="(160,3330)" to="(160,3470)"/>
-    <wire from="(60,2350)" to="(180,2350)"/>
-    <wire from="(80,1330)" to="(80,1470)"/>
-    <wire from="(60,2910)" to="(60,3050)"/>
-    <wire from="(100,1350)" to="(100,1490)"/>
-    <wire from="(120,1370)" to="(120,1510)"/>
-    <wire from="(230,2380)" to="(230,2400)"/>
-    <wire from="(230,2700)" to="(230,2720)"/>
-    <wire from="(160,1730)" to="(160,1880)"/>
-    <wire from="(330,3300)" to="(330,3700)"/>
-    <wire from="(240,150)" to="(240,180)"/>
-    <wire from="(240,470)" to="(240,500)"/>
-    <wire from="(290,2850)" to="(330,2850)"/>
-    <wire from="(80,3670)" to="(180,3670)"/>
-    <wire from="(80,3990)" to="(180,3990)"/>
-    <wire from="(60,990)" to="(60,1150)"/>
-    <wire from="(100,1200)" to="(260,1200)"/>
-    <wire from="(120,1690)" to="(120,1850)"/>
-    <wire from="(140,1710)" to="(140,1870)"/>
-    <wire from="(140,2780)" to="(230,2780)"/>
-    <wire from="(230,1520)" to="(260,1520)"/>
-    <wire from="(230,3440)" to="(260,3440)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,2820)" to="(260,2820)"/>
-    <wire from="(360,140)" to="(430,140)"/>
-    <wire from="(120,1510)" to="(180,1510)"/>
-    <wire from="(120,3430)" to="(180,3430)"/>
-    <wire from="(60,1760)" to="(60,1900)"/>
-    <wire from="(80,180)" to="(80,320)"/>
-    <wire from="(80,500)" to="(80,640)"/>
-    <wire from="(230,1230)" to="(230,1240)"/>
-    <wire from="(60,3360)" to="(60,3500)"/>
-    <wire from="(160,2180)" to="(160,2320)"/>
-    <wire from="(100,200)" to="(100,350)"/>
-    <wire from="(100,520)" to="(100,670)"/>
-    <wire from="(240,1240)" to="(240,1270)"/>
-    <wire from="(140,3150)" to="(180,3150)"/>
-    <wire from="(200,3210)" to="(240,3210)"/>
-    <wire from="(40,240)" to="(140,240)"/>
-    <wire from="(60,1440)" to="(60,1600)"/>
-    <wire from="(120,220)" to="(120,380)"/>
-    <wire from="(120,540)" to="(120,700)"/>
-    <wire from="(160,2500)" to="(160,2660)"/>
-    <wire from="(230,1650)" to="(260,1650)"/>
-    <wire from="(230,1970)" to="(260,1970)"/>
-    <wire from="(230,2290)" to="(260,2290)"/>
-    <wire from="(230,2610)" to="(260,2610)"/>
-    <wire from="(230,3250)" to="(260,3250)"/>
-    <wire from="(230,3890)" to="(260,3890)"/>
-    <wire from="(240,1030)" to="(260,1030)"/>
-    <wire from="(140,240)" to="(140,410)"/>
-    <wire from="(240,2950)" to="(260,2950)"/>
-    <wire from="(240,3590)" to="(260,3590)"/>
-    <wire from="(240,3800)" to="(240,3840)"/>
-    <wire from="(240,390)" to="(260,390)"/>
-    <wire from="(240,710)" to="(260,710)"/>
-    <wire from="(160,1270)" to="(180,1270)"/>
-    <wire from="(120,90)" to="(260,90)"/>
-    <wire from="(360,2190)" to="(430,2190)"/>
-    <wire from="(290,530)" to="(350,530)"/>
-    <wire from="(120,2280)" to="(180,2280)"/>
-    <wire from="(120,2600)" to="(180,2600)"/>
-    <wire from="(60,2210)" to="(60,2350)"/>
-    <wire from="(60,2680)" to="(240,2680)"/>
-    <wire from="(60,2530)" to="(60,2680)"/>
-    <wire from="(140,2000)" to="(180,2000)"/>
-    <wire from="(140,3600)" to="(180,3600)"/>
-    <wire from="(200,2060)" to="(240,2060)"/>
-    <wire from="(80,3830)" to="(80,3990)"/>
-    <wire from="(230,2100)" to="(260,2100)"/>
-    <wire from="(200,3670)" to="(230,3670)"/>
-    <wire from="(200,3990)" to="(230,3990)"/>
-    <wire from="(290,1210)" to="(310,1210)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(160,440)" to="(180,440)"/>
-    <wire from="(60,740)" to="(60,850)"/>
-    <wire from="(160,830)" to="(240,830)"/>
-    <wire from="(60,290)" to="(60,470)"/>
-    <wire from="(340,3310)" to="(340,3870)"/>
-    <wire from="(80,760)" to="(80,880)"/>
-    <wire from="(120,800)" to="(120,930)"/>
-    <wire from="(140,820)" to="(140,950)"/>
-    <wire from="(320,3250)" to="(380,3250)"/>
-    <wire from="(100,780)" to="(100,910)"/>
-    <wire from="(320,2980)" to="(320,3250)"/>
-    <wire from="(290,3870)" to="(340,3870)"/>
-    <wire from="(220,4040)" to="(220,4050)"/>
-    <wire from="(230,4050)" to="(230,4070)"/>
-    <wire from="(240,4060)" to="(240,4080)"/>
-    <wire from="(200,3470)" to="(240,3470)"/>
-    <wire from="(80,1180)" to="(180,1180)"/>
-    <wire from="(200,1240)" to="(230,1240)"/>
-    <wire from="(230,2870)" to="(260,2870)"/>
-    <wire from="(160,3770)" to="(180,3770)"/>
-    <wire from="(240,3530)" to="(260,3530)"/>
-    <wire from="(360,3330)" to="(380,3330)"/>
-    <wire from="(240,330)" to="(260,330)"/>
-    <wire from="(240,650)" to="(260,650)"/>
-    <wire from="(310,1120)" to="(380,1120)"/>
-    <wire from="(200,1660)" to="(260,1660)"/>
-    <wire from="(120,2860)" to="(180,2860)"/>
-    <wire from="(330,1160)" to="(380,1160)"/>
-    <wire from="(100,910)" to="(100,1050)"/>
-    <wire from="(120,930)" to="(120,1070)"/>
-    <wire from="(140,950)" to="(140,1090)"/>
-    <wire from="(160,2890)" to="(160,3030)"/>
-    <wire from="(160,970)" to="(160,1120)"/>
-    <wire from="(200,2320)" to="(240,2320)"/>
-    <wire from="(80,1630)" to="(180,1630)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(230,1080)" to="(260,1080)"/>
-    <wire from="(230,3000)" to="(260,3000)"/>
-    <wire from="(240,990)" to="(240,1030)"/>
-    <wire from="(340,2740)" to="(340,3230)"/>
-    <wire from="(240,2910)" to="(240,2950)"/>
-    <wire from="(160,130)" to="(240,130)"/>
-    <wire from="(310,1060)" to="(310,1120)"/>
-    <wire from="(200,3710)" to="(260,3710)"/>
-    <wire from="(350,3320)" to="(350,4030)"/>
-    <wire from="(60,3640)" to="(180,3640)"/>
-    <wire from="(60,3960)" to="(180,3960)"/>
-    <wire from="(80,2940)" to="(80,3080)"/>
-    <wire from="(140,1400)" to="(140,1540)"/>
-    <wire from="(230,3670)" to="(230,3680)"/>
-    <wire from="(230,3990)" to="(230,4010)"/>
-    <wire from="(160,1420)" to="(160,1570)"/>
-    <wire from="(240,1440)" to="(240,1470)"/>
-    <wire from="(200,850)" to="(240,850)"/>
-    <wire from="(240,3360)" to="(240,3390)"/>
-    <wire from="(340,3230)" to="(380,3230)"/>
-    <wire from="(200,1180)" to="(230,1180)"/>
-    <wire from="(80,1020)" to="(80,1180)"/>
-    <wire from="(140,4070)" to="(230,4070)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(200,3740)" to="(230,3740)"/>
-    <wire from="(240,3150)" to="(260,3150)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(120,930)" to="(260,930)"/>
-    <wire from="(80,1790)" to="(80,1920)"/>
-    <wire from="(330,1100)" to="(380,1100)"/>
-    <wire from="(80,3390)" to="(80,3530)"/>
-    <wire from="(230,4120)" to="(230,4130)"/>
-    <wire from="(100,3410)" to="(100,3550)"/>
-    <wire from="(120,3430)" to="(120,3570)"/>
-    <wire from="(160,3470)" to="(160,3620)"/>
-    <wire from="(140,570)" to="(140,720)"/>
-    <wire from="(140,3450)" to="(140,3600)"/>
-    <wire from="(140,1240)" to="(180,1240)"/>
-    <wire from="(240,2210)" to="(240,2240)"/>
-    <wire from="(240,2530)" to="(240,2560)"/>
-    <wire from="(200,20)" to="(240,20)"/>
-    <wire from="(200,1300)" to="(240,1300)"/>
-    <wire from="(220,1960)" to="(260,1960)"/>
-    <wire from="(220,3880)" to="(260,3880)"/>
-    <wire from="(230,60)" to="(260,60)"/>
-    <wire from="(230,380)" to="(260,380)"/>
-    <wire from="(230,700)" to="(260,700)"/>
-    <wire from="(200,1630)" to="(230,1630)"/>
-    <wire from="(80,1470)" to="(80,1630)"/>
-    <wire from="(60,3050)" to="(60,3210)"/>
-    <wire from="(100,3260)" to="(260,3260)"/>
-    <wire from="(230,1340)" to="(260,1340)"/>
-    <wire from="(230,3580)" to="(260,3580)"/>
-    <wire from="(310,150)" to="(330,150)"/>
-    <wire from="(100,1490)" to="(100,1660)"/>
-    <wire from="(240,290)" to="(240,330)"/>
-    <wire from="(360,3330)" to="(360,4150)"/>
-    <wire from="(120,1510)" to="(120,1690)"/>
-    <wire from="(60,620)" to="(60,740)"/>
-    <wire from="(80,640)" to="(80,760)"/>
-    <wire from="(120,1970)" to="(180,1970)"/>
-    <wire from="(120,3570)" to="(180,3570)"/>
-    <wire from="(120,3890)" to="(180,3890)"/>
-    <wire from="(220,1680)" to="(220,1690)"/>
-    <wire from="(60,3500)" to="(60,3640)"/>
-    <wire from="(80,2240)" to="(80,2380)"/>
-    <wire from="(80,2560)" to="(80,2700)"/>
-    <wire from="(230,3290)" to="(230,3300)"/>
-    <wire from="(230,1690)" to="(230,1710)"/>
-    <wire from="(100,2260)" to="(100,2410)"/>
-    <wire from="(100,2580)" to="(100,2730)"/>
-    <wire from="(240,740)" to="(240,760)"/>
-    <wire from="(140,410)" to="(180,410)"/>
-    <wire from="(240,1700)" to="(240,1730)"/>
-    <wire from="(200,150)" to="(240,150)"/>
-    <wire from="(200,470)" to="(240,470)"/>
-    <wire from="(240,3300)" to="(240,3330)"/>
-    <wire from="(230,190)" to="(260,190)"/>
-    <wire from="(230,510)" to="(260,510)"/>
-    <wire from="(60,1900)" to="(60,2060)"/>
-    <wire from="(100,2110)" to="(260,2110)"/>
-    <wire from="(120,2280)" to="(120,2440)"/>
-    <wire from="(100,3860)" to="(100,4020)"/>
-    <wire from="(120,2600)" to="(120,2760)"/>
-    <wire from="(240,2450)" to="(260,2450)"/>
-    <wire from="(240,2770)" to="(260,2770)"/>
-    <wire from="(160,3330)" to="(180,3330)"/>
-    <wire from="(80,1920)" to="(80,2090)"/>
-    <wire from="(100,1940)" to="(100,2110)"/>
-    <wire from="(310,2200)" to="(330,2200)"/>
-    <wire from="(240,3090)" to="(260,3090)"/>
-    <wire from="(240,3730)" to="(260,3730)"/>
-    <wire from="(140,2300)" to="(140,2470)"/>
-    <wire from="(360,3210)" to="(380,3210)"/>
-    <wire from="(160,1730)" to="(180,1730)"/>
-    <wire from="(80,320)" to="(80,500)"/>
-    <wire from="(160,2320)" to="(160,2500)"/>
-    <wire from="(290,2590)" to="(350,2590)"/>
-    <wire from="(60,1150)" to="(180,1150)"/>
-    <wire from="(290,680)" to="(340,680)"/>
-    <wire from="(230,1180)" to="(230,1190)"/>
-    <wire from="(230,2140)" to="(230,2150)"/>
-    <wire from="(240,2150)" to="(240,2180)"/>
-    <wire from="(200,600)" to="(240,600)"/>
-    <wire from="(140,3740)" to="(180,3740)"/>
-    <wire from="(200,3800)" to="(240,3800)"/>
-    <wire from="(350,3320)" to="(380,3320)"/>
-    <wire from="(350,1080)" to="(380,1080)"/>
-    <wire from="(240,4180)" to="(260,4180)"/>
-    <wire from="(60,2800)" to="(60,2910)"/>
-    <wire from="(160,260)" to="(180,260)"/>
-    <wire from="(160,2180)" to="(180,2180)"/>
-    <wire from="(160,2500)" to="(180,2500)"/>
-    <wire from="(100,910)" to="(180,910)"/>
-    <wire from="(160,970)" to="(240,970)"/>
-    <wire from="(160,2890)" to="(240,2890)"/>
-    <wire from="(60,2350)" to="(60,2530)"/>
-    <wire from="(80,2820)" to="(80,2940)"/>
-    <wire from="(100,2840)" to="(100,2970)"/>
-    <wire from="(320,1150)" to="(380,1150)"/>
-    <wire from="(120,2860)" to="(120,2990)"/>
-    <wire from="(140,2880)" to="(140,3010)"/>
-    <wire from="(40,300)" to="(160,300)"/>
-    <wire from="(60,1600)" to="(180,1600)"/>
-    <wire from="(230,1630)" to="(230,1650)"/>
-    <wire from="(200,3930)" to="(240,3930)"/>
-    <wire from="(80,3240)" to="(180,3240)"/>
-    <wire from="(290,3700)" to="(330,3700)"/>
-    <wire from="(230,770)" to="(260,770)"/>
-    <wire from="(140,1710)" to="(230,1710)"/>
-    <wire from="(200,3300)" to="(230,3300)"/>
-    <wire from="(240,2390)" to="(260,2390)"/>
-    <wire from="(240,2710)" to="(260,2710)"/>
-    <wire from="(160,4230)" to="(180,4230)"/>
-    <wire from="(290,2120)" to="(310,2120)"/>
-    <wire from="(240,3670)" to="(260,3670)"/>
-    <wire from="(160,1420)" to="(240,1420)"/>
-    <wire from="(100,2970)" to="(100,3110)"/>
-    <wire from="(120,2990)" to="(120,3130)"/>
-    <wire from="(140,3010)" to="(140,3150)"/>
-    <wire from="(100,1050)" to="(100,1200)"/>
-    <wire from="(120,1070)" to="(120,1220)"/>
-    <wire from="(140,1090)" to="(140,1240)"/>
-    <wire from="(160,3030)" to="(160,3180)"/>
-    <wire from="(220,1840)" to="(260,1840)"/>
-    <wire from="(80,2090)" to="(180,2090)"/>
-    <wire from="(290,3270)" to="(380,3270)"/>
-    <wire from="(230,900)" to="(260,900)"/>
-    <wire from="(140,240)" to="(230,240)"/>
-    <wire from="(200,2150)" to="(230,2150)"/>
-    <wire from="(200,2470)" to="(230,2470)"/>
-    <wire from="(230,3140)" to="(260,3140)"/>
-    <wire from="(240,1240)" to="(260,1240)"/>
-    <wire from="(240,4120)" to="(260,4120)"/>
-    <wire from="(240,3050)" to="(240,3090)"/>
-    <wire from="(100,1820)" to="(100,1940)"/>
-    <wire from="(160,600)" to="(160,730)"/>
-    <wire from="(120,1850)" to="(180,1850)"/>
-    <wire from="(60,4100)" to="(180,4100)"/>
-    <wire from="(240,1900)" to="(240,1920)"/>
-    <wire from="(160,1880)" to="(160,2030)"/>
-    <wire from="(220,370)" to="(260,370)"/>
-    <wire from="(220,690)" to="(260,690)"/>
-    <wire from="(200,990)" to="(240,990)"/>
-    <wire from="(240,3500)" to="(240,3530)"/>
-    <wire from="(200,2910)" to="(240,2910)"/>
-    <wire from="(240,620)" to="(240,650)"/>
-    <wire from="(100,70)" to="(260,70)"/>
-    <wire from="(100,1350)" to="(260,1350)"/>
-    <wire from="(80,3080)" to="(80,3240)"/>
-    <wire from="(200,3240)" to="(230,3240)"/>
-    <wire from="(160,730)" to="(160,830)"/>
-    <wire from="(200,4200)" to="(230,4200)"/>
-    <wire from="(200,3890)" to="(220,3890)"/>
-    <wire from="(140,1540)" to="(140,1710)"/>
-    <wire from="(200,1970)" to="(220,1970)"/>
-    <wire from="(100,670)" to="(100,780)"/>
-    <wire from="(100,1940)" to="(180,1940)"/>
-    <wire from="(100,3860)" to="(180,3860)"/>
-    <wire from="(120,1070)" to="(260,1070)"/>
-    <wire from="(120,2990)" to="(260,2990)"/>
-    <wire from="(290,1830)" to="(350,1830)"/>
-    <wire from="(120,380)" to="(180,380)"/>
-    <wire from="(120,700)" to="(180,700)"/>
-    <wire from="(230,100)" to="(230,110)"/>
-    <wire from="(310,3120)" to="(310,3260)"/>
-    <wire from="(80,3530)" to="(80,3670)"/>
-    <wire from="(100,3550)" to="(100,3690)"/>
-    <wire from="(120,3570)" to="(120,3710)"/>
-    <wire from="(230,1380)" to="(230,1400)"/>
-    <wire from="(160,3930)" to="(160,4080)"/>
-    <wire from="(140,2630)" to="(140,2780)"/>
-    <wire from="(240,110)" to="(240,130)"/>
-    <wire from="(240,1390)" to="(240,1420)"/>
-    <wire from="(200,1120)" to="(240,1120)"/>
-    <wire from="(200,1440)" to="(240,1440)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(140,3300)" to="(180,3300)"/>
-    <wire from="(200,3360)" to="(240,3360)"/>
-    <wire from="(100,200)" to="(260,200)"/>
-    <wire from="(100,520)" to="(260,520)"/>
-    <wire from="(120,1970)" to="(120,2130)"/>
-    <wire from="(120,3890)" to="(120,4050)"/>
-    <wire from="(140,820)" to="(230,820)"/>
-    <wire from="(140,3910)" to="(140,4070)"/>
-    <wire from="(230,1480)" to="(260,1480)"/>
-    <wire from="(200,2090)" to="(230,2090)"/>
-    <wire from="(230,2440)" to="(260,2440)"/>
-    <wire from="(230,2760)" to="(260,2760)"/>
-    <wire from="(230,3400)" to="(260,3400)"/>
-    <wire from="(230,3720)" to="(260,3720)"/>
-    <wire from="(240,1180)" to="(260,1180)"/>
-    <wire from="(240,4060)" to="(260,4060)"/>
-    <wire from="(410,3270)" to="(430,3270)"/>
-    <wire from="(100,350)" to="(100,520)"/>
-    <wire from="(240,2350)" to="(240,2390)"/>
-    <wire from="(60,2680)" to="(60,2800)"/>
-    <wire from="(80,2700)" to="(80,2820)"/>
-    <wire from="(290,1950)" to="(360,1950)"/>
-    <comp lib="0" loc="(430,3270)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,360)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2850)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(430,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,80)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3080)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1060)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,790)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,2190)" name="OR Gate">
+    <comp lib="0" loc="(340,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="1" loc="(1180,230)" name="XOR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(200,670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4030)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2980)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2590)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,3120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3270)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="13"/>
-    </comp>
-    <comp lib="1" loc="(200,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(360,140)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3670)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,300)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3640)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,1130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2740)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(430,2190)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUop2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1360)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4200)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3870)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1130)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="12"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-  </circuit>
-  <circuit name="Opcode_Decoder">
-    <a name="circuit" val="Opcode_Decoder"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="none" height="235" stroke="#000000" stroke-width="2" width="31" x="50" y="55"/>
-      <circ-port height="8" pin="40,30" width="8" x="46" y="136"/>
-      <circ-port height="10" pin="420,70" width="10" x="75" y="65"/>
-      <circ-port height="8" pin="40,80" width="8" x="46" y="146"/>
-      <circ-port height="8" pin="40,140" width="8" x="46" y="156"/>
-      <circ-port height="10" pin="420,180" width="10" x="75" y="85"/>
-      <circ-port height="8" pin="40,190" width="8" x="46" y="166"/>
-      <circ-port height="8" pin="40,250" width="8" x="46" y="176"/>
-      <circ-port height="8" pin="40,300" width="8" x="46" y="186"/>
-      <circ-port height="10" pin="420,750" width="10" x="75" y="105"/>
-      <circ-port height="10" pin="420,1490" width="10" x="75" y="125"/>
-      <circ-port height="10" pin="420,1690" width="10" x="75" y="145"/>
-      <circ-port height="10" pin="420,1900" width="10" x="75" y="165"/>
-      <circ-port height="10" pin="420,2130" width="10" x="75" y="185"/>
-      <circ-port height="10" pin="420,2970" width="10" x="75" y="205"/>
-      <circ-port height="10" pin="420,3790" width="10" x="75" y="225"/>
-      <circ-port height="10" pin="420,3930" width="10" x="75" y="245"/>
-      <circ-port height="10" pin="420,4130" width="10" x="75" y="265"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
-    </appear>
-    <wire from="(120,190)" to="(180,190)"/>
-    <wire from="(350,3020)" to="(350,3610)"/>
-    <wire from="(60,3720)" to="(180,3720)"/>
-    <wire from="(330,450)" to="(330,720)"/>
-    <wire from="(220,2140)" to="(220,2150)"/>
-    <wire from="(230,3750)" to="(230,3770)"/>
-    <wire from="(230,2150)" to="(230,2180)"/>
-    <wire from="(140,2790)" to="(180,2790)"/>
-    <wire from="(240,3120)" to="(240,3150)"/>
-    <wire from="(200,2210)" to="(240,2210)"/>
-    <wire from="(200,2850)" to="(240,2850)"/>
-    <wire from="(240,240)" to="(240,270)"/>
-    <wire from="(320,730)" to="(360,730)"/>
-    <wire from="(230,2890)" to="(260,2890)"/>
-    <wire from="(200,3820)" to="(230,3820)"/>
-    <wire from="(240,990)" to="(260,990)"/>
-    <wire from="(200,3510)" to="(220,3510)"/>
-    <wire from="(350,3020)" to="(370,3020)"/>
-    <wire from="(200,1590)" to="(220,1590)"/>
-    <wire from="(100,1560)" to="(180,1560)"/>
-    <wire from="(160,1620)" to="(240,1620)"/>
-    <wire from="(100,3480)" to="(180,3480)"/>
-    <wire from="(160,3540)" to="(240,3540)"/>
-    <wire from="(120,690)" to="(260,690)"/>
-    <wire from="(240,2160)" to="(240,2210)"/>
-    <wire from="(120,4210)" to="(260,4210)"/>
-    <wire from="(310,1910)" to="(310,1970)"/>
-    <wire from="(120,1590)" to="(120,1710)"/>
-    <wire from="(140,1610)" to="(140,1730)"/>
-    <wire from="(120,3510)" to="(120,3630)"/>
-    <wire from="(200,3600)" to="(260,3600)"/>
-    <wire from="(200,3920)" to="(260,3920)"/>
-    <wire from="(140,3530)" to="(140,3660)"/>
-    <wire from="(200,1680)" to="(260,1680)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(80,270)" to="(80,410)"/>
-    <wire from="(80,3150)" to="(80,3290)"/>
-    <wire from="(100,3170)" to="(100,3310)"/>
-    <wire from="(120,3190)" to="(120,3330)"/>
-    <wire from="(100,290)" to="(100,440)"/>
-    <wire from="(200,740)" to="(240,740)"/>
-    <wire from="(200,2980)" to="(240,2980)"/>
-    <wire from="(80,1650)" to="(180,1650)"/>
-    <wire from="(80,3890)" to="(180,3890)"/>
-    <wire from="(200,1070)" to="(230,1070)"/>
-    <wire from="(120,310)" to="(120,470)"/>
-    <wire from="(160,1310)" to="(160,1470)"/>
-    <wire from="(230,3020)" to="(260,3020)"/>
-    <wire from="(290,2760)" to="(320,2760)"/>
-    <wire from="(230,3340)" to="(260,3340)"/>
-    <wire from="(240,800)" to="(260,800)"/>
-    <wire from="(240,1440)" to="(260,1440)"/>
-    <wire from="(290,4050)" to="(310,4050)"/>
-    <wire from="(240,480)" to="(260,480)"/>
-    <wire from="(310,760)" to="(310,830)"/>
-    <wire from="(120,3330)" to="(180,3330)"/>
-    <wire from="(60,2060)" to="(180,2060)"/>
-    <wire from="(60,2700)" to="(180,2700)"/>
-    <wire from="(230,2730)" to="(230,2740)"/>
-    <wire from="(230,2090)" to="(230,2110)"/>
-    <wire from="(240,2420)" to="(240,2450)"/>
-    <wire from="(60,1340)" to="(60,1500)"/>
-    <wire from="(100,1230)" to="(260,1230)"/>
-    <wire from="(60,3260)" to="(60,3420)"/>
-    <wire from="(140,3660)" to="(140,3820)"/>
-    <wire from="(390,750)" to="(420,750)"/>
-    <wire from="(230,1550)" to="(260,1550)"/>
-    <wire from="(230,3470)" to="(260,3470)"/>
-    <wire from="(240,930)" to="(260,930)"/>
-    <wire from="(340,710)" to="(360,710)"/>
-    <wire from="(160,3090)" to="(180,3090)"/>
-    <wire from="(60,510)" to="(60,620)"/>
-    <wire from="(330,2630)" to="(330,2940)"/>
-    <wire from="(160,600)" to="(240,600)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(80,530)" to="(80,650)"/>
-    <wire from="(100,550)" to="(100,670)"/>
-    <wire from="(120,570)" to="(120,690)"/>
-    <wire from="(140,590)" to="(140,710)"/>
-    <wire from="(80,2450)" to="(80,2590)"/>
-    <wire from="(230,1260)" to="(230,1280)"/>
-    <wire from="(100,2470)" to="(100,2620)"/>
-    <wire from="(290,450)" to="(330,450)"/>
-    <wire from="(200,3560)" to="(240,3560)"/>
-    <wire from="(140,3820)" to="(180,3820)"/>
-    <wire from="(200,1650)" to="(230,1650)"/>
-    <wire from="(120,2490)" to="(120,2650)"/>
-    <wire from="(200,3890)" to="(230,3890)"/>
-    <wire from="(240,1380)" to="(260,1380)"/>
-    <wire from="(240,2340)" to="(260,2340)"/>
-    <wire from="(240,2660)" to="(260,2660)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,1270)" to="(240,1310)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,420)" to="(260,420)"/>
-    <wire from="(160,2210)" to="(160,2390)"/>
-    <wire from="(320,770)" to="(320,960)"/>
-    <wire from="(200,1110)" to="(260,1110)"/>
-    <wire from="(60,1040)" to="(180,1040)"/>
-    <wire from="(230,1070)" to="(230,1080)"/>
-    <wire from="(220,1700)" to="(220,1710)"/>
-    <wire from="(160,740)" to="(160,880)"/>
-    <wire from="(220,3620)" to="(220,3630)"/>
-    <wire from="(220,3940)" to="(220,3950)"/>
-    <wire from="(230,1710)" to="(230,1730)"/>
-    <wire from="(240,1720)" to="(240,1740)"/>
-    <wire from="(230,3950)" to="(230,3970)"/>
-    <wire from="(240,3960)" to="(240,3980)"/>
-    <wire from="(230,3630)" to="(230,3660)"/>
-    <wire from="(200,3690)" to="(240,3690)"/>
-    <wire from="(230,850)" to="(260,850)"/>
-    <wire from="(200,1140)" to="(230,1140)"/>
-    <wire from="(100,1960)" to="(100,2120)"/>
-    <wire from="(100,4050)" to="(260,4050)"/>
-    <wire from="(140,3070)" to="(230,3070)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(120,1980)" to="(120,2150)"/>
-    <wire from="(240,2790)" to="(260,2790)"/>
-    <wire from="(240,4070)" to="(260,4070)"/>
-    <wire from="(310,4140)" to="(330,4140)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(160,2390)" to="(180,2390)"/>
-    <wire from="(160,220)" to="(240,220)"/>
-    <wire from="(60,2240)" to="(60,2420)"/>
-    <wire from="(240,3640)" to="(240,3690)"/>
-    <wire from="(140,2000)" to="(140,2180)"/>
-    <wire from="(80,150)" to="(80,270)"/>
-    <wire from="(100,170)" to="(100,290)"/>
-    <wire from="(120,190)" to="(120,310)"/>
-    <wire from="(200,3480)" to="(260,3480)"/>
-    <wire from="(60,770)" to="(60,900)"/>
-    <wire from="(200,1560)" to="(260,1560)"/>
-    <wire from="(200,620)" to="(240,620)"/>
-    <wire from="(200,1900)" to="(240,1900)"/>
-    <wire from="(80,1210)" to="(180,1210)"/>
-    <wire from="(290,2630)" to="(330,2630)"/>
-    <wire from="(200,4140)" to="(240,4140)"/>
-    <wire from="(80,1530)" to="(180,1530)"/>
-    <wire from="(80,3450)" to="(180,3450)"/>
-    <wire from="(230,660)" to="(260,660)"/>
-    <wire from="(230,980)" to="(260,980)"/>
-    <wire from="(100,2900)" to="(260,2900)"/>
-    <wire from="(340,3010)" to="(370,3010)"/>
-    <wire from="(230,4180)" to="(260,4180)"/>
-    <wire from="(240,2280)" to="(260,2280)"/>
-    <wire from="(240,2600)" to="(260,2600)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(120,1980)" to="(260,1980)"/>
-    <wire from="(330,780)" to="(330,1100)"/>
-    <wire from="(120,970)" to="(180,970)"/>
-    <wire from="(60,3860)" to="(180,3860)"/>
-    <wire from="(60,900)" to="(60,1040)"/>
-    <wire from="(230,2930)" to="(230,2940)"/>
-    <wire from="(140,3220)" to="(140,3360)"/>
-    <wire from="(230,1650)" to="(230,1670)"/>
-    <wire from="(240,2940)" to="(240,2960)"/>
-    <wire from="(230,3890)" to="(230,3910)"/>
-    <wire from="(160,3240)" to="(160,3390)"/>
-    <wire from="(140,340)" to="(140,490)"/>
-    <wire from="(240,3260)" to="(240,3290)"/>
-    <wire from="(200,2030)" to="(240,2030)"/>
-    <wire from="(230,470)" to="(260,470)"/>
-    <wire from="(140,3970)" to="(230,3970)"/>
-    <wire from="(100,3030)" to="(260,3030)"/>
-    <wire from="(140,1730)" to="(230,1730)"/>
-    <wire from="(230,1430)" to="(260,1430)"/>
-    <wire from="(200,2360)" to="(230,2360)"/>
-    <wire from="(240,1130)" to="(260,1130)"/>
-    <wire from="(240,2730)" to="(260,2730)"/>
-    <wire from="(160,4250)" to="(180,4250)"/>
-    <wire from="(240,1340)" to="(240,1380)"/>
-    <wire from="(320,2760)" to="(320,2950)"/>
-    <wire from="(60,390)" to="(60,510)"/>
-    <wire from="(80,410)" to="(80,530)"/>
-    <wire from="(310,1410)" to="(310,1480)"/>
-    <wire from="(160,300)" to="(160,370)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(230,3060)" to="(230,3070)"/>
-    <wire from="(240,3070)" to="(240,3090)"/>
-    <wire from="(160,3690)" to="(160,3840)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(240,510)" to="(240,530)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(140,1140)" to="(180,1140)"/>
-    <wire from="(200,240)" to="(240,240)"/>
-    <wire from="(200,3120)" to="(240,3120)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(80,4030)" to="(180,4030)"/>
-    <wire from="(230,280)" to="(260,280)"/>
-    <wire from="(200,1210)" to="(230,1210)"/>
-    <wire from="(200,1530)" to="(230,1530)"/>
-    <wire from="(80,1370)" to="(80,1530)"/>
-    <wire from="(80,3290)" to="(80,3450)"/>
-    <wire from="(200,3450)" to="(230,3450)"/>
-    <wire from="(230,3160)" to="(260,3160)"/>
-    <wire from="(290,2910)" to="(310,2910)"/>
-    <wire from="(240,3820)" to="(260,3820)"/>
-    <wire from="(100,3310)" to="(100,3480)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(120,3330)" to="(120,3510)"/>
-    <wire from="(290,180)" to="(420,180)"/>
-    <wire from="(340,790)" to="(340,1240)"/>
-    <wire from="(60,1630)" to="(240,1630)"/>
-    <wire from="(220,1580)" to="(220,1590)"/>
-    <wire from="(60,3720)" to="(60,3860)"/>
-    <wire from="(220,3500)" to="(220,3510)"/>
-    <wire from="(230,1590)" to="(230,1610)"/>
-    <wire from="(240,1600)" to="(240,1620)"/>
-    <wire from="(230,3510)" to="(230,3530)"/>
-    <wire from="(240,3520)" to="(240,3540)"/>
-    <wire from="(140,2520)" to="(140,2670)"/>
-    <wire from="(200,370)" to="(240,370)"/>
-    <wire from="(200,1010)" to="(240,1010)"/>
-    <wire from="(290,1100)" to="(330,1100)"/>
-    <wire from="(80,2880)" to="(180,2880)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(140,4230)" to="(230,4230)"/>
-    <wire from="(230,2330)" to="(260,2330)"/>
-    <wire from="(230,2650)" to="(260,2650)"/>
-    <wire from="(200,2940)" to="(230,2940)"/>
-    <wire from="(240,1070)" to="(260,1070)"/>
-    <wire from="(290,3040)" to="(310,3040)"/>
-    <wire from="(240,2240)" to="(240,2280)"/>
-    <wire from="(160,1310)" to="(180,1310)"/>
-    <wire from="(100,1960)" to="(180,1960)"/>
-    <wire from="(60,2570)" to="(60,2700)"/>
-    <wire from="(80,2590)" to="(80,2730)"/>
-    <wire from="(240,130)" to="(240,150)"/>
-    <wire from="(240,770)" to="(240,800)"/>
-    <wire from="(140,2360)" to="(180,2360)"/>
-    <wire from="(200,2420)" to="(240,2420)"/>
-    <wire from="(80,3010)" to="(180,3010)"/>
-    <wire from="(230,540)" to="(260,540)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(230,2460)" to="(260,2460)"/>
-    <wire from="(230,2780)" to="(260,2780)"/>
-    <wire from="(200,4030)" to="(230,4030)"/>
-    <wire from="(230,4060)" to="(260,4060)"/>
-    <wire from="(240,2160)" to="(260,2160)"/>
-    <wire from="(290,1570)" to="(310,1570)"/>
-    <wire from="(310,1910)" to="(330,1910)"/>
-    <wire from="(240,3760)" to="(260,3760)"/>
-    <wire from="(80,2270)" to="(80,2450)"/>
-    <wire from="(160,2030)" to="(160,2210)"/>
-    <wire from="(120,840)" to="(120,970)"/>
-    <wire from="(140,860)" to="(140,990)"/>
-    <wire from="(160,880)" to="(160,1010)"/>
-    <wire from="(310,2960)" to="(370,2960)"/>
-    <wire from="(80,800)" to="(80,930)"/>
-    <wire from="(100,820)" to="(100,950)"/>
-    <wire from="(200,1250)" to="(260,1250)"/>
-    <wire from="(60,1180)" to="(180,1180)"/>
-    <wire from="(60,1500)" to="(180,1500)"/>
-    <wire from="(60,3420)" to="(180,3420)"/>
-    <wire from="(230,1210)" to="(230,1220)"/>
-    <wire from="(230,1850)" to="(230,1860)"/>
-    <wire from="(230,1530)" to="(230,1550)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(230,3450)" to="(230,3470)"/>
-    <wire from="(60,2700)" to="(60,2850)"/>
-    <wire from="(240,900)" to="(240,930)"/>
-    <wire from="(200,2550)" to="(240,2550)"/>
-    <wire from="(140,4090)" to="(180,4090)"/>
-    <wire from="(330,3000)" to="(370,3000)"/>
-    <wire from="(100,670)" to="(260,670)"/>
-    <wire from="(200,1280)" to="(230,1280)"/>
-    <wire from="(100,4190)" to="(260,4190)"/>
-    <wire from="(140,1610)" to="(230,1610)"/>
-    <wire from="(140,3530)" to="(230,3530)"/>
-    <wire from="(230,1950)" to="(260,1950)"/>
-    <wire from="(200,2880)" to="(230,2880)"/>
-    <wire from="(340,790)" to="(360,790)"/>
-    <wire from="(160,2210)" to="(180,2210)"/>
-    <wire from="(160,3240)" to="(240,3240)"/>
-    <wire from="(60,2060)" to="(60,2240)"/>
-    <wire from="(160,370)" to="(160,500)"/>
-    <wire from="(230,700)" to="(230,710)"/>
-    <wire from="(80,930)" to="(80,1070)"/>
-    <wire from="(100,950)" to="(100,1090)"/>
-    <wire from="(120,970)" to="(120,1110)"/>
-    <wire from="(230,3580)" to="(230,3590)"/>
-    <wire from="(230,4220)" to="(230,4230)"/>
-    <wire from="(240,4230)" to="(240,4250)"/>
-    <wire from="(140,990)" to="(140,1140)"/>
-    <wire from="(160,1010)" to="(160,1160)"/>
-    <wire from="(220,460)" to="(260,460)"/>
-    <wire from="(140,2940)" to="(180,2940)"/>
-    <wire from="(220,1420)" to="(260,1420)"/>
-    <wire from="(240,390)" to="(240,420)"/>
-    <wire from="(240,710)" to="(240,740)"/>
-    <wire from="(230,160)" to="(260,160)"/>
-    <wire from="(230,1120)" to="(260,1120)"/>
-    <wire from="(200,3010)" to="(230,3010)"/>
-    <wire from="(160,500)" to="(160,600)"/>
-    <wire from="(240,2100)" to="(260,2100)"/>
-    <wire from="(290,1830)" to="(310,1830)"/>
-    <wire from="(160,740)" to="(180,740)"/>
-    <wire from="(100,440)" to="(100,550)"/>
-    <wire from="(120,840)" to="(260,840)"/>
-    <wire from="(120,470)" to="(180,470)"/>
-    <wire from="(120,1110)" to="(180,1110)"/>
-    <wire from="(120,1430)" to="(180,1430)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(60,4000)" to="(180,4000)"/>
-    <wire from="(60,1040)" to="(60,1180)"/>
-    <wire from="(230,4030)" to="(230,4040)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(120,4070)" to="(230,4070)"/>
-    <wire from="(200,4090)" to="(240,4090)"/>
-    <wire from="(330,2940)" to="(370,2940)"/>
-    <wire from="(100,290)" to="(260,290)"/>
-    <wire from="(200,1860)" to="(230,1860)"/>
-    <wire from="(100,1400)" to="(100,1560)"/>
-    <wire from="(100,3170)" to="(260,3170)"/>
-    <wire from="(140,590)" to="(230,590)"/>
-    <wire from="(200,2180)" to="(230,2180)"/>
-    <wire from="(230,3810)" to="(260,3810)"/>
-    <wire from="(290,680)" to="(310,680)"/>
-    <wire from="(240,1270)" to="(260,1270)"/>
-    <wire from="(140,3360)" to="(140,3530)"/>
-    <wire from="(290,4200)" to="(310,4200)"/>
-    <wire from="(240,3720)" to="(240,3760)"/>
-    <wire from="(200,1960)" to="(260,1960)"/>
-    <wire from="(160,2550)" to="(160,2680)"/>
-    <wire from="(60,2850)" to="(180,2850)"/>
-    <wire from="(230,2880)" to="(230,2890)"/>
-    <wire from="(80,3750)" to="(80,3890)"/>
-    <wire from="(230,3200)" to="(230,3220)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(230,320)" to="(230,340)"/>
-    <wire from="(140,1280)" to="(180,1280)"/>
-    <wire from="(240,2570)" to="(240,2600)"/>
-    <wire from="(220,80)" to="(260,80)"/>
-    <wire from="(200,1340)" to="(240,1340)"/>
-    <wire from="(240,3210)" to="(240,3240)"/>
-    <wire from="(220,2320)" to="(260,2320)"/>
-    <wire from="(220,2640)" to="(260,2640)"/>
-    <wire from="(200,3260)" to="(240,3260)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(80,650)" to="(180,650)"/>
-    <wire from="(80,1930)" to="(180,1930)"/>
-    <wire from="(80,4170)" to="(180,4170)"/>
-    <wire from="(200,710)" to="(230,710)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(230,3300)" to="(260,3300)"/>
-    <wire from="(240,1720)" to="(260,1720)"/>
-    <wire from="(240,3640)" to="(260,3640)"/>
-    <wire from="(240,3960)" to="(260,3960)"/>
-    <wire from="(240,330)" to="(240,370)"/>
-    <wire from="(200,3050)" to="(260,3050)"/>
-    <wire from="(100,2620)" to="(100,2750)"/>
-    <wire from="(120,90)" to="(180,90)"/>
-    <wire from="(120,2330)" to="(180,2330)"/>
-    <wire from="(120,2650)" to="(180,2650)"/>
-    <wire from="(60,2980)" to="(180,2980)"/>
-    <wire from="(230,3010)" to="(230,3020)"/>
-    <wire from="(60,3860)" to="(60,4000)"/>
-    <wire from="(160,2680)" to="(160,2820)"/>
-    <wire from="(240,2700)" to="(240,2730)"/>
-    <wire from="(200,1470)" to="(240,1470)"/>
-    <wire from="(200,3390)" to="(240,3390)"/>
-    <wire from="(100,550)" to="(260,550)"/>
-    <wire from="(100,2470)" to="(260,2470)"/>
-    <wire from="(140,210)" to="(230,210)"/>
-    <wire from="(230,2150)" to="(260,2150)"/>
-    <wire from="(240,1210)" to="(260,1210)"/>
-    <wire from="(160,3690)" to="(180,3690)"/>
-    <wire from="(100,2300)" to="(100,2470)"/>
-    <wire from="(350,2920)" to="(370,2920)"/>
-    <wire from="(400,2970)" to="(420,2970)"/>
-    <wire from="(240,2060)" to="(240,2100)"/>
-    <wire from="(160,880)" to="(240,880)"/>
-    <wire from="(310,4050)" to="(310,4120)"/>
-    <wire from="(290,2310)" to="(350,2310)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(320,2990)" to="(370,2990)"/>
-    <wire from="(230,580)" to="(230,590)"/>
-    <wire from="(240,590)" to="(240,600)"/>
-    <wire from="(310,740)" to="(360,740)"/>
-    <wire from="(230,2500)" to="(230,2520)"/>
-    <wire from="(80,2730)" to="(80,2880)"/>
-    <wire from="(100,2750)" to="(100,2900)"/>
-    <wire from="(120,2770)" to="(120,2920)"/>
-    <wire from="(140,2790)" to="(140,2940)"/>
-    <wire from="(140,1860)" to="(180,1860)"/>
-    <wire from="(140,2180)" to="(180,2180)"/>
-    <wire from="(200,2240)" to="(240,2240)"/>
-    <wire from="(80,270)" to="(180,270)"/>
-    <wire from="(80,3150)" to="(180,3150)"/>
-    <wire from="(200,650)" to="(230,650)"/>
-    <wire from="(200,1930)" to="(230,1930)"/>
-    <wire from="(330,780)" to="(360,780)"/>
-    <wire from="(200,4170)" to="(230,4170)"/>
-    <wire from="(240,1660)" to="(260,1660)"/>
-    <wire from="(240,2940)" to="(260,2940)"/>
-    <wire from="(240,3580)" to="(260,3580)"/>
-    <wire from="(240,3900)" to="(260,3900)"/>
-    <wire from="(240,2510)" to="(240,2550)"/>
-    <wire from="(80,2090)" to="(80,2270)"/>
-    <wire from="(60,3560)" to="(180,3560)"/>
-    <wire from="(230,1990)" to="(230,2000)"/>
-    <wire from="(140,710)" to="(180,710)"/>
-    <wire from="(240,1040)" to="(240,1070)"/>
-    <wire from="(240,2000)" to="(240,2030)"/>
-    <wire from="(200,770)" to="(240,770)"/>
-    <wire from="(100,170)" to="(260,170)"/>
-    <wire from="(230,810)" to="(260,810)"/>
-    <wire from="(200,3660)" to="(230,3660)"/>
-    <wire from="(120,470)" to="(120,570)"/>
-    <wire from="(140,490)" to="(140,590)"/>
-    <wire from="(240,3070)" to="(260,3070)"/>
-    <wire from="(240,4030)" to="(260,4030)"/>
-    <wire from="(200,470)" to="(220,470)"/>
-    <wire from="(200,1430)" to="(220,1430)"/>
-    <wire from="(160,2030)" to="(180,2030)"/>
-    <wire from="(100,440)" to="(180,440)"/>
-    <wire from="(160,500)" to="(240,500)"/>
-    <wire from="(100,1400)" to="(180,1400)"/>
-    <wire from="(120,2770)" to="(260,2770)"/>
-    <wire from="(290,70)" to="(420,70)"/>
-    <wire from="(230,200)" to="(230,210)"/>
-    <wire from="(240,210)" to="(240,220)"/>
-    <wire from="(80,1070)" to="(80,1210)"/>
-    <wire from="(100,1090)" to="(100,1230)"/>
-    <wire from="(120,1110)" to="(120,1250)"/>
-    <wire from="(160,3390)" to="(160,3540)"/>
-    <wire from="(160,1470)" to="(160,1620)"/>
-    <wire from="(200,900)" to="(240,900)"/>
-    <wire from="(200,2820)" to="(240,2820)"/>
-    <wire from="(80,530)" to="(180,530)"/>
-    <wire from="(80,2450)" to="(180,2450)"/>
-    <wire from="(200,270)" to="(230,270)"/>
-    <wire from="(230,940)" to="(260,940)"/>
-    <wire from="(120,1430)" to="(120,1590)"/>
-    <wire from="(140,1450)" to="(140,1610)"/>
-    <wire from="(230,1260)" to="(260,1260)"/>
-    <wire from="(200,3150)" to="(230,3150)"/>
-    <wire from="(330,720)" to="(360,720)"/>
-    <wire from="(240,1600)" to="(260,1600)"/>
-    <wire from="(290,1970)" to="(310,1970)"/>
-    <wire from="(240,2880)" to="(260,2880)"/>
-    <wire from="(240,3520)" to="(260,3520)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(360,1490)" to="(420,1490)"/>
-    <wire from="(60,1500)" to="(60,1630)"/>
-    <wire from="(120,1250)" to="(180,1250)"/>
-    <wire from="(160,3840)" to="(160,3980)"/>
-    <wire from="(60,620)" to="(180,620)"/>
-    <wire from="(230,650)" to="(230,660)"/>
-    <wire from="(60,1900)" to="(180,1900)"/>
-    <wire from="(60,4140)" to="(180,4140)"/>
-    <wire from="(60,3420)" to="(60,3560)"/>
-    <wire from="(100,3780)" to="(100,3920)"/>
-    <wire from="(230,4170)" to="(230,4180)"/>
-    <wire from="(230,1930)" to="(230,1950)"/>
-    <wire from="(120,3800)" to="(120,3950)"/>
-    <wire from="(140,3820)" to="(140,3970)"/>
-    <wire from="(340,300)" to="(340,710)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(60,1180)" to="(60,1340)"/>
-    <wire from="(100,3310)" to="(260,3310)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(230,1390)" to="(260,1390)"/>
-    <wire from="(230,1710)" to="(260,1710)"/>
-    <wire from="(200,2000)" to="(230,2000)"/>
-    <wire from="(140,110)" to="(140,210)"/>
-    <wire from="(230,3630)" to="(260,3630)"/>
-    <wire from="(230,3950)" to="(260,3950)"/>
-    <wire from="(200,2330)" to="(220,2330)"/>
-    <wire from="(200,2650)" to="(220,2650)"/>
-    <wire from="(310,1480)" to="(330,1480)"/>
-    <wire from="(240,3010)" to="(260,3010)"/>
-    <wire from="(240,3860)" to="(240,3900)"/>
-    <wire from="(160,370)" to="(180,370)"/>
-    <wire from="(160,1010)" to="(180,1010)"/>
-    <wire from="(200,90)" to="(220,90)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(100,2300)" to="(180,2300)"/>
-    <wire from="(100,2620)" to="(180,2620)"/>
-    <wire from="(160,2680)" to="(240,2680)"/>
-    <wire from="(120,2650)" to="(120,2770)"/>
-    <wire from="(140,2670)" to="(140,2790)"/>
-    <wire from="(60,1630)" to="(60,1760)"/>
-    <wire from="(290,1240)" to="(340,1240)"/>
-    <wire from="(80,1650)" to="(80,1790)"/>
-    <wire from="(80,3890)" to="(80,4030)"/>
-    <wire from="(230,3340)" to="(230,3360)"/>
-    <wire from="(140,3660)" to="(180,3660)"/>
-    <wire from="(220,2140)" to="(260,2140)"/>
-    <wire from="(200,3720)" to="(240,3720)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(200,530)" to="(230,530)"/>
-    <wire from="(120,2330)" to="(120,2490)"/>
-    <wire from="(200,2450)" to="(230,2450)"/>
-    <wire from="(290,3180)" to="(320,3180)"/>
-    <wire from="(240,1540)" to="(260,1540)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,3460)" to="(260,3460)"/>
-    <wire from="(240,3350)" to="(240,3390)"/>
-    <wire from="(120,3800)" to="(260,3800)"/>
-    <wire from="(200,3190)" to="(260,3190)"/>
-    <wire from="(310,2980)" to="(370,2980)"/>
-    <wire from="(310,1500)" to="(310,1570)"/>
-    <wire from="(120,2150)" to="(180,2150)"/>
-    <wire from="(200,310)" to="(260,310)"/>
-    <wire from="(60,240)" to="(180,240)"/>
-    <wire from="(230,270)" to="(230,280)"/>
-    <wire from="(60,3120)" to="(180,3120)"/>
-    <wire from="(60,1760)" to="(60,1900)"/>
-    <wire from="(60,4000)" to="(60,4140)"/>
-    <wire from="(230,3150)" to="(230,3160)"/>
-    <wire from="(160,2820)" to="(160,2960)"/>
-    <wire from="(320,770)" to="(360,770)"/>
-    <wire from="(100,140)" to="(100,170)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(200,340)" to="(230,340)"/>
-    <wire from="(140,990)" to="(230,990)"/>
-    <wire from="(230,2290)" to="(260,2290)"/>
-    <wire from="(230,2610)" to="(260,2610)"/>
-    <wire from="(230,2930)" to="(260,2930)"/>
-    <wire from="(200,3220)" to="(230,3220)"/>
-    <wire from="(240,4230)" to="(260,4230)"/>
-    <wire from="(240,710)" to="(260,710)"/>
-    <wire from="(160,2550)" to="(180,2550)"/>
-    <wire from="(310,2910)" to="(310,2960)"/>
-    <wire from="(100,2120)" to="(100,2300)"/>
-    <wire from="(290,3790)" to="(420,3790)"/>
-    <wire from="(60,2850)" to="(60,2980)"/>
-    <wire from="(340,2480)" to="(340,2930)"/>
-    <wire from="(200,440)" to="(260,440)"/>
-    <wire from="(200,1400)" to="(260,1400)"/>
-    <wire from="(140,2000)" to="(180,2000)"/>
-    <wire from="(200,2060)" to="(240,2060)"/>
-    <wire from="(200,2700)" to="(240,2700)"/>
-    <wire from="(80,410)" to="(180,410)"/>
-    <wire from="(80,1370)" to="(180,1370)"/>
-    <wire from="(80,3290)" to="(180,3290)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(100,820)" to="(260,820)"/>
-    <wire from="(290,560)" to="(320,560)"/>
-    <wire from="(230,2740)" to="(260,2740)"/>
-    <wire from="(230,3060)" to="(260,3060)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(200,2490)" to="(260,2490)"/>
-    <wire from="(200,570)" to="(260,570)"/>
-    <wire from="(120,3050)" to="(180,3050)"/>
-    <wire from="(230,530)" to="(230,540)"/>
-    <wire from="(230,850)" to="(230,860)"/>
-    <wire from="(60,2420)" to="(180,2420)"/>
-    <wire from="(230,2450)" to="(230,2460)"/>
-    <wire from="(60,2980)" to="(60,3120)"/>
-    <wire from="(140,1140)" to="(140,1280)"/>
-    <wire from="(240,860)" to="(240,880)"/>
-    <wire from="(160,1160)" to="(160,1310)"/>
-    <wire from="(240,1180)" to="(240,1210)"/>
-    <wire from="(100,950)" to="(260,950)"/>
-    <wire from="(230,1590)" to="(260,1590)"/>
-    <wire from="(200,2520)" to="(230,2520)"/>
-    <wire from="(230,3510)" to="(260,3510)"/>
-    <wire from="(240,3210)" to="(260,3210)"/>
-    <wire from="(240,4170)" to="(260,4170)"/>
-    <wire from="(240,1500)" to="(240,1540)"/>
-    <wire from="(240,3420)" to="(240,3460)"/>
-    <wire from="(240,330)" to="(260,330)"/>
-    <wire from="(240,650)" to="(260,650)"/>
-    <wire from="(100,3780)" to="(180,3780)"/>
-    <wire from="(160,3840)" to="(240,3840)"/>
-    <wire from="(80,1530)" to="(80,1650)"/>
-    <wire from="(290,2130)" to="(420,2130)"/>
-    <wire from="(200,2300)" to="(260,2300)"/>
-    <wire from="(200,2620)" to="(260,2620)"/>
-    <wire from="(80,3450)" to="(80,3580)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(230,980)" to="(230,990)"/>
-    <wire from="(240,990)" to="(240,1010)"/>
-    <wire from="(140,340)" to="(180,340)"/>
-    <wire from="(240,1630)" to="(240,1660)"/>
-    <wire from="(200,1040)" to="(240,1040)"/>
-    <wire from="(140,3220)" to="(180,3220)"/>
-    <wire from="(220,1700)" to="(260,1700)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(220,3620)" to="(260,3620)"/>
-    <wire from="(220,3940)" to="(260,3940)"/>
-    <wire from="(80,2270)" to="(180,2270)"/>
-    <wire from="(80,2590)" to="(180,2590)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(200,1370)" to="(230,1370)"/>
-    <wire from="(80,1210)" to="(80,1370)"/>
-    <wire from="(230,1080)" to="(260,1080)"/>
-    <wire from="(200,3290)" to="(230,3290)"/>
-    <wire from="(290,830)" to="(310,830)"/>
-    <wire from="(100,1230)" to="(100,1400)"/>
-    <wire from="(120,1250)" to="(120,1430)"/>
-    <wire from="(310,2980)" to="(310,3040)"/>
-    <wire from="(100,3920)" to="(100,4050)"/>
-    <wire from="(120,1710)" to="(180,1710)"/>
-    <wire from="(200,190)" to="(260,190)"/>
-    <wire from="(120,3630)" to="(180,3630)"/>
-    <wire from="(120,3950)" to="(180,3950)"/>
-    <wire from="(290,3490)" to="(340,3490)"/>
-    <wire from="(230,150)" to="(230,160)"/>
-    <wire from="(220,460)" to="(220,470)"/>
-    <wire from="(60,510)" to="(240,510)"/>
-    <wire from="(220,1420)" to="(220,1430)"/>
-    <wire from="(100,1680)" to="(100,1820)"/>
-    <wire from="(160,1740)" to="(160,1880)"/>
-    <wire from="(230,1430)" to="(230,1450)"/>
-    <wire from="(230,470)" to="(230,490)"/>
-    <wire from="(240,480)" to="(240,500)"/>
-    <wire from="(140,250)" to="(140,340)"/>
-    <wire from="(240,1440)" to="(240,1470)"/>
-    <wire from="(240,4000)" to="(240,4030)"/>
-    <wire from="(200,3090)" to="(240,3090)"/>
-    <wire from="(80,800)" to="(180,800)"/>
-    <wire from="(200,860)" to="(230,860)"/>
-    <wire from="(60,3560)" to="(60,3720)"/>
-    <wire from="(140,2360)" to="(140,2520)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(230,3770)" to="(260,3770)"/>
-    <wire from="(200,2150)" to="(220,2150)"/>
-    <wire from="(240,2510)" to="(260,2510)"/>
-    <wire from="(160,3390)" to="(180,3390)"/>
-    <wire from="(80,3580)" to="(80,3750)"/>
-    <wire from="(240,3150)" to="(260,3150)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(240,270)" to="(260,270)"/>
-    <wire from="(240,590)" to="(260,590)"/>
-    <wire from="(160,1470)" to="(180,1470)"/>
-    <wire from="(100,2120)" to="(180,2120)"/>
-    <wire from="(100,3600)" to="(100,3780)"/>
-    <wire from="(310,1830)" to="(310,1890)"/>
-    <wire from="(290,3610)" to="(350,3610)"/>
-    <wire from="(140,4090)" to="(140,4230)"/>
-    <wire from="(310,760)" to="(360,760)"/>
-    <wire from="(80,1790)" to="(80,1930)"/>
-    <wire from="(120,4070)" to="(120,4210)"/>
-    <wire from="(100,4050)" to="(100,4190)"/>
-    <wire from="(80,4030)" to="(80,4170)"/>
-    <wire from="(140,2520)" to="(180,2520)"/>
-    <wire from="(240,2850)" to="(240,2880)"/>
-    <wire from="(200,3860)" to="(240,3860)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(80,930)" to="(180,930)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(230,700)" to="(260,700)"/>
-    <wire from="(200,2270)" to="(230,2270)"/>
-    <wire from="(200,2590)" to="(230,2590)"/>
-    <wire from="(230,4220)" to="(260,4220)"/>
-    <wire from="(240,2000)" to="(260,2000)"/>
-    <wire from="(290,1410)" to="(310,1410)"/>
-    <wire from="(120,2150)" to="(120,2330)"/>
-    <wire from="(320,2990)" to="(320,3180)"/>
-    <wire from="(310,680)" to="(310,740)"/>
-    <wire from="(200,3330)" to="(260,3330)"/>
-    <wire from="(80,2880)" to="(80,3010)"/>
-    <wire from="(100,2900)" to="(100,3030)"/>
-    <wire from="(120,2920)" to="(120,3050)"/>
-    <wire from="(140,2940)" to="(140,3070)"/>
-    <wire from="(160,2960)" to="(160,3090)"/>
-    <wire from="(360,4130)" to="(420,4130)"/>
-    <wire from="(220,80)" to="(220,90)"/>
-    <wire from="(60,1340)" to="(180,1340)"/>
-    <wire from="(60,3260)" to="(180,3260)"/>
-    <wire from="(160,3980)" to="(160,4250)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(220,2320)" to="(220,2330)"/>
-    <wire from="(220,2640)" to="(220,2650)"/>
-    <wire from="(230,3290)" to="(230,3300)"/>
-    <wire from="(230,1370)" to="(230,1390)"/>
-    <wire from="(230,2650)" to="(230,2670)"/>
-    <wire from="(240,2660)" to="(240,2680)"/>
-    <wire from="(230,90)" to="(230,110)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(230,410)" to="(230,430)"/>
-    <wire from="(60,620)" to="(60,770)"/>
-    <wire from="(230,2330)" to="(230,2360)"/>
-    <wire from="(240,2980)" to="(240,3010)"/>
-    <wire from="(200,2390)" to="(240,2390)"/>
-    <wire from="(200,800)" to="(230,800)"/>
-    <wire from="(60,1900)" to="(60,2060)"/>
-    <wire from="(100,2750)" to="(260,2750)"/>
-    <wire from="(140,490)" to="(230,490)"/>
-    <wire from="(140,1450)" to="(230,1450)"/>
-    <wire from="(230,2110)" to="(260,2110)"/>
-    <wire from="(200,3360)" to="(230,3360)"/>
-    <wire from="(240,2450)" to="(260,2450)"/>
-    <wire from="(310,4120)" to="(330,4120)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(320,560)" to="(320,730)"/>
-    <wire from="(240,530)" to="(260,530)"/>
-    <wire from="(160,1160)" to="(240,1160)"/>
-    <wire from="(240,2340)" to="(240,2390)"/>
-    <wire from="(290,3930)" to="(420,3930)"/>
-    <wire from="(290,1690)" to="(420,1690)"/>
-    <wire from="(200,3780)" to="(260,3780)"/>
-    <wire from="(320,2950)" to="(370,2950)"/>
-    <wire from="(230,2780)" to="(230,2790)"/>
-    <wire from="(80,3010)" to="(80,3150)"/>
-    <wire from="(100,3030)" to="(100,3170)"/>
-    <wire from="(120,3050)" to="(120,3190)"/>
-    <wire from="(230,4060)" to="(230,4070)"/>
-    <wire from="(240,4070)" to="(240,4090)"/>
-    <wire from="(140,3070)" to="(140,3220)"/>
-    <wire from="(160,3090)" to="(160,3240)"/>
-    <wire from="(140,860)" to="(180,860)"/>
-    <wire from="(240,2790)" to="(240,2820)"/>
-    <wire from="(220,1580)" to="(260,1580)"/>
-    <wire from="(220,3500)" to="(260,3500)"/>
-    <wire from="(80,3750)" to="(180,3750)"/>
-    <wire from="(230,320)" to="(260,320)"/>
-    <wire from="(200,930)" to="(230,930)"/>
-    <wire from="(230,3200)" to="(260,3200)"/>
-    <wire from="(240,1940)" to="(260,1940)"/>
-    <wire from="(160,2820)" to="(180,2820)"/>
-    <wire from="(120,2920)" to="(260,2920)"/>
-    <wire from="(100,1560)" to="(100,1680)"/>
-    <wire from="(310,4140)" to="(310,4200)"/>
-    <wire from="(100,3480)" to="(100,3600)"/>
-    <wire from="(160,1620)" to="(160,1740)"/>
-    <wire from="(120,310)" to="(180,310)"/>
-    <wire from="(120,1590)" to="(180,1590)"/>
-    <wire from="(330,3000)" to="(330,3320)"/>
-    <wire from="(120,3190)" to="(180,3190)"/>
-    <wire from="(120,3510)" to="(180,3510)"/>
-    <wire from="(40,300)" to="(160,300)"/>
-    <wire from="(60,2240)" to="(180,2240)"/>
-    <wire from="(60,390)" to="(240,390)"/>
-    <wire from="(60,3120)" to="(60,3260)"/>
-    <wire from="(230,2270)" to="(230,2290)"/>
-    <wire from="(230,2590)" to="(230,2610)"/>
-    <wire from="(240,3560)" to="(240,3580)"/>
-    <wire from="(160,3540)" to="(160,3690)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(60,240)" to="(60,390)"/>
-    <wire from="(200,4250)" to="(240,4250)"/>
-    <wire from="(100,1090)" to="(260,1090)"/>
-    <wire from="(140,110)" to="(230,110)"/>
-    <wire from="(140,2670)" to="(230,2670)"/>
-    <wire from="(200,3630)" to="(220,3630)"/>
-    <wire from="(200,3950)" to="(220,3950)"/>
-    <wire from="(140,1280)" to="(140,1450)"/>
-    <wire from="(310,1500)" to="(330,1500)"/>
-    <wire from="(240,3350)" to="(260,3350)"/>
-    <wire from="(240,150)" to="(260,150)"/>
-    <wire from="(200,1710)" to="(220,1710)"/>
-    <wire from="(100,1680)" to="(180,1680)"/>
-    <wire from="(160,1740)" to="(240,1740)"/>
-    <wire from="(100,3600)" to="(180,3600)"/>
-    <wire from="(100,3920)" to="(180,3920)"/>
-    <wire from="(160,3980)" to="(240,3980)"/>
-    <wire from="(120,3950)" to="(120,4070)"/>
-    <wire from="(140,3970)" to="(140,4090)"/>
-    <wire from="(200,2120)" to="(260,2120)"/>
-    <wire from="(120,1710)" to="(120,1840)"/>
-    <wire from="(140,1730)" to="(140,1860)"/>
-    <wire from="(60,770)" to="(180,770)"/>
-    <wire from="(230,800)" to="(230,810)"/>
-    <wire from="(290,300)" to="(340,300)"/>
-    <wire from="(230,1120)" to="(230,1140)"/>
-    <wire from="(240,1130)" to="(240,1160)"/>
-    <wire from="(200,1180)" to="(240,1180)"/>
-    <wire from="(200,1500)" to="(240,1500)"/>
-    <wire from="(140,3360)" to="(180,3360)"/>
-    <wire from="(200,3420)" to="(240,3420)"/>
-    <wire from="(80,2090)" to="(180,2090)"/>
-    <wire from="(80,2730)" to="(180,2730)"/>
-    <wire from="(230,580)" to="(260,580)"/>
-    <wire from="(160,2390)" to="(160,2550)"/>
-    <wire from="(350,2310)" to="(350,2920)"/>
-    <wire from="(340,2930)" to="(370,2930)"/>
-    <wire from="(290,960)" to="(320,960)"/>
-    <wire from="(230,1220)" to="(260,1220)"/>
-    <wire from="(230,2500)" to="(260,2500)"/>
-    <wire from="(200,2790)" to="(230,2790)"/>
-    <wire from="(200,3750)" to="(230,3750)"/>
-    <wire from="(120,3630)" to="(120,3800)"/>
-    <wire from="(120,570)" to="(180,570)"/>
-    <wire from="(200,970)" to="(260,970)"/>
-    <wire from="(120,2490)" to="(180,2490)"/>
-    <wire from="(60,900)" to="(180,900)"/>
-    <wire from="(230,930)" to="(230,940)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(60,2570)" to="(240,2570)"/>
-    <wire from="(100,1820)" to="(100,1960)"/>
-    <wire from="(120,1840)" to="(120,1980)"/>
-    <wire from="(160,600)" to="(160,740)"/>
-    <wire from="(230,3810)" to="(230,3820)"/>
-    <wire from="(140,1860)" to="(140,2000)"/>
-    <wire from="(240,3820)" to="(240,3840)"/>
-    <wire from="(60,2420)" to="(60,2570)"/>
-    <wire from="(160,1880)" to="(160,2030)"/>
-    <wire from="(200,1310)" to="(240,1310)"/>
-    <wire from="(240,4140)" to="(240,4170)"/>
-    <wire from="(240,620)" to="(240,650)"/>
-    <wire from="(290,3320)" to="(330,3320)"/>
-    <wire from="(230,1670)" to="(260,1670)"/>
-    <wire from="(230,1990)" to="(260,1990)"/>
-    <wire from="(340,3010)" to="(340,3490)"/>
-    <wire from="(230,3590)" to="(260,3590)"/>
-    <wire from="(230,3910)" to="(260,3910)"/>
-    <wire from="(240,3290)" to="(260,3290)"/>
-    <wire from="(80,3580)" to="(230,3580)"/>
-    <wire from="(240,1900)" to="(240,1940)"/>
-    <wire from="(160,2960)" to="(240,2960)"/>
-    <wire from="(140,2180)" to="(140,2360)"/>
-    <wire from="(360,1900)" to="(420,1900)"/>
-    <wire from="(290,2480)" to="(340,2480)"/>
-    <wire from="(160,220)" to="(160,300)"/>
-    <wire from="(120,690)" to="(120,840)"/>
-    <wire from="(140,710)" to="(140,860)"/>
-    <wire from="(80,650)" to="(80,800)"/>
-    <wire from="(100,670)" to="(100,820)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(200,4000)" to="(240,4000)"/>
-    <wire from="(80,1070)" to="(180,1070)"/>
-    <wire from="(230,200)" to="(260,200)"/>
-    <wire from="(80,1930)" to="(80,2090)"/>
-    <wire from="(200,2090)" to="(230,2090)"/>
-    <wire from="(200,2730)" to="(230,2730)"/>
-    <wire from="(230,4040)" to="(260,4040)"/>
-    <wire from="(240,860)" to="(260,860)"/>
-    <wire from="(310,1890)" to="(330,1890)"/>
-    <wire from="(120,1840)" to="(260,1840)"/>
-    <comp lib="1" loc="(200,2450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,970)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,2970)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWrite"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,1900)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Branch"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,4130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ZeroExtend"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(390,750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="1" loc="(200,770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,750)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrc"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3790)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,960)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4200)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,300)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1100)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Jump"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,3090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,3790)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneBeq"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3050)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,300)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1590)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1900)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(290,1970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2760)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3920)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2130)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,3930)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJAL"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWrite"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,4090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,70)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemRead"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,3930)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2630)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,2910)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,2130)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegDst"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(360,4130)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,2590)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1530)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1240)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1490)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,2480)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1690)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoReg"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(400,2970)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(200,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,3040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,3750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,2390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,4050)" name="AND Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(200,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,3610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="0" loc="(570,530)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(90,1040)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(850,610)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="5" loc="(1420,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="3" loc="(1180,150)" name="Shifter">
+      <a name="width" val="32"/>
     </comp>
   </circuit>
   <circuit name="Syscall_Decoder">
@@ -5964,25 +1565,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(680,230)" to="(690,230)"/>
     <wire from="(170,440)" to="(300,440)"/>
     <wire from="(640,420)" to="(650,420)"/>
+    <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
     <comp lib="0" loc="(720,200)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="4"/>
       <a name="label" val="Hex1"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(510,440)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(440,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(720,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="Hex3"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(660,270)" name="Splitter">
@@ -6021,65 +1609,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(650,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Halt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,320)" name="Pin">
+    <comp lib="0" loc="(720,260)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="4"/>
-      <a name="label" val="Hex5"/>
+      <a name="label" val="Hex3"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="Hex0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(470,130)" name="Tunnel">
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(310,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(440,320)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="3" loc="(340,450)" name="Comparator">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(580,420)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(510,480)" name="Tunnel">
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(480,320)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(500,270)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(720,380)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="Hex7"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,440)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="v0"/>
     </comp>
     <comp lib="0" loc="(420,270)" name="Pin">
       <a name="width" val="32"/>
@@ -6093,17 +1628,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Hex2"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
-    <comp lib="0" loc="(270,460)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0xa"/>
+    <comp lib="0" loc="(480,320)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="Hex4"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="3" loc="(340,450)" name="Comparator">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(510,480)" name="Tunnel">
+      <a name="label" val="Enable"/>
     </comp>
     <comp lib="0" loc="(720,350)" name="Pin">
       <a name="facing" val="west"/>
@@ -6112,10 +1645,78 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Hex6"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(320,130)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(440,320)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(650,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Halt"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(440,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="2" loc="(510,440)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(720,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="Hex5"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(500,270)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(720,380)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="Hex7"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="0" loc="(470,430)" name="Constant">
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(320,130)" name="Tunnel">
+    <comp lib="0" loc="(720,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="Hex4"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,440)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(720,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="Hex0"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(270,460)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0xa"/>
+    </comp>
+    <comp lib="0" loc="(470,130)" name="Tunnel">
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(310,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(580,420)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="clk"/>
     </comp>
   </circuit>
@@ -6280,6 +1881,124 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(730,720)" to="(740,720)"/>
     <wire from="(1000,850)" to="(1080,850)"/>
     <wire from="(870,1020)" to="(870,1070)"/>
+    <comp lib="0" loc="(840,210)" name="Tunnel">
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="2" loc="(1120,860)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(410,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(850,580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(370,460)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="0" loc="(270,530)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(680,550)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCin"/>
+    </comp>
+    <comp lib="0" loc="(940,1060)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="0" loc="(110,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(770,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(940,720)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(460,180)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(230,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExRegWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1080,970)" name="Constant">
+      <a name="facing" val="west"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(770,1030)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="1" loc="(470,910)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="2" loc="(740,560)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(780,1020)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1120,230)" name="Tunnel">
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(180,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(940,890)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
     <comp lib="0" loc="(730,1020)" name="Constant">
       <a name="width" val="32"/>
     </comp>
@@ -6288,8 +2007,41 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
-    <comp lib="1" loc="(470,910)" name="NOT Gate">
+    <comp lib="0" loc="(720,480)" name="Tunnel">
       <a name="facing" val="south"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="4" loc="(960,850)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Status"/>
+    </comp>
+    <comp lib="0" loc="(730,720)" name="Constant"/>
+    <comp lib="0" loc="(1100,910)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="0" loc="(770,970)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(730,960)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(520,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(624,130)" name="Text">
+      <a name="text" val="Input &amp; Output"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(240,870)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpClick"/>
     </comp>
     <comp lib="1" loc="(360,530)" name="AND Gate">
       <a name="size" val="30"/>
@@ -6299,15 +2051,221 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="negate4" val="true"/>
       <a name="negate5" val="true"/>
     </comp>
-    <comp lib="0" loc="(230,230)" name="Pin">
+    <comp lib="0" loc="(190,230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="4" loc="(960,1020)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Cause"/>
+    </comp>
+    <comp lib="0" loc="(780,250)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="6" loc="(294,718)" name="Text">
+      <a name="text" val="Exception Signals"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="1" loc="(780,960)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(940,700)" name="Tunnel">
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="4" loc="(430,890)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(780,210)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="6" loc="(297,376)" name="Text">
+      <a name="text" val="Signal Decoding"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(840,170)" name="Tunnel">
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(1060,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(240,900)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(940,600)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(210,480)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Inst"/>
+    </comp>
+    <comp lib="0" loc="(1000,880)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="1" loc="(860,740)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(960,560)" name="Register">
+      <a name="width" val="32"/>
+      <a name="trigger" val="high"/>
+      <a name="label" val="EPC"/>
+    </comp>
+    <comp lib="1" loc="(860,680)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(370,770)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(450,780)" name="Tunnel">
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(1150,560)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="ExpBlock"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCout"/>
+    </comp>
+    <comp lib="0" loc="(1060,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(370,430)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="1" loc="(420,780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(270,430)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(680,850)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
+    <comp lib="1" loc="(890,710)" name="AND Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(520,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="HasExp"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(460,180)" name="Tunnel">
+    <comp lib="0" loc="(1000,860)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="1" loc="(340,430)" name="NOT Gate"/>
+    <comp lib="0" loc="(200,180)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="IsEret"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(760,790)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="1" loc="(910,590)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(320,860)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+    </comp>
+    <comp lib="0" loc="(760,770)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
     </comp>
     <comp lib="0" loc="(1120,180)" name="Tunnel">
       <a name="label" val="clk"/>
@@ -6349,91 +2307,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(780,210)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="6" loc="(624,130)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="2" loc="(740,720)" name="Demultiplexer">
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(520,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="HasExp"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(320,860)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-    </comp>
-    <comp lib="0" loc="(770,970)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(940,1060)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="1" loc="(240,900)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="0" loc="(110,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(230,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ExRegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1000,880)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(1060,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(380,530)" name="Tunnel">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(200,180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(940,700)" name="Tunnel">
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(410,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(720,480)" name="Tunnel">
+    <comp lib="1" loc="(720,530)" name="NOT Gate">
       <a name="facing" val="south"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="4" loc="(960,560)" name="Register">
-      <a name="width" val="32"/>
-      <a name="trigger" val="high"/>
-      <a name="label" val="EPC"/>
-    </comp>
-    <comp lib="0" loc="(770,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="4" loc="(960,1020)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Cause"/>
     </comp>
     <comp lib="0" loc="(1150,860)" name="Pin">
       <a name="facing" val="west"/>
@@ -6442,322 +2317,48 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="Dout"/>
     </comp>
-    <comp lib="1" loc="(420,780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(840,210)" name="Tunnel">
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(680,850)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
-    </comp>
-    <comp lib="6" loc="(297,376)" name="Text">
-      <a name="text" val="Signal Decoding"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="4" loc="(960,850)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Status"/>
-    </comp>
-    <comp lib="1" loc="(860,740)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(780,1020)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(760,770)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-    </comp>
-    <comp lib="0" loc="(940,890)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(250,970)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(780,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(730,720)" name="Constant"/>
-    <comp lib="0" loc="(730,1070)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(770,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(850,580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="4" loc="(430,890)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(270,530)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="1" loc="(860,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(370,430)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(370,770)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1000,860)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(520,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(380,530)" name="Tunnel">
       <a name="label" val="IsEret"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(680,550)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCin"/>
-    </comp>
-    <comp lib="0" loc="(730,960)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1120,230)" name="Tunnel">
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(370,460)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(470,230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(840,170)" name="Tunnel">
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(760,790)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(940,720)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="6" loc="(923,412)" name="Text">
-      <a name="text" val="Registers"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(180,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(940,600)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(780,1070)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1100,910)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="2" loc="(740,560)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(840,250)" name="Tunnel">
       <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="1" loc="(340,430)" name="NOT Gate"/>
-    <comp lib="0" loc="(190,230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(1150,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCout"/>
     </comp>
     <comp lib="0" loc="(250,1020)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(450,780)" name="Tunnel">
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="1" loc="(910,590)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(270,430)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(294,718)" name="Text">
-      <a name="text" val="Exception Signals"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(1060,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1080,970)" name="Constant">
-      <a name="facing" val="west"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(890,710)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="1" loc="(780,960)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(210,480)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Inst"/>
-    </comp>
-    <comp lib="0" loc="(240,870)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="2" loc="(1120,860)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
     <comp lib="0" loc="(780,170)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ExpSrc0"/>
     </comp>
-    <comp lib="1" loc="(720,530)" name="NOT Gate">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(230,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExpBlock"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(730,1070)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(250,970)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(470,230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="6" loc="(923,412)" name="Text">
+      <a name="text" val="Registers"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="1" loc="(780,1070)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="2" loc="(740,720)" name="Demultiplexer">
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
   </circuit>
   <circuit name="Statistics">
@@ -7144,25 +2745,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(80,1450)" to="(80,1630)"/>
     <wire from="(120,320)" to="(260,320)"/>
     <wire from="(120,1330)" to="(120,1510)"/>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1420)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1450)" name="NOT Gate">
+    <comp lib="1" loc="(200,340)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
+    <comp lib="1" loc="(200,1630)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(420,670)" name="Pin">
@@ -7171,90 +2765,164 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="i"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,890)" name="NOT Gate">
+    <comp lib="1" loc="(400,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(200,1330)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,1490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(200,930)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
+    <comp lib="1" loc="(200,300)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,600)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(360,1750)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,1510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(40,250)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="op4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1320)" name="AND Gate">
+    <comp lib="1" loc="(290,180)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
+    <comp lib="1" loc="(200,1220)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
+    <comp lib="1" loc="(200,1190)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(290,880)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
+    <comp lib="1" loc="(200,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1020)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,1830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,990)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(290,70)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
+    <comp lib="1" loc="(290,1670)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,1420)" name="NOT Gate">
+    <comp lib="1" loc="(290,1320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
+    <comp lib="1" loc="(200,1090)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
+    <comp lib="1" loc="(200,660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
+    <comp lib="0" loc="(40,190)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,890)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(420,1490)" name="Pin">
@@ -7263,86 +2931,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="r"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
+    <comp lib="1" loc="(200,1120)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
+    <comp lib="1" loc="(200,60)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
+    <comp lib="1" loc="(200,1660)" name="NOT Gate">
       <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
     </comp>
     <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(400,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1480)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(420,1750)" name="Pin">
@@ -7351,67 +2949,70 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="j"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+    <comp lib="1" loc="(200,1390)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
+    <comp lib="1" loc="(200,1600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,660)" name="NOT Gate">
+    <comp lib="1" loc="(200,380)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
+    <comp lib="1" loc="(200,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,310)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1490)" name="AND Gate">
+    <comp lib="1" loc="(290,1180)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
+    <comp lib="1" loc="(200,270)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
+    <comp lib="1" loc="(200,1820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,510)" name="NOT Gate">
+    <comp lib="1" loc="(200,1760)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1290)" name="NOT Gate">
+    <comp lib="1" loc="(200,1480)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,1260)" name="NOT Gate">
+    <comp lib="1" loc="(200,1850)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(200,1150)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(200,1730)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
+    <comp lib="1" loc="(200,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,90)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1030)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
   </circuit>


### PR DESCRIPTION
This PR moves the Control Unit to be shared by all version of MIPS-CPUs since the implementations are the same. An output label reorder was also done for the single cycle CPU to match the output pin of the control unit from pipelined version.

Additionally, the control-unit-related components that were duplicated among the MIPS-CPUs are removed.