### PR TITLE
Share statistics component.

### DIFF
--- a/src/common/statistics.circ
+++ b/src/common/statistics.circ
@@ -1,0 +1,786 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project source="2.7.1" version="1.0">
+  This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
+
+  <lib desc="#Wiring" name="0">
+    <tool name="Splitter">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Pin">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+    </tool>
+    <tool name="Tunnel">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="Pull Resistor">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Clock">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Constant">
+      <a name="value" val="0x0"/>
+    </tool>
+    <tool name="Bit Extender">
+      <a name="type" val="sign"/>
+    </tool>
+  </lib>
+  <lib desc="#Gates" name="1">
+    <tool name="Buffer">
+      <a name="width" val="3"/>
+    </tool>
+    <tool name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="OR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="NOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="XOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="Odd Parity">
+      <a name="facing" val="south"/>
+      <a name="inputs" val="3"/>
+    </tool>
+  </lib>
+  <lib desc="#Plexers" name="2">
+    <tool name="Multiplexer">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="Demultiplexer">
+      <a name="select" val="5"/>
+    </tool>
+  </lib>
+  <lib desc="#Arithmetic" name="3">
+    <tool name="Subtractor">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Multiplier">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Divider">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Negator">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Comparator">
+      <a name="width" val="32"/>
+    </tool>
+  </lib>
+  <lib desc="#Memory" name="4">
+    <tool name="Register">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="ROM">
+      <a name="contents">addr/data: 8 8
+0
+</a>
+    </tool>
+  </lib>
+  <lib desc="#I/O" name="5"/>
+  <lib desc="#Base" name="6">
+    <tool name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+  </lib>
+  <main name="statistics"/>
+  <options>
+    <a name="gateUndefined" val="ignore"/>
+    <a name="simlimit" val="1000"/>
+    <a name="simrand" val="0"/>
+  </options>
+  <mappings>
+    <tool lib="6" map="Button2" name="Menu Tool"/>
+    <tool lib="6" map="Button3" name="Menu Tool"/>
+    <tool lib="6" map="Ctrl Button1" name="Menu Tool"/>
+  </mappings>
+  <toolbar>
+    <tool lib="6" name="Poke Tool"/>
+    <tool lib="6" name="Edit Tool"/>
+    <tool lib="6" name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+    <sep/>
+    <tool lib="0" name="Pin">
+      <a name="tristate" val="false"/>
+    </tool>
+    <tool lib="0" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="labelloc" val="east"/>
+    </tool>
+    <tool lib="1" name="NOT Gate"/>
+    <tool lib="1" name="AND Gate"/>
+    <tool lib="1" name="OR Gate"/>
+  </toolbar>
+  <circuit name="statistics">
+    <a name="circuit" val="statistics"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <rect fill="#ff01b2" height="60" stroke="none" width="30" x="50" y="55"/>
+      <circ-port height="8" pin="40,30" width="8" x="76" y="56"/>
+      <circ-port height="8" pin="40,80" width="8" x="76" y="66"/>
+      <circ-port height="8" pin="40,140" width="8" x="76" y="76"/>
+      <circ-port height="8" pin="40,190" width="8" x="76" y="86"/>
+      <circ-port height="8" pin="40,250" width="8" x="76" y="96"/>
+      <circ-port height="8" pin="40,310" width="8" x="76" y="106"/>
+      <circ-port height="10" pin="420,670" width="10" x="45" y="65"/>
+      <circ-port height="10" pin="420,1490" width="10" x="45" y="75"/>
+      <circ-port height="10" pin="420,1750" width="10" x="45" y="85"/>
+      <circ-anchor facing="east" height="6" width="6" x="77" y="77"/>
+    </appear>
+    <wire from="(290,1320)" to="(350,1320)"/>
+    <wire from="(120,190)" to="(180,190)"/>
+    <wire from="(200,190)" to="(260,190)"/>
+    <wire from="(230,150)" to="(230,160)"/>
+    <wire from="(230,470)" to="(230,480)"/>
+    <wire from="(220,1500)" to="(220,1510)"/>
+    <wire from="(340,710)" to="(340,1180)"/>
+    <wire from="(140,250)" to="(140,340)"/>
+    <wire from="(230,1510)" to="(230,1540)"/>
+    <wire from="(140,630)" to="(180,630)"/>
+    <wire from="(240,960)" to="(240,990)"/>
+    <wire from="(240,1120)" to="(240,1150)"/>
+    <wire from="(200,930)" to="(240,930)"/>
+    <wire from="(200,1090)" to="(240,1090)"/>
+    <wire from="(200,1570)" to="(240,1570)"/>
+    <wire from="(200,1730)" to="(240,1730)"/>
+    <wire from="(200,690)" to="(240,690)"/>
+    <wire from="(290,1020)" to="(330,1020)"/>
+    <wire from="(80,720)" to="(180,720)"/>
+    <wire from="(240,480)" to="(240,510)"/>
+    <wire from="(100,170)" to="(260,170)"/>
+    <wire from="(230,330)" to="(260,330)"/>
+    <wire from="(200,780)" to="(230,780)"/>
+    <wire from="(230,90)" to="(260,90)"/>
+    <wire from="(230,730)" to="(260,730)"/>
+    <wire from="(230,1690)" to="(260,1690)"/>
+    <wire from="(230,1850)" to="(260,1850)"/>
+    <wire from="(240,990)" to="(260,990)"/>
+    <wire from="(240,1150)" to="(260,1150)"/>
+    <wire from="(240,910)" to="(260,910)"/>
+    <wire from="(350,620)" to="(370,620)"/>
+    <wire from="(400,670)" to="(420,670)"/>
+    <wire from="(240,240)" to="(240,280)"/>
+    <wire from="(240,1600)" to="(240,1640)"/>
+    <wire from="(240,1760)" to="(240,1800)"/>
+    <wire from="(160,510)" to="(180,510)"/>
+    <wire from="(160,1390)" to="(180,1390)"/>
+    <wire from="(200,1510)" to="(220,1510)"/>
+    <wire from="(100,440)" to="(180,440)"/>
+    <wire from="(100,1480)" to="(180,1480)"/>
+    <wire from="(240,1520)" to="(240,1570)"/>
+    <wire from="(120,610)" to="(260,610)"/>
+    <wire from="(310,1670)" to="(310,1740)"/>
+    <wire from="(80,80)" to="(80,150)"/>
+    <wire from="(40,310)" to="(160,310)"/>
+    <wire from="(230,200)" to="(230,210)"/>
+    <wire from="(240,210)" to="(240,220)"/>
+    <wire from="(290,180)" to="(340,180)"/>
+    <wire from="(320,690)" to="(370,690)"/>
+    <wire from="(80,270)" to="(80,410)"/>
+    <wire from="(80,1150)" to="(80,1290)"/>
+    <wire from="(100,1170)" to="(100,1310)"/>
+    <wire from="(120,1190)" to="(120,1330)"/>
+    <wire from="(160,510)" to="(160,660)"/>
+    <wire from="(240,130)" to="(240,150)"/>
+    <wire from="(200,660)" to="(240,660)"/>
+    <wire from="(200,820)" to="(240,820)"/>
+    <wire from="(40,250)" to="(140,250)"/>
+    <wire from="(240,690)" to="(240,720)"/>
+    <wire from="(80,850)" to="(180,850)"/>
+    <wire from="(200,990)" to="(230,990)"/>
+    <wire from="(200,270)" to="(230,270)"/>
+    <wire from="(230,620)" to="(260,620)"/>
+    <wire from="(200,30)" to="(230,30)"/>
+    <wire from="(230,860)" to="(260,860)"/>
+    <wire from="(200,1150)" to="(230,1150)"/>
+    <wire from="(200,1630)" to="(230,1630)"/>
+    <wire from="(200,1790)" to="(230,1790)"/>
+    <wire from="(80,990)" to="(80,1150)"/>
+    <wire from="(80,1630)" to="(80,1790)"/>
+    <wire from="(100,1010)" to="(100,1170)"/>
+    <wire from="(120,1030)" to="(120,1190)"/>
+    <wire from="(230,1340)" to="(260,1340)"/>
+    <wire from="(240,1520)" to="(260,1520)"/>
+    <wire from="(240,480)" to="(260,480)"/>
+    <wire from="(240,720)" to="(260,720)"/>
+    <wire from="(40,190)" to="(120,190)"/>
+    <wire from="(120,1510)" to="(120,1690)"/>
+    <wire from="(160,1390)" to="(160,1570)"/>
+    <wire from="(310,600)" to="(310,660)"/>
+    <wire from="(120,760)" to="(120,890)"/>
+    <wire from="(140,780)" to="(140,910)"/>
+    <wire from="(160,800)" to="(160,930)"/>
+    <wire from="(80,720)" to="(80,850)"/>
+    <wire from="(100,740)" to="(100,870)"/>
+    <wire from="(310,680)" to="(310,750)"/>
+    <wire from="(120,1330)" to="(180,1330)"/>
+    <wire from="(200,1330)" to="(260,1330)"/>
+    <wire from="(60,1420)" to="(180,1420)"/>
+    <wire from="(230,330)" to="(230,340)"/>
+    <wire from="(60,1260)" to="(180,1260)"/>
+    <wire from="(220,80)" to="(220,90)"/>
+    <wire from="(60,380)" to="(180,380)"/>
+    <wire from="(60,540)" to="(180,540)"/>
+    <wire from="(230,570)" to="(230,580)"/>
+    <wire from="(60,130)" to="(240,130)"/>
+    <wire from="(230,1290)" to="(230,1300)"/>
+    <wire from="(220,1680)" to="(220,1690)"/>
+    <wire from="(220,1840)" to="(220,1850)"/>
+    <wire from="(230,1450)" to="(230,1470)"/>
+    <wire from="(230,1690)" to="(230,1710)"/>
+    <wire from="(230,1850)" to="(230,1870)"/>
+    <wire from="(240,1860)" to="(240,1880)"/>
+    <wire from="(240,340)" to="(240,360)"/>
+    <wire from="(60,540)" to="(60,690)"/>
+    <wire from="(230,90)" to="(230,110)"/>
+    <wire from="(240,100)" to="(240,120)"/>
+    <wire from="(230,410)" to="(230,430)"/>
+    <wire from="(240,820)" to="(240,850)"/>
+    <wire from="(240,1700)" to="(240,1730)"/>
+    <wire from="(350,720)" to="(350,1320)"/>
+    <wire from="(230,430)" to="(260,430)"/>
+    <wire from="(100,590)" to="(260,590)"/>
+    <wire from="(200,720)" to="(230,720)"/>
+    <wire from="(200,1360)" to="(230,1360)"/>
+    <wire from="(60,380)" to="(60,540)"/>
+    <wire from="(200,480)" to="(230,480)"/>
+    <wire from="(60,1260)" to="(60,1420)"/>
+    <wire from="(100,1310)" to="(260,1310)"/>
+    <wire from="(60,30)" to="(60,130)"/>
+    <wire from="(120,90)" to="(120,190)"/>
+    <wire from="(140,110)" to="(140,210)"/>
+    <wire from="(230,1470)" to="(260,1470)"/>
+    <wire from="(240,850)" to="(260,850)"/>
+    <wire from="(350,720)" to="(370,720)"/>
+    <wire from="(160,930)" to="(180,930)"/>
+    <wire from="(160,1090)" to="(180,1090)"/>
+    <wire from="(200,90)" to="(220,90)"/>
+    <wire from="(200,1690)" to="(220,1690)"/>
+    <wire from="(200,1850)" to="(220,1850)"/>
+    <wire from="(240,210)" to="(260,210)"/>
+    <wire from="(160,1570)" to="(180,1570)"/>
+    <wire from="(160,1730)" to="(180,1730)"/>
+    <wire from="(100,60)" to="(180,60)"/>
+    <wire from="(100,300)" to="(180,300)"/>
+    <wire from="(160,120)" to="(240,120)"/>
+    <wire from="(100,1660)" to="(180,1660)"/>
+    <wire from="(100,1820)" to="(180,1820)"/>
+    <wire from="(160,360)" to="(240,360)"/>
+    <wire from="(160,1240)" to="(240,1240)"/>
+    <wire from="(160,1880)" to="(240,1880)"/>
+    <wire from="(60,1420)" to="(60,1600)"/>
+    <wire from="(230,620)" to="(230,630)"/>
+    <wire from="(80,850)" to="(80,990)"/>
+    <wire from="(100,870)" to="(100,1010)"/>
+    <wire from="(120,890)" to="(120,1030)"/>
+    <wire from="(330,310)" to="(330,640)"/>
+    <wire from="(230,1340)" to="(230,1360)"/>
+    <wire from="(140,910)" to="(140,1060)"/>
+    <wire from="(160,1090)" to="(160,1240)"/>
+    <wire from="(160,1730)" to="(160,1880)"/>
+    <wire from="(140,780)" to="(180,780)"/>
+    <wire from="(220,1500)" to="(260,1500)"/>
+    <wire from="(80,150)" to="(180,150)"/>
+    <wire from="(240,630)" to="(240,660)"/>
+    <wire from="(200,850)" to="(230,850)"/>
+    <wire from="(230,160)" to="(260,160)"/>
+    <wire from="(120,1690)" to="(120,1850)"/>
+    <wire from="(140,1710)" to="(140,1870)"/>
+    <wire from="(160,930)" to="(160,1090)"/>
+    <wire from="(160,1570)" to="(160,1730)"/>
+    <wire from="(230,1040)" to="(260,1040)"/>
+    <wire from="(230,1200)" to="(260,1200)"/>
+    <wire from="(240,1700)" to="(260,1700)"/>
+    <wire from="(240,1860)" to="(260,1860)"/>
+    <wire from="(240,1460)" to="(260,1460)"/>
+    <wire from="(290,1670)" to="(310,1670)"/>
+    <wire from="(290,1830)" to="(310,1830)"/>
+    <wire from="(140,210)" to="(140,250)"/>
+    <wire from="(240,1350)" to="(240,1390)"/>
+    <wire from="(160,660)" to="(180,660)"/>
+    <wire from="(240,100)" to="(260,100)"/>
+    <wire from="(240,420)" to="(260,420)"/>
+    <wire from="(240,340)" to="(260,340)"/>
+    <wire from="(160,310)" to="(160,360)"/>
+    <wire from="(120,760)" to="(260,760)"/>
+    <wire from="(320,690)" to="(320,880)"/>
+    <wire from="(310,660)" to="(370,660)"/>
+    <wire from="(360,1750)" to="(420,1750)"/>
+    <wire from="(120,1030)" to="(180,1030)"/>
+    <wire from="(120,1190)" to="(180,1190)"/>
+    <wire from="(120,1510)" to="(180,1510)"/>
+    <wire from="(200,1030)" to="(260,1030)"/>
+    <wire from="(200,1190)" to="(260,1190)"/>
+    <wire from="(60,240)" to="(180,240)"/>
+    <wire from="(60,960)" to="(180,960)"/>
+    <wire from="(230,990)" to="(230,1000)"/>
+    <wire from="(60,1120)" to="(180,1120)"/>
+    <wire from="(60,1600)" to="(180,1600)"/>
+    <wire from="(60,1760)" to="(180,1760)"/>
+    <wire from="(320,450)" to="(320,650)"/>
+    <wire from="(60,1120)" to="(60,1260)"/>
+    <wire from="(60,240)" to="(60,380)"/>
+    <wire from="(230,1150)" to="(230,1160)"/>
+    <wire from="(160,660)" to="(160,800)"/>
+    <wire from="(230,1630)" to="(230,1650)"/>
+    <wire from="(230,1790)" to="(230,1810)"/>
+    <wire from="(120,460)" to="(120,610)"/>
+    <wire from="(140,480)" to="(140,630)"/>
+    <wire from="(230,270)" to="(230,290)"/>
+    <wire from="(230,30)" to="(230,50)"/>
+    <wire from="(100,440)" to="(100,590)"/>
+    <wire from="(330,700)" to="(370,700)"/>
+    <wire from="(100,140)" to="(100,170)"/>
+    <wire from="(200,340)" to="(230,340)"/>
+    <wire from="(230,50)" to="(260,50)"/>
+    <wire from="(60,960)" to="(60,1120)"/>
+    <wire from="(60,1600)" to="(60,1760)"/>
+    <wire from="(230,290)" to="(260,290)"/>
+    <wire from="(230,770)" to="(260,770)"/>
+    <wire from="(200,1060)" to="(230,1060)"/>
+    <wire from="(200,1220)" to="(230,1220)"/>
+    <wire from="(200,1540)" to="(230,1540)"/>
+    <wire from="(100,1010)" to="(260,1010)"/>
+    <wire from="(100,1170)" to="(260,1170)"/>
+    <wire from="(350,70)" to="(350,620)"/>
+    <wire from="(140,110)" to="(230,110)"/>
+    <wire from="(140,910)" to="(230,910)"/>
+    <wire from="(140,1710)" to="(230,1710)"/>
+    <wire from="(140,1870)" to="(230,1870)"/>
+    <wire from="(230,1650)" to="(260,1650)"/>
+    <wire from="(230,1810)" to="(260,1810)"/>
+    <wire from="(290,600)" to="(310,600)"/>
+    <wire from="(240,1350)" to="(260,1350)"/>
+    <wire from="(310,1740)" to="(330,1740)"/>
+    <wire from="(40,30)" to="(60,30)"/>
+    <wire from="(60,130)" to="(60,240)"/>
+    <wire from="(240,150)" to="(260,150)"/>
+    <wire from="(240,630)" to="(260,630)"/>
+    <wire from="(160,220)" to="(240,220)"/>
+    <wire from="(100,1480)" to="(100,1660)"/>
+    <wire from="(140,1360)" to="(140,1540)"/>
+    <wire from="(80,150)" to="(80,270)"/>
+    <wire from="(100,170)" to="(100,300)"/>
+    <wire from="(120,190)" to="(120,320)"/>
+    <wire from="(60,690)" to="(60,820)"/>
+    <wire from="(200,440)" to="(260,440)"/>
+    <wire from="(200,1480)" to="(260,1480)"/>
+    <wire from="(60,690)" to="(180,690)"/>
+    <wire from="(230,720)" to="(230,730)"/>
+    <wire from="(290,1180)" to="(340,1180)"/>
+    <wire from="(320,650)" to="(370,650)"/>
+    <wire from="(230,1200)" to="(230,1220)"/>
+    <wire from="(100,60)" to="(100,140)"/>
+    <wire from="(230,1040)" to="(230,1060)"/>
+    <wire from="(240,1210)" to="(240,1240)"/>
+    <wire from="(140,1360)" to="(180,1360)"/>
+    <wire from="(140,480)" to="(180,480)"/>
+    <wire from="(200,1260)" to="(240,1260)"/>
+    <wire from="(200,1420)" to="(240,1420)"/>
+    <wire from="(220,80)" to="(260,80)"/>
+    <wire from="(200,380)" to="(240,380)"/>
+    <wire from="(200,540)" to="(240,540)"/>
+    <wire from="(290,310)" to="(330,310)"/>
+    <wire from="(220,1680)" to="(260,1680)"/>
+    <wire from="(220,1840)" to="(260,1840)"/>
+    <wire from="(80,410)" to="(180,410)"/>
+    <wire from="(80,570)" to="(180,570)"/>
+    <wire from="(240,10)" to="(240,40)"/>
+    <wire from="(80,1290)" to="(180,1290)"/>
+    <wire from="(80,1450)" to="(180,1450)"/>
+    <wire from="(200,150)" to="(230,150)"/>
+    <wire from="(200,630)" to="(230,630)"/>
+    <wire from="(230,580)" to="(260,580)"/>
+    <wire from="(100,740)" to="(260,740)"/>
+    <wire from="(230,900)" to="(260,900)"/>
+    <wire from="(290,880)" to="(320,880)"/>
+    <wire from="(230,1300)" to="(260,1300)"/>
+    <wire from="(160,120)" to="(160,220)"/>
+    <wire from="(240,1640)" to="(260,1640)"/>
+    <wire from="(240,1800)" to="(260,1800)"/>
+    <wire from="(240,1050)" to="(240,1090)"/>
+    <wire from="(240,40)" to="(260,40)"/>
+    <wire from="(240,280)" to="(260,280)"/>
+    <wire from="(120,460)" to="(260,460)"/>
+    <wire from="(310,680)" to="(370,680)"/>
+    <wire from="(310,1760)" to="(310,1830)"/>
+    <wire from="(120,90)" to="(180,90)"/>
+    <wire from="(330,700)" to="(330,1020)"/>
+    <wire from="(120,890)" to="(180,890)"/>
+    <wire from="(120,1690)" to="(180,1690)"/>
+    <wire from="(120,1850)" to="(180,1850)"/>
+    <wire from="(200,890)" to="(260,890)"/>
+    <wire from="(60,820)" to="(180,820)"/>
+    <wire from="(230,850)" to="(230,860)"/>
+    <wire from="(230,770)" to="(230,780)"/>
+    <wire from="(60,10)" to="(240,10)"/>
+    <wire from="(100,300)" to="(100,440)"/>
+    <wire from="(120,320)" to="(120,460)"/>
+    <wire from="(60,820)" to="(60,960)"/>
+    <wire from="(140,340)" to="(140,480)"/>
+    <wire from="(140,1220)" to="(140,1360)"/>
+    <wire from="(240,780)" to="(240,800)"/>
+    <wire from="(160,360)" to="(160,510)"/>
+    <wire from="(160,1240)" to="(160,1390)"/>
+    <wire from="(240,1260)" to="(240,1290)"/>
+    <wire from="(200,1390)" to="(240,1390)"/>
+    <wire from="(200,510)" to="(240,510)"/>
+    <wire from="(240,540)" to="(240,570)"/>
+    <wire from="(330,640)" to="(370,640)"/>
+    <wire from="(230,470)" to="(260,470)"/>
+    <wire from="(100,870)" to="(260,870)"/>
+    <wire from="(100,1660)" to="(100,1820)"/>
+    <wire from="(140,1060)" to="(140,1220)"/>
+    <wire from="(140,210)" to="(230,210)"/>
+    <wire from="(290,450)" to="(320,450)"/>
+    <wire from="(230,1510)" to="(260,1510)"/>
+    <wire from="(240,1290)" to="(260,1290)"/>
+    <wire from="(240,1050)" to="(260,1050)"/>
+    <wire from="(240,1210)" to="(260,1210)"/>
+    <wire from="(140,1540)" to="(140,1710)"/>
+    <wire from="(310,1760)" to="(330,1760)"/>
+    <wire from="(240,380)" to="(240,420)"/>
+    <wire from="(240,1420)" to="(240,1460)"/>
+    <wire from="(240,570)" to="(260,570)"/>
+    <wire from="(160,800)" to="(240,800)"/>
+    <wire from="(290,1490)" to="(420,1490)"/>
+    <wire from="(290,70)" to="(350,70)"/>
+    <wire from="(40,140)" to="(100,140)"/>
+    <wire from="(200,60)" to="(260,60)"/>
+    <wire from="(340,180)" to="(340,630)"/>
+    <wire from="(200,1660)" to="(260,1660)"/>
+    <wire from="(200,1820)" to="(260,1820)"/>
+    <wire from="(200,300)" to="(260,300)"/>
+    <wire from="(230,900)" to="(230,910)"/>
+    <wire from="(240,910)" to="(240,930)"/>
+    <wire from="(60,10)" to="(60,30)"/>
+    <wire from="(120,610)" to="(120,760)"/>
+    <wire from="(140,630)" to="(140,780)"/>
+    <wire from="(80,570)" to="(80,720)"/>
+    <wire from="(100,590)" to="(100,740)"/>
+    <wire from="(40,80)" to="(80,80)"/>
+    <wire from="(160,220)" to="(160,310)"/>
+    <wire from="(140,340)" to="(180,340)"/>
+    <wire from="(140,1060)" to="(180,1060)"/>
+    <wire from="(140,1220)" to="(180,1220)"/>
+    <wire from="(140,1540)" to="(180,1540)"/>
+    <wire from="(200,240)" to="(240,240)"/>
+    <wire from="(200,960)" to="(240,960)"/>
+    <wire from="(200,1120)" to="(240,1120)"/>
+    <wire from="(200,1600)" to="(240,1600)"/>
+    <wire from="(200,1760)" to="(240,1760)"/>
+    <wire from="(80,30)" to="(180,30)"/>
+    <wire from="(80,990)" to="(180,990)"/>
+    <wire from="(80,1150)" to="(180,1150)"/>
+    <wire from="(80,270)" to="(180,270)"/>
+    <wire from="(80,1630)" to="(180,1630)"/>
+    <wire from="(80,1790)" to="(180,1790)"/>
+    <wire from="(200,410)" to="(230,410)"/>
+    <wire from="(200,570)" to="(230,570)"/>
+    <wire from="(80,410)" to="(80,570)"/>
+    <wire from="(230,200)" to="(260,200)"/>
+    <wire from="(230,1000)" to="(260,1000)"/>
+    <wire from="(200,1290)" to="(230,1290)"/>
+    <wire from="(200,1450)" to="(230,1450)"/>
+    <wire from="(80,1290)" to="(80,1450)"/>
+    <wire from="(230,1160)" to="(260,1160)"/>
+    <wire from="(340,710)" to="(370,710)"/>
+    <wire from="(340,630)" to="(370,630)"/>
+    <wire from="(240,780)" to="(260,780)"/>
+    <wire from="(290,750)" to="(310,750)"/>
+    <wire from="(100,1310)" to="(100,1480)"/>
+    <wire from="(80,30)" to="(80,80)"/>
+    <wire from="(80,1450)" to="(80,1630)"/>
+    <wire from="(120,320)" to="(260,320)"/>
+    <wire from="(120,1330)" to="(120,1510)"/>
+    <comp lib="1" loc="(200,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,70)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,60)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,250)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,600)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,990)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,670)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="i"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,1490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(420,1750)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="j"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,90)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(420,1490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="r"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(400,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(200,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,190)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1730)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,880)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(290,450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,1760)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(290,1020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,890)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(360,1750)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(200,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,1180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(200,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,1820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(200,30)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(200,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+  </circuit>
+</project>

--- a/src/pipeline_cpu.circ
+++ b/src/pipeline_cpu.circ
@@ -98,6 +98,7 @@
   <lib desc="file#common/alu.circ" name="7"/>
   <lib desc="file#common/regfile.circ" name="8"/>
   <lib desc="file#common/control.circ" name="9"/>
+  <lib desc="file#common/statistics.circ" name="10"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -587,289 +588,7 @@
     <wire from="(730,560)" to="(740,560)"/>
     <wire from="(550,220)" to="(560,220)"/>
     <wire from="(490,1280)" to="(500,1280)"/>
-    <comp lib="0" loc="(1120,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(1220,1290)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp lib="0" loc="(1490,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(620,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="5" loc="(590,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(280,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="1" loc="(750,1290)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(950,470)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(650,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="6" loc="(1347,1084)" name="Text">
-      <a name="text" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(680,1290)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Load/Use"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="2" loc="(1950,770)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1700,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(840,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1380,1130)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1780,1120)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(400,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="6" loc="(1316,692)" name="Text">
-      <a name="text" val="WriteReg#"/>
-    </comp>
-    <comp lib="0" loc="(480,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="2" loc="(720,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(210,1330)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="2" loc="(1340,590)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1110,540)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="0" loc="(1040,920)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="2" loc="(1000,690)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1140,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="6" loc="(1175,1145)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp lib="2" loc="(2410,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1315,765)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="2" loc="(260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(840,700)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(870,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(1110,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="0" loc="(1040,1060)" name="Tunnel">
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(2100,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0MEM"/>
-    </comp>
-    <comp lib="0" loc="(1670,1110)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
-    </comp>
-    <comp lib="0" loc="(840,510)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1760,60)" name="Tunnel">
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="0" loc="(1320,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp lib="6" loc="(584,110)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="4" loc="(530,1270)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp loc="(360,1330)" name="Hazard Unit"/>
-    <comp lib="0" loc="(1980,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp loc="(1670,590)" name="ALU_Wrapper"/>
-    <comp lib="3" loc="(1530,1160)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(840,850)" name="Splitter">
+    <comp lib="0" loc="(840,770)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -888,35 +607,22 @@
       <a name="bit13" val="0"/>
       <a name="bit14" val="0"/>
       <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
       <a name="bit26" val="none"/>
       <a name="bit27" val="none"/>
       <a name="bit28" val="none"/>
       <a name="bit29" val="none"/>
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(550,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="6" loc="(1443,1265)" name="Text">
-      <a name="text" val="Memory Result"/>
-    </comp>
-    <comp lib="6" loc="(1437,1244)" name="Text">
-      <a name="text" val="ALU Result"/>
-    </comp>
-    <comp lib="0" loc="(950,450)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
     </comp>
     <comp lib="0" loc="(1940,590)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -955,214 +661,12 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="1" loc="(440,700)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1070,770)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="1"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="1"/>
-      <a name="bit9" val="1"/>
-      <a name="bit10" val="1"/>
-      <a name="bit11" val="1"/>
-      <a name="bit12" val="1"/>
-      <a name="bit13" val="1"/>
-      <a name="bit14" val="1"/>
-      <a name="bit15" val="1"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="2"/>
-      <a name="bit29" val="2"/>
-      <a name="bit30" val="2"/>
-      <a name="bit31" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1090,500)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(1600,630)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1165,1186)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="5" loc="(550,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(760,130)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(450,560)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="0" loc="(420,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(2100,590)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="0" loc="(1520,350)" name="Tunnel">
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(550,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1030,710)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="5" loc="(600,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp loc="(1290,180)" name="RegWrite_Decider"/>
-    <comp lib="0" loc="(840,250)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(490,1280)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="0" loc="(970,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(2220,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="0" loc="(1520,290)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
-    </comp>
-    <comp lib="0" loc="(230,1330)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(930,920)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="4" loc="(540,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
+    <comp loc="(980,990)" name="CP0"/>
     <comp lib="0" loc="(1630,160)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="IsCOP0EX"/>
     </comp>
-    <comp lib="0" loc="(2250,460)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(1960,1070)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(160,520)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1720,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(390,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="2" loc="(310,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(2160,140)" name="MEM/WB"/>
-    <comp lib="0" loc="(1560,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(830,880)" name="Splitter">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(840,510)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -1187,90 +691,6 @@
       <a name="bit18" val="none"/>
       <a name="bit19" val="none"/>
       <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="2" loc="(480,560)" name="Demultiplexer">
-      <a name="width" val="9"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(460,710)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(1167,1164)" name="Text">
-      <a name="text" val="Jump Addr"/>
-    </comp>
-    <comp lib="2" loc="(430,650)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(840,770)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
       <a name="bit21" val="0"/>
       <a name="bit22" val="0"/>
       <a name="bit23" val="0"/>
@@ -1283,120 +703,140 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="6" loc="(2010,695)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(2030,630)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp loc="(1120,490)" name="Regfile_Wrapper"/>
-    <comp lib="4" loc="(470,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="2" loc="(360,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="6" loc="(682,877)" name="Text">
-      <a name="text" val="PCPlus4IF"/>
-    </comp>
-    <comp lib="2" loc="(220,1280)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(980,920)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpSrc1"/>
     </comp>
     <comp lib="5" loc="(710,180)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
+    <comp lib="6" loc="(1579,1326)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
     </comp>
-    <comp lib="0" loc="(2010,1050)" name="Tunnel">
-      <a name="label" val="IsCOP0MEM"/>
-    </comp>
-    <comp lib="0" loc="(840,330)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+    <comp lib="6" loc="(859,501)" name="Text">
+      <a name="text" val="RS"/>
     </comp>
     <comp lib="0" loc="(340,760)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="IsCOP0EX"/>
     </comp>
-    <comp lib="2" loc="(210,530)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="0" loc="(1640,1090)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="0" loc="(2100,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="4" loc="(450,560)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(350,1350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp loc="(360,1330)" name="Hazard Unit"/>
+    <comp lib="3" loc="(640,850)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp loc="(1770,150)" name="EX/MEM"/>
+    <comp lib="6" loc="(682,877)" name="Text">
+      <a name="text" val="PCPlus4IF"/>
+    </comp>
+    <comp lib="2" loc="(360,560)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(2010,750)" name="Tunnel">
-      <a name="label" val="MemtoRegMEM"/>
+    <comp lib="6" loc="(1443,1265)" name="Text">
+      <a name="text" val="Memory Result"/>
     </comp>
-    <comp lib="0" loc="(580,860)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
+    <comp lib="6" loc="(2010,695)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="0" loc="(460,560)" name="Splitter">
+    <comp lib="1" loc="(390,1290)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(520,420)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1120,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(2190,1110)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(870,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="2" loc="(430,650)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(890,1030)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1030,760)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1280,150)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(1110,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="6" loc="(1175,1145)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="4" loc="(670,650)" name="ROM">
+      <a name="addrWidth" val="9"/>
+      <a name="dataWidth" val="32"/>
+      <a name="contents">addr/data: 9 32
+201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
+401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
+23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
+23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
+1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
+20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
+23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
+8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
+23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
+8fda0000 409a0000 201a0000 409a0800 42000018
+</a>
+    </comp>
+    <comp lib="0" loc="(2290,510)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(840,700)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit0" val="none"/>
       <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
       <a name="bit16" val="none"/>
       <a name="bit17" val="none"/>
       <a name="bit18" val="none"/>
@@ -1413,20 +853,6 @@
       <a name="bit29" val="none"/>
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
-    </comp>
-    <comp loc="(1770,150)" name="EX/MEM"/>
-    <comp lib="6" loc="(862,240)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="0" loc="(1570,1060)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="6" loc="(1317,872)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="6" loc="(2439,1205)" name="Text">
-      <a name="text" val="WB_DATA"/>
     </comp>
     <comp lib="0" loc="(700,370)" name="Splitter">
       <a name="facing" val="west"/>
@@ -1440,133 +866,23 @@
       <a name="bit4" val="1"/>
       <a name="bit5" val="0"/>
     </comp>
-    <comp lib="0" loc="(890,1030)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(1220,1290)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RsOutput"/>
     </comp>
-    <comp lib="2" loc="(2360,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="10" loc="(680,360)" name="statistics"/>
+    <comp lib="2" loc="(720,560)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1870,1310)" name="Tunnel">
+    <comp lib="0" loc="(1090,500)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(1190,630)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="3" loc="(1590,1150)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="1" loc="(1180,490)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1610,1110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp loc="(950,830)" name="Immediate_Extend"/>
-    <comp lib="0" loc="(2220,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="0" loc="(1640,1090)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="6" loc="(1214,627)" name="Text">
-      <a name="text" val="Shamt"/>
-    </comp>
-    <comp lib="0" loc="(220,1270)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1670,1130)" name="Tunnel">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(1030,760)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(1080,700)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
       <a name="width" val="5"/>
-      <a name="enable" val="false"/>
+      <a name="label" val="Rs"/>
     </comp>
-    <comp lib="0" loc="(350,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp loc="(2230,460)" name="Syscall_Decoder"/>
-    <comp lib="0" loc="(920,540)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(1050,950)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp loc="(680,360)" name="Statistics"/>
-    <comp lib="2" loc="(1530,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(980,920)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="3" loc="(640,850)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(550,1270)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(600,770)" name="Tunnel">
+    <comp lib="0" loc="(970,1110)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(320,520)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x800"/>
-    </comp>
-    <comp lib="0" loc="(980,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="6" loc="(860,688)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="0" loc="(1880,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="6" loc="(857,539)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(250,1300)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(1200,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-    </comp>
-    <comp lib="0" loc="(930,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(1280,150)" name="Tunnel">
       <a name="label" val="ExRegWrite"/>
     </comp>
     <comp lib="0" loc="(730,560)" name="Splitter">
@@ -1607,51 +923,412 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="2" loc="(1340,500)" name="Multiplexer">
+    <comp lib="0" loc="(420,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(840,330)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1800,1120)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="9" loc="(890,150)" name="Control"/>
+    <comp lib="0" loc="(1040,1060)" name="Tunnel">
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(490,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="6" loc="(857,539)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(1140,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="6" loc="(1165,1186)" name="Text">
+      <a name="text" val="Branch Addr"/>
+    </comp>
+    <comp lib="2" loc="(1340,590)" name="Multiplexer">
       <a name="select" val="2"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(380,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1500,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2190,1110)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1490,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(1320,640)" name="Tunnel">
+    <comp loc="(1370,140)" name="ID/EX"/>
+    <comp lib="0" loc="(1320,530)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
+      <a name="label" val="RsOutput"/>
     </comp>
-    <comp lib="0" loc="(330,660)" name="Tunnel">
+    <comp lib="0" loc="(1610,1110)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
+      <a name="label" val="JumpEX"/>
     </comp>
     <comp lib="5" loc="(650,760)" name="Button">
       <a name="facing" val="south"/>
     </comp>
-    <comp lib="6" loc="(1314,841)" name="Text">
-      <a name="text" val="Immediate"/>
-    </comp>
-    <comp lib="1" loc="(1710,340)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1740,280)" name="AND Gate">
+    <comp lib="0" loc="(2170,1110)" name="Constant">
       <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(1950,770)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(320,520)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x800"/>
+    </comp>
+    <comp lib="0" loc="(1480,1170)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(210,1330)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(220,1280)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(580,860)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(930,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(830,880)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1870,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(2010,750)" name="Tunnel">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(250,1300)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(980,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="0" loc="(2220,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(570,280)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+      <a name="bit11" val="2"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+      <a name="bit14" val="3"/>
+      <a name="bit15" val="3"/>
+      <a name="bit16" val="4"/>
+      <a name="bit17" val="4"/>
+      <a name="bit18" val="4"/>
+      <a name="bit19" val="4"/>
+      <a name="bit20" val="5"/>
+      <a name="bit21" val="5"/>
+      <a name="bit22" val="5"/>
+      <a name="bit23" val="5"/>
+      <a name="bit24" val="6"/>
+      <a name="bit25" val="6"/>
+      <a name="bit26" val="6"/>
+      <a name="bit27" val="6"/>
+      <a name="bit28" val="7"/>
+      <a name="bit29" val="7"/>
+      <a name="bit30" val="7"/>
+      <a name="bit31" val="7"/>
+    </comp>
+    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1030,710)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="2" loc="(1080,700)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(2360,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(550,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(550,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(920,1070)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(2250,460)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1690,1040)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="2" loc="(2460,590)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(920,540)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="6" loc="(1347,1084)" name="Text">
+      <a name="text" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(460,710)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1780,1120)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1190,630)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1880,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp loc="(1290,180)" name="RegWrite_Decider"/>
+    <comp lib="0" loc="(1520,350)" name="Tunnel">
+      <a name="label" val="JumpEX"/>
+    </comp>
+    <comp lib="1" loc="(1640,1190)" name="OR Gate">
+      <a name="facing" val="south"/>
       <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="5" loc="(550,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(620,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(840,850)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="3" loc="(1590,1150)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="2" loc="(260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(480,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1490,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="2" loc="(1530,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(600,760)" name="Button">
+      <a name="facing" val="south"/>
     </comp>
     <comp lib="4" loc="(670,550)" name="ROM">
       <a name="addrWidth" val="9"/>
@@ -1701,54 +1378,14 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="0" loc="(1480,1170)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
+    <comp loc="(2160,140)" name="MEM/WB"/>
+    <comp lib="0" loc="(1670,1110)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
     </comp>
-    <comp loc="(1370,140)" name="ID/EX"/>
-    <comp lib="2" loc="(2460,590)" name="Multiplexer">
+    <comp lib="2" loc="(210,530)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(920,520)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="1" loc="(290,690)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(2166,1226)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="6" loc="(1579,1326)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="0" loc="(920,1070)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(510,1300)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1800,1120)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(390,1290)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="6" loc="(863,316)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(2170,1110)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1690,1040)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsCOP0EX"/>
     </comp>
     <comp lib="0" loc="(840,630)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1787,99 +1424,463 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="4" loc="(670,650)" name="ROM">
-      <a name="addrWidth" val="9"/>
-      <a name="dataWidth" val="32"/>
-      <a name="contents">addr/data: 9 32
-201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
-401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
-23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
-23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
-1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
-20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
-23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
-8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
-23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
-8fda0000 409a0000 201a0000 409a0800 42000018
-</a>
+    <comp lib="0" loc="(950,450)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
     </comp>
-    <comp lib="0" loc="(520,420)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+    <comp lib="6" loc="(1314,841)" name="Text">
+      <a name="text" val="Immediate"/>
     </comp>
-    <comp lib="0" loc="(1160,480)" name="Tunnel">
+    <comp lib="0" loc="(1490,1310)" name="Tunnel">
       <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="0" loc="(1200,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="0" loc="(2220,480)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="32"/>
-      <a name="label" val="a0"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(1980,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="1" loc="(380,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(610,310)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(280,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp loc="(950,830)" name="Immediate_Extend"/>
+    <comp lib="6" loc="(1317,872)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
     </comp>
     <comp lib="0" loc="(1090,1320)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="width" val="5"/>
       <a name="label" val="Rs"/>
     </comp>
-    <comp lib="9" loc="(890,150)" name="Control"/>
-    <comp lib="4" loc="(610,310)" name="Counter">
+    <comp lib="2" loc="(1600,630)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(2290,510)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="1" loc="(1640,1190)" name="OR Gate">
-      <a name="facing" val="south"/>
+    <comp lib="1" loc="(1740,280)" name="AND Gate">
+      <a name="facing" val="north"/>
       <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp loc="(980,990)" name="CP0"/>
-    <comp lib="6" loc="(859,501)" name="Text">
-      <a name="text" val="RS"/>
+    <comp lib="1" loc="(440,700)" name="NOT Gate">
+      <a name="facing" val="north"/>
     </comp>
-    <comp loc="(740,140)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
+    <comp lib="0" loc="(930,920)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpSrc0"/>
     </comp>
-    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
+    <comp lib="6" loc="(863,316)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(950,470)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
+    <comp loc="(740,140)" name="IF/ID">
+      <a name="labelfont" val="Monaco bold 44"/>
+    </comp>
+    <comp lib="0" loc="(1050,950)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(400,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(330,660)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
     <comp lib="6" loc="(1656,674)" name="Text">
       <a name="text" val="WriteDataEX"/>
     </comp>
-    <comp lib="0" loc="(570,280)" name="Splitter">
+    <comp lib="6" loc="(1437,1244)" name="Text">
+      <a name="text" val="ALU Result"/>
+    </comp>
+    <comp loc="(1670,590)" name="ALU_Wrapper"/>
+    <comp lib="0" loc="(1380,1130)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="fanout" val="8"/>
+    </comp>
+    <comp lib="0" loc="(1040,920)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="4" loc="(2100,590)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="4" loc="(530,1270)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="6" loc="(584,110)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp lib="0" loc="(1320,640)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="0" loc="(840,250)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="0" loc="(2010,1050)" name="Tunnel">
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="0" loc="(1720,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="2" loc="(310,550)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(1316,692)" name="Text">
+      <a name="text" val="WriteReg#"/>
+    </comp>
+    <comp lib="0" loc="(840,550)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(680,1290)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Load/Use"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(1180,490)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="1" loc="(290,690)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(2166,1226)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="6" loc="(1214,627)" name="Text">
+      <a name="text" val="Shamt"/>
+    </comp>
+    <comp lib="4" loc="(470,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(460,560)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1340,500)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(600,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="2" loc="(1000,690)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1700,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="0" loc="(220,1270)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(860,688)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="0" loc="(1520,290)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
+    </comp>
+    <comp lib="0" loc="(650,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(230,1330)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(1315,765)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="4" loc="(540,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="6" loc="(862,240)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp lib="4" loc="(390,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
+    </comp>
+    <comp lib="0" loc="(1160,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(1570,1060)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp lib="0" loc="(920,520)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="5" loc="(590,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1560,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(1110,540)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="2" loc="(1960,1070)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1670,1130)" name="Tunnel">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="2" loc="(1500,550)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(2410,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(2230,460)" name="Syscall_Decoder"/>
+    <comp lib="6" loc="(2439,1205)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="1" loc="(1710,340)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(480,560)" name="Demultiplexer">
+      <a name="width" val="9"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(550,1270)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2030,630)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="3" loc="(1530,1160)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(510,1300)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1760,60)" name="Tunnel">
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="6" loc="(1167,1164)" name="Text">
+      <a name="text" val="Jump Addr"/>
+    </comp>
+    <comp loc="(1120,490)" name="Regfile_Wrapper"/>
+    <comp lib="0" loc="(760,130)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(160,520)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1070,770)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="1"/>
       <a name="bit4" val="1"/>
       <a name="bit5" val="1"/>
       <a name="bit6" val="1"/>
       <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-      <a name="bit16" val="4"/>
-      <a name="bit17" val="4"/>
-      <a name="bit18" val="4"/>
-      <a name="bit19" val="4"/>
-      <a name="bit20" val="5"/>
-      <a name="bit21" val="5"/>
-      <a name="bit22" val="5"/>
-      <a name="bit23" val="5"/>
-      <a name="bit24" val="6"/>
-      <a name="bit25" val="6"/>
-      <a name="bit26" val="6"/>
-      <a name="bit27" val="6"/>
-      <a name="bit28" val="7"/>
-      <a name="bit29" val="7"/>
-      <a name="bit30" val="7"/>
-      <a name="bit31" val="7"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+      <a name="bit11" val="1"/>
+      <a name="bit12" val="1"/>
+      <a name="bit13" val="1"/>
+      <a name="bit14" val="1"/>
+      <a name="bit15" val="1"/>
+      <a name="bit16" val="1"/>
+      <a name="bit17" val="1"/>
+      <a name="bit18" val="1"/>
+      <a name="bit19" val="1"/>
+      <a name="bit20" val="1"/>
+      <a name="bit21" val="1"/>
+      <a name="bit22" val="1"/>
+      <a name="bit23" val="1"/>
+      <a name="bit24" val="1"/>
+      <a name="bit25" val="1"/>
+      <a name="bit26" val="1"/>
+      <a name="bit27" val="1"/>
+      <a name="bit28" val="2"/>
+      <a name="bit29" val="2"/>
+      <a name="bit30" val="2"/>
+      <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="1" loc="(750,1290)" name="NOT Gate">
+      <a name="facing" val="north"/>
     </comp>
   </circuit>
   <circuit name="Syscall_Decoder">
@@ -1914,6 +1915,36 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(490,460)" to="(490,480)"/>
     <wire from="(480,290)" to="(480,320)"/>
     <wire from="(170,440)" to="(300,440)"/>
+    <comp lib="4" loc="(500,270)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(440,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(480,320)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(570,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Halt"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(320,130)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(510,440)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="3" loc="(340,450)" name="Comparator">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(310,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
     <comp lib="0" loc="(420,270)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
@@ -1922,48 +1953,13 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(510,480)" name="Tunnel">
       <a name="label" val="Enable"/>
     </comp>
-    <comp lib="0" loc="(440,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(440,320)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(270,460)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0xa"/>
-    </comp>
     <comp lib="0" loc="(170,440)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="v0"/>
     </comp>
-    <comp lib="0" loc="(310,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(510,440)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(570,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Halt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(480,320)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(500,270)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
     <comp lib="0" loc="(470,130)" name="Tunnel">
       <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(320,130)" name="Tunnel">
-      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(660,270)" name="Pin">
       <a name="facing" val="west"/>
@@ -1973,670 +1969,20 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
-    <comp lib="0" loc="(470,430)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
     <comp lib="0" loc="(580,420)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="3" loc="(340,450)" name="Comparator">
+    <comp lib="0" loc="(440,320)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(270,460)" name="Constant">
       <a name="width" val="32"/>
+      <a name="value" val="0xa"/>
     </comp>
-  </circuit>
-  <circuit name="Statistics">
-    <a name="circuit" val="Statistics"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#ff01b2" height="60" stroke="none" width="30" x="50" y="55"/>
-      <circ-port height="8" pin="40,30" width="8" x="76" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="76" y="66"/>
-      <circ-port height="8" pin="40,140" width="8" x="76" y="76"/>
-      <circ-port height="8" pin="40,190" width="8" x="76" y="86"/>
-      <circ-port height="8" pin="40,250" width="8" x="76" y="96"/>
-      <circ-port height="8" pin="40,310" width="8" x="76" y="106"/>
-      <circ-port height="10" pin="420,670" width="10" x="45" y="65"/>
-      <circ-port height="10" pin="420,1490" width="10" x="45" y="75"/>
-      <circ-port height="10" pin="420,1750" width="10" x="45" y="85"/>
-      <circ-anchor facing="east" height="6" width="6" x="77" y="77"/>
-    </appear>
-    <wire from="(290,1320)" to="(350,1320)"/>
-    <wire from="(120,190)" to="(180,190)"/>
-    <wire from="(200,190)" to="(260,190)"/>
-    <wire from="(230,150)" to="(230,160)"/>
-    <wire from="(230,470)" to="(230,480)"/>
-    <wire from="(220,1500)" to="(220,1510)"/>
-    <wire from="(340,710)" to="(340,1180)"/>
-    <wire from="(140,250)" to="(140,340)"/>
-    <wire from="(230,1510)" to="(230,1540)"/>
-    <wire from="(140,630)" to="(180,630)"/>
-    <wire from="(240,960)" to="(240,990)"/>
-    <wire from="(240,1120)" to="(240,1150)"/>
-    <wire from="(200,930)" to="(240,930)"/>
-    <wire from="(200,1090)" to="(240,1090)"/>
-    <wire from="(200,1570)" to="(240,1570)"/>
-    <wire from="(200,1730)" to="(240,1730)"/>
-    <wire from="(200,690)" to="(240,690)"/>
-    <wire from="(290,1020)" to="(330,1020)"/>
-    <wire from="(80,720)" to="(180,720)"/>
-    <wire from="(240,480)" to="(240,510)"/>
-    <wire from="(100,170)" to="(260,170)"/>
-    <wire from="(230,330)" to="(260,330)"/>
-    <wire from="(200,780)" to="(230,780)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(230,730)" to="(260,730)"/>
-    <wire from="(230,1690)" to="(260,1690)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(240,990)" to="(260,990)"/>
-    <wire from="(240,1150)" to="(260,1150)"/>
-    <wire from="(240,910)" to="(260,910)"/>
-    <wire from="(350,620)" to="(370,620)"/>
-    <wire from="(400,670)" to="(420,670)"/>
-    <wire from="(240,240)" to="(240,280)"/>
-    <wire from="(240,1600)" to="(240,1640)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(160,510)" to="(180,510)"/>
-    <wire from="(160,1390)" to="(180,1390)"/>
-    <wire from="(200,1510)" to="(220,1510)"/>
-    <wire from="(100,440)" to="(180,440)"/>
-    <wire from="(100,1480)" to="(180,1480)"/>
-    <wire from="(240,1520)" to="(240,1570)"/>
-    <wire from="(120,610)" to="(260,610)"/>
-    <wire from="(310,1670)" to="(310,1740)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(40,310)" to="(160,310)"/>
-    <wire from="(230,200)" to="(230,210)"/>
-    <wire from="(240,210)" to="(240,220)"/>
-    <wire from="(290,180)" to="(340,180)"/>
-    <wire from="(320,690)" to="(370,690)"/>
-    <wire from="(80,270)" to="(80,410)"/>
-    <wire from="(80,1150)" to="(80,1290)"/>
-    <wire from="(100,1170)" to="(100,1310)"/>
-    <wire from="(120,1190)" to="(120,1330)"/>
-    <wire from="(160,510)" to="(160,660)"/>
-    <wire from="(240,130)" to="(240,150)"/>
-    <wire from="(200,660)" to="(240,660)"/>
-    <wire from="(200,820)" to="(240,820)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(240,690)" to="(240,720)"/>
-    <wire from="(80,850)" to="(180,850)"/>
-    <wire from="(200,990)" to="(230,990)"/>
-    <wire from="(200,270)" to="(230,270)"/>
-    <wire from="(230,620)" to="(260,620)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(230,860)" to="(260,860)"/>
-    <wire from="(200,1150)" to="(230,1150)"/>
-    <wire from="(200,1630)" to="(230,1630)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(80,990)" to="(80,1150)"/>
-    <wire from="(80,1630)" to="(80,1790)"/>
-    <wire from="(100,1010)" to="(100,1170)"/>
-    <wire from="(120,1030)" to="(120,1190)"/>
-    <wire from="(230,1340)" to="(260,1340)"/>
-    <wire from="(240,1520)" to="(260,1520)"/>
-    <wire from="(240,480)" to="(260,480)"/>
-    <wire from="(240,720)" to="(260,720)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(120,1510)" to="(120,1690)"/>
-    <wire from="(160,1390)" to="(160,1570)"/>
-    <wire from="(310,600)" to="(310,660)"/>
-    <wire from="(120,760)" to="(120,890)"/>
-    <wire from="(140,780)" to="(140,910)"/>
-    <wire from="(160,800)" to="(160,930)"/>
-    <wire from="(80,720)" to="(80,850)"/>
-    <wire from="(100,740)" to="(100,870)"/>
-    <wire from="(310,680)" to="(310,750)"/>
-    <wire from="(120,1330)" to="(180,1330)"/>
-    <wire from="(200,1330)" to="(260,1330)"/>
-    <wire from="(60,1420)" to="(180,1420)"/>
-    <wire from="(230,330)" to="(230,340)"/>
-    <wire from="(60,1260)" to="(180,1260)"/>
-    <wire from="(220,80)" to="(220,90)"/>
-    <wire from="(60,380)" to="(180,380)"/>
-    <wire from="(60,540)" to="(180,540)"/>
-    <wire from="(230,570)" to="(230,580)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(230,1290)" to="(230,1300)"/>
-    <wire from="(220,1680)" to="(220,1690)"/>
-    <wire from="(220,1840)" to="(220,1850)"/>
-    <wire from="(230,1450)" to="(230,1470)"/>
-    <wire from="(230,1690)" to="(230,1710)"/>
-    <wire from="(230,1850)" to="(230,1870)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(240,340)" to="(240,360)"/>
-    <wire from="(60,540)" to="(60,690)"/>
-    <wire from="(230,90)" to="(230,110)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(230,410)" to="(230,430)"/>
-    <wire from="(240,820)" to="(240,850)"/>
-    <wire from="(240,1700)" to="(240,1730)"/>
-    <wire from="(350,720)" to="(350,1320)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(100,590)" to="(260,590)"/>
-    <wire from="(200,720)" to="(230,720)"/>
-    <wire from="(200,1360)" to="(230,1360)"/>
-    <wire from="(60,380)" to="(60,540)"/>
-    <wire from="(200,480)" to="(230,480)"/>
-    <wire from="(60,1260)" to="(60,1420)"/>
-    <wire from="(100,1310)" to="(260,1310)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(140,110)" to="(140,210)"/>
-    <wire from="(230,1470)" to="(260,1470)"/>
-    <wire from="(240,850)" to="(260,850)"/>
-    <wire from="(350,720)" to="(370,720)"/>
-    <wire from="(160,930)" to="(180,930)"/>
-    <wire from="(160,1090)" to="(180,1090)"/>
-    <wire from="(200,90)" to="(220,90)"/>
-    <wire from="(200,1690)" to="(220,1690)"/>
-    <wire from="(200,1850)" to="(220,1850)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(160,1570)" to="(180,1570)"/>
-    <wire from="(160,1730)" to="(180,1730)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(100,300)" to="(180,300)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(100,1660)" to="(180,1660)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,360)" to="(240,360)"/>
-    <wire from="(160,1240)" to="(240,1240)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(60,1420)" to="(60,1600)"/>
-    <wire from="(230,620)" to="(230,630)"/>
-    <wire from="(80,850)" to="(80,990)"/>
-    <wire from="(100,870)" to="(100,1010)"/>
-    <wire from="(120,890)" to="(120,1030)"/>
-    <wire from="(330,310)" to="(330,640)"/>
-    <wire from="(230,1340)" to="(230,1360)"/>
-    <wire from="(140,910)" to="(140,1060)"/>
-    <wire from="(160,1090)" to="(160,1240)"/>
-    <wire from="(160,1730)" to="(160,1880)"/>
-    <wire from="(140,780)" to="(180,780)"/>
-    <wire from="(220,1500)" to="(260,1500)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(240,630)" to="(240,660)"/>
-    <wire from="(200,850)" to="(230,850)"/>
-    <wire from="(230,160)" to="(260,160)"/>
-    <wire from="(120,1690)" to="(120,1850)"/>
-    <wire from="(140,1710)" to="(140,1870)"/>
-    <wire from="(160,930)" to="(160,1090)"/>
-    <wire from="(160,1570)" to="(160,1730)"/>
-    <wire from="(230,1040)" to="(260,1040)"/>
-    <wire from="(230,1200)" to="(260,1200)"/>
-    <wire from="(240,1700)" to="(260,1700)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,1460)" to="(260,1460)"/>
-    <wire from="(290,1670)" to="(310,1670)"/>
-    <wire from="(290,1830)" to="(310,1830)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,1350)" to="(240,1390)"/>
-    <wire from="(160,660)" to="(180,660)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,420)" to="(260,420)"/>
-    <wire from="(240,340)" to="(260,340)"/>
-    <wire from="(160,310)" to="(160,360)"/>
-    <wire from="(120,760)" to="(260,760)"/>
-    <wire from="(320,690)" to="(320,880)"/>
-    <wire from="(310,660)" to="(370,660)"/>
-    <wire from="(360,1750)" to="(420,1750)"/>
-    <wire from="(120,1030)" to="(180,1030)"/>
-    <wire from="(120,1190)" to="(180,1190)"/>
-    <wire from="(120,1510)" to="(180,1510)"/>
-    <wire from="(200,1030)" to="(260,1030)"/>
-    <wire from="(200,1190)" to="(260,1190)"/>
-    <wire from="(60,240)" to="(180,240)"/>
-    <wire from="(60,960)" to="(180,960)"/>
-    <wire from="(230,990)" to="(230,1000)"/>
-    <wire from="(60,1120)" to="(180,1120)"/>
-    <wire from="(60,1600)" to="(180,1600)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(320,450)" to="(320,650)"/>
-    <wire from="(60,1120)" to="(60,1260)"/>
-    <wire from="(60,240)" to="(60,380)"/>
-    <wire from="(230,1150)" to="(230,1160)"/>
-    <wire from="(160,660)" to="(160,800)"/>
-    <wire from="(230,1630)" to="(230,1650)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(120,460)" to="(120,610)"/>
-    <wire from="(140,480)" to="(140,630)"/>
-    <wire from="(230,270)" to="(230,290)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(100,440)" to="(100,590)"/>
-    <wire from="(330,700)" to="(370,700)"/>
-    <wire from="(100,140)" to="(100,170)"/>
-    <wire from="(200,340)" to="(230,340)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(60,960)" to="(60,1120)"/>
-    <wire from="(60,1600)" to="(60,1760)"/>
-    <wire from="(230,290)" to="(260,290)"/>
-    <wire from="(230,770)" to="(260,770)"/>
-    <wire from="(200,1060)" to="(230,1060)"/>
-    <wire from="(200,1220)" to="(230,1220)"/>
-    <wire from="(200,1540)" to="(230,1540)"/>
-    <wire from="(100,1010)" to="(260,1010)"/>
-    <wire from="(100,1170)" to="(260,1170)"/>
-    <wire from="(350,70)" to="(350,620)"/>
-    <wire from="(140,110)" to="(230,110)"/>
-    <wire from="(140,910)" to="(230,910)"/>
-    <wire from="(140,1710)" to="(230,1710)"/>
-    <wire from="(140,1870)" to="(230,1870)"/>
-    <wire from="(230,1650)" to="(260,1650)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(290,600)" to="(310,600)"/>
-    <wire from="(240,1350)" to="(260,1350)"/>
-    <wire from="(310,1740)" to="(330,1740)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(240,150)" to="(260,150)"/>
-    <wire from="(240,630)" to="(260,630)"/>
-    <wire from="(160,220)" to="(240,220)"/>
-    <wire from="(100,1480)" to="(100,1660)"/>
-    <wire from="(140,1360)" to="(140,1540)"/>
-    <wire from="(80,150)" to="(80,270)"/>
-    <wire from="(100,170)" to="(100,300)"/>
-    <wire from="(120,190)" to="(120,320)"/>
-    <wire from="(60,690)" to="(60,820)"/>
-    <wire from="(200,440)" to="(260,440)"/>
-    <wire from="(200,1480)" to="(260,1480)"/>
-    <wire from="(60,690)" to="(180,690)"/>
-    <wire from="(230,720)" to="(230,730)"/>
-    <wire from="(290,1180)" to="(340,1180)"/>
-    <wire from="(320,650)" to="(370,650)"/>
-    <wire from="(230,1200)" to="(230,1220)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(230,1040)" to="(230,1060)"/>
-    <wire from="(240,1210)" to="(240,1240)"/>
-    <wire from="(140,1360)" to="(180,1360)"/>
-    <wire from="(140,480)" to="(180,480)"/>
-    <wire from="(200,1260)" to="(240,1260)"/>
-    <wire from="(200,1420)" to="(240,1420)"/>
-    <wire from="(220,80)" to="(260,80)"/>
-    <wire from="(200,380)" to="(240,380)"/>
-    <wire from="(200,540)" to="(240,540)"/>
-    <wire from="(290,310)" to="(330,310)"/>
-    <wire from="(220,1680)" to="(260,1680)"/>
-    <wire from="(220,1840)" to="(260,1840)"/>
-    <wire from="(80,410)" to="(180,410)"/>
-    <wire from="(80,570)" to="(180,570)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(80,1290)" to="(180,1290)"/>
-    <wire from="(80,1450)" to="(180,1450)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(200,630)" to="(230,630)"/>
-    <wire from="(230,580)" to="(260,580)"/>
-    <wire from="(100,740)" to="(260,740)"/>
-    <wire from="(230,900)" to="(260,900)"/>
-    <wire from="(290,880)" to="(320,880)"/>
-    <wire from="(230,1300)" to="(260,1300)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(240,1640)" to="(260,1640)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(240,1050)" to="(240,1090)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(240,280)" to="(260,280)"/>
-    <wire from="(120,460)" to="(260,460)"/>
-    <wire from="(310,680)" to="(370,680)"/>
-    <wire from="(310,1760)" to="(310,1830)"/>
-    <wire from="(120,90)" to="(180,90)"/>
-    <wire from="(330,700)" to="(330,1020)"/>
-    <wire from="(120,890)" to="(180,890)"/>
-    <wire from="(120,1690)" to="(180,1690)"/>
-    <wire from="(120,1850)" to="(180,1850)"/>
-    <wire from="(200,890)" to="(260,890)"/>
-    <wire from="(60,820)" to="(180,820)"/>
-    <wire from="(230,850)" to="(230,860)"/>
-    <wire from="(230,770)" to="(230,780)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(100,300)" to="(100,440)"/>
-    <wire from="(120,320)" to="(120,460)"/>
-    <wire from="(60,820)" to="(60,960)"/>
-    <wire from="(140,340)" to="(140,480)"/>
-    <wire from="(140,1220)" to="(140,1360)"/>
-    <wire from="(240,780)" to="(240,800)"/>
-    <wire from="(160,360)" to="(160,510)"/>
-    <wire from="(160,1240)" to="(160,1390)"/>
-    <wire from="(240,1260)" to="(240,1290)"/>
-    <wire from="(200,1390)" to="(240,1390)"/>
-    <wire from="(200,510)" to="(240,510)"/>
-    <wire from="(240,540)" to="(240,570)"/>
-    <wire from="(330,640)" to="(370,640)"/>
-    <wire from="(230,470)" to="(260,470)"/>
-    <wire from="(100,870)" to="(260,870)"/>
-    <wire from="(100,1660)" to="(100,1820)"/>
-    <wire from="(140,1060)" to="(140,1220)"/>
-    <wire from="(140,210)" to="(230,210)"/>
-    <wire from="(290,450)" to="(320,450)"/>
-    <wire from="(230,1510)" to="(260,1510)"/>
-    <wire from="(240,1290)" to="(260,1290)"/>
-    <wire from="(240,1050)" to="(260,1050)"/>
-    <wire from="(240,1210)" to="(260,1210)"/>
-    <wire from="(140,1540)" to="(140,1710)"/>
-    <wire from="(310,1760)" to="(330,1760)"/>
-    <wire from="(240,380)" to="(240,420)"/>
-    <wire from="(240,1420)" to="(240,1460)"/>
-    <wire from="(240,570)" to="(260,570)"/>
-    <wire from="(160,800)" to="(240,800)"/>
-    <wire from="(290,1490)" to="(420,1490)"/>
-    <wire from="(290,70)" to="(350,70)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(340,180)" to="(340,630)"/>
-    <wire from="(200,1660)" to="(260,1660)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(200,300)" to="(260,300)"/>
-    <wire from="(230,900)" to="(230,910)"/>
-    <wire from="(240,910)" to="(240,930)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(120,610)" to="(120,760)"/>
-    <wire from="(140,630)" to="(140,780)"/>
-    <wire from="(80,570)" to="(80,720)"/>
-    <wire from="(100,590)" to="(100,740)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(160,220)" to="(160,310)"/>
-    <wire from="(140,340)" to="(180,340)"/>
-    <wire from="(140,1060)" to="(180,1060)"/>
-    <wire from="(140,1220)" to="(180,1220)"/>
-    <wire from="(140,1540)" to="(180,1540)"/>
-    <wire from="(200,240)" to="(240,240)"/>
-    <wire from="(200,960)" to="(240,960)"/>
-    <wire from="(200,1120)" to="(240,1120)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(80,990)" to="(180,990)"/>
-    <wire from="(80,1150)" to="(180,1150)"/>
-    <wire from="(80,270)" to="(180,270)"/>
-    <wire from="(80,1630)" to="(180,1630)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(200,570)" to="(230,570)"/>
-    <wire from="(80,410)" to="(80,570)"/>
-    <wire from="(230,200)" to="(260,200)"/>
-    <wire from="(230,1000)" to="(260,1000)"/>
-    <wire from="(200,1290)" to="(230,1290)"/>
-    <wire from="(200,1450)" to="(230,1450)"/>
-    <wire from="(80,1290)" to="(80,1450)"/>
-    <wire from="(230,1160)" to="(260,1160)"/>
-    <wire from="(340,710)" to="(370,710)"/>
-    <wire from="(340,630)" to="(370,630)"/>
-    <wire from="(240,780)" to="(260,780)"/>
-    <wire from="(290,750)" to="(310,750)"/>
-    <wire from="(100,1310)" to="(100,1480)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(80,1450)" to="(80,1630)"/>
-    <wire from="(120,320)" to="(260,320)"/>
-    <wire from="(120,1330)" to="(120,1510)"/>
-    <comp lib="1" loc="(200,630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(360,1750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="i"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,1490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(400,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(200,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,880)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,1490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="r"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1750)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="j"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="0" loc="(470,430)" name="Constant">
+      <a name="value" val="0x0"/>
     </comp>
   </circuit>
   <circuit name="IF/ID">
@@ -2675,24 +2021,24 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(310,470)" to="(350,470)"/>
     <wire from="(370,520)" to="(570,520)"/>
     <wire from="(370,420)" to="(570,420)"/>
+    <comp lib="4" loc="(380,370)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
     <comp lib="0" loc="(310,370)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="InstIF"/>
-    </comp>
-    <comp lib="0" loc="(340,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(310,470)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="PCPlus4ID"/>
     </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(340,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(410,470)" name="Pin">
       <a name="facing" val="west"/>
@@ -2701,12 +2047,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="PCPlus4IF"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(160,350)" name="Pin">
       <a name="facing" val="south"/>
@@ -2722,8 +2062,14 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="InstID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(380,370)" name="Register">
+    <comp lib="4" loc="(380,470)" name="Register">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(570,350)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
     </comp>
   </circuit>
   <circuit name="ID/EX">
@@ -3027,131 +2373,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(900,630)" to="(980,630)"/>
     <wire from="(900,390)" to="(980,390)"/>
     <wire from="(1230,410)" to="(1250,410)"/>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(930,600)" name="Pin">
+    <comp lib="0" loc="(590,360)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,670)" name="Register">
       <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
+      <a name="label" val="ShamtEX"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
     </comp>
     <comp lib="0" loc="(1180,470)" name="Pin">
       <a name="label" val="BranchID"/>
-    </comp>
-    <comp lib="0" loc="(590,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
-    </comp>
-    <comp lib="0" loc="(240,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ImmEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(930,660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrcEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="0" loc="(180,830)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
-    </comp>
-    <comp lib="0" loc="(1250,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsEret"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,670)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
     </comp>
     <comp lib="0" loc="(1250,410)" name="Pin">
       <a name="facing" val="west"/>
@@ -3159,16 +2389,14 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
+    <comp lib="4" loc="(1230,710)" name="Register">
+      <a name="width" val="5"/>
     </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(860,600)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="0" loc="(860,360)" name="Pin">
+      <a name="label" val="IsJALID"/>
     </comp>
     <comp lib="0" loc="(930,540)" name="Pin">
       <a name="facing" val="west"/>
@@ -3176,20 +2404,60 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RegWriteEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
+    <comp lib="4" loc="(1230,350)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,420)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(60,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1180,780)" name="Pin">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(860,480)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
+    </comp>
+    <comp lib="0" loc="(1180,650)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
+    </comp>
+    <comp lib="4" loc="(910,660)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1230,530)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(220,670)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(570,560)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(860,420)" name="Pin">
       <a name="label" val="IsShamtID"/>
     </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(1250,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BranchEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(180,830)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="4" loc="(910,540)" name="Register">
       <a name="width" val="1"/>
@@ -3200,79 +2468,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemReadEX"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="4" loc="(1230,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(910,780)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,720)" name="Pin">
+      <a name="label" val="IsExceptionID"/>
+    </comp>
+    <comp lib="0" loc="(170,670)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="CP0Dout"/>
+    </comp>
+    <comp lib="0" loc="(520,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ShamtID"/>
+    </comp>
+    <comp lib="4" loc="(1230,780)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="0" loc="(240,460)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
       <a name="label" val="R1EX"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(240,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R2EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
-    </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1180,780)" name="Pin">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(240,670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="PCPlusEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(1240,650)" name="Pin">
       <a name="facing" val="west"/>
@@ -3287,49 +2510,117 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemtoRegEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(1230,780)" name="Register">
+    <comp lib="4" loc="(1230,650)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="4" loc="(910,720)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="4" loc="(1230,590)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(1180,530)" name="Pin">
+      <a name="label" val="IsJRID"/>
     </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
+    <comp lib="0" loc="(240,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
+      <a name="label" val="ImmEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(920,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(860,720)" name="Pin">
-      <a name="label" val="IsExceptionID"/>
+    <comp lib="4" loc="(220,560)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(520,560)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="PCPlus4ID"/>
     </comp>
+    <comp lib="0" loc="(100,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(1230,590)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(170,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ImmID"/>
+    </comp>
+    <comp lib="0" loc="(1240,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,600)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeqEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(860,540)" name="Pin">
+      <a name="label" val="RegWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1180,350)" name="Pin">
+      <a name="label" val="MemWriteID"/>
+    </comp>
+    <comp lib="0" loc="(170,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(1180,590)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="0" loc="(1180,710)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#ID"/>
+    </comp>
     <comp lib="4" loc="(1230,410)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
+    <comp lib="4" loc="(220,460)" name="Register">
+      <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
+    <comp lib="4" loc="(910,480)" name="Register">
+      <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
+    <comp lib="0" loc="(1250,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(590,560)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
+      <a name="label" val="PCPlusEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,660)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrcEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,780)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(1250,530)" name="Pin">
@@ -3338,7 +2629,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsJREX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
+    <comp lib="0" loc="(170,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2ID"/>
+    </comp>
+    <comp lib="0" loc="(240,670)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,600)" name="Register">
       <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(930,420)" name="Pin">
@@ -3346,6 +2649,49 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="output" val="true"/>
       <a name="label" val="IsShamtEX"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(570,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(570,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(590,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,660)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
+    </comp>
+    <comp lib="0" loc="(1250,590)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1180,410)" name="Pin">
+      <a name="label" val="JumpID"/>
+    </comp>
+    <comp lib="0" loc="(520,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="JumpAddr"/>
+    </comp>
+    <comp lib="0" loc="(240,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R2EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,780)" name="Pin">
+      <a name="label" val="MemReadID"/>
     </comp>
   </circuit>
   <circuit name="EX/MEM">
@@ -3456,12 +2802,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,160)" to="(860,190)"/>
     <wire from="(850,470)" to="(850,500)"/>
     <wire from="(560,70)" to="(980,70)"/>
-    <wire from="(470,380)" to="(560,380)"/>
-    <wire from="(870,240)" to="(890,240)"/>
-    <wire from="(470,260)" to="(560,260)"/>
     <wire from="(470,500)" to="(560,500)"/>
     <wire from="(980,390)" to="(980,500)"/>
     <wire from="(470,140)" to="(560,140)"/>
+    <wire from="(470,380)" to="(560,380)"/>
+    <wire from="(870,240)" to="(890,240)"/>
+    <wire from="(470,260)" to="(560,260)"/>
     <wire from="(640,290)" to="(850,290)"/>
     <wire from="(300,80)" to="(640,80)"/>
     <wire from="(980,190)" to="(980,290)"/>
@@ -3511,8 +2857,165 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(430,530)" to="(450,530)"/>
     <wire from="(430,410)" to="(450,410)"/>
     <wire from="(830,460)" to="(840,460)"/>
+    <comp lib="0" loc="(500,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(870,450)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(890,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(890,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,290)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,410)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(430,110)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(440,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(430,350)" name="Pin">
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="4" loc="(480,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,470)" name="Pin">
+      <a name="label" val="IsSyscallEX"/>
+    </comp>
+    <comp lib="0" loc="(500,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(820,240)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataEX"/>
+    </comp>
+    <comp lib="4" loc="(480,530)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(820,450)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+    </comp>
+    <comp lib="0" loc="(430,290)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
+    </comp>
+    <comp lib="0" loc="(500,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(820,340)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrEX"/>
+    </comp>
+    <comp lib="0" loc="(500,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="4" loc="(480,170)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(870,340)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(500,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(890,450)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(870,140)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(870,240)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(300,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(480,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(480,110)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,230)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(500,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(350,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(430,530)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(820,140)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="0" loc="(430,170)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
     </comp>
     <comp lib="0" loc="(890,240)" name="Pin">
       <a name="facing" val="west"/>
@@ -3526,163 +3029,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="output" val="true"/>
       <a name="label" val="MemReadMEM"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="0" loc="(350,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(870,450)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(500,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(500,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,530)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,450)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="0" loc="(500,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(890,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(870,340)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,530)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
     </comp>
   </circuit>
   <circuit name="MEM/WB">
@@ -3824,100 +3170,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(250,290)" to="(390,290)"/>
     <wire from="(290,200)" to="(490,200)"/>
     <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="4" loc="(770,290)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(720,390)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
-    </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
-    </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(370,720)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="0" loc="(790,610)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="4" loc="(770,610)" name="Register">
       <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(790,290)" name="Pin">
       <a name="facing" val="west"/>
@@ -3926,8 +3180,81 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUResultWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(410,380)" name="Register">
+    <comp lib="0" loc="(360,440)" name="Pin">
+      <a name="label" val="IsExceptionMEM"/>
+    </comp>
+    <comp lib="0" loc="(370,720)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(250,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(410,500)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(720,390)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataMEM"/>
+    </comp>
+    <comp lib="4" loc="(410,440)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(360,560)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="0" loc="(430,380)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(720,610)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="4" loc="(770,290)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(360,380)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,260)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,500)" name="Pin">
+      <a name="label" val="IsSyscallMEM"/>
+    </comp>
+    <comp lib="0" loc="(360,260)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(770,500)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(790,500)" name="Pin">
       <a name="facing" val="west"/>
@@ -3942,36 +3269,55 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="clr"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
+    <comp lib="4" loc="(770,390)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(720,500)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(790,390)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
+    <comp lib="4" loc="(410,320)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(430,260)" name="Pin">
+    <comp lib="4" loc="(410,260)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(720,290)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+    </comp>
+    <comp lib="4" loc="(410,380)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,560)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="IsJALWB"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,380)" name="Pin">
+    <comp lib="0" loc="(430,320)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="RegWriteWB"/>
+      <a name="label" val="MemtoRegWB"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="4" loc="(410,560)" name="Register">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
+    <comp lib="0" loc="(790,610)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(720,610)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
+      <a name="label" val="JumpAddrWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="Regfile_Wrapper">
@@ -4018,24 +3364,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(240,190)" to="(280,190)"/>
     <wire from="(240,230)" to="(280,230)"/>
     <wire from="(320,90)" to="(320,180)"/>
-    <comp lib="0" loc="(350,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(240,190)" name="Pin">
+    <comp lib="0" loc="(240,210)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="R1#"/>
+      <a name="label" val="R2#"/>
     </comp>
-    <comp lib="0" loc="(400,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(320,290)" name="Pin">
+      <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="R2"/>
-      <a name="labelloc" val="east"/>
+      <a name="label" val="WE"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(400,80)" name="Pin">
       <a name="facing" val="south"/>
@@ -4045,13 +3383,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="a0"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="8" loc="(370,210)" name="main"/>
-    <comp lib="0" loc="(300,350)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
-    </comp>
     <comp lib="0" loc="(400,140)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -4059,6 +3390,32 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="R1"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(300,350)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
+    <comp lib="0" loc="(350,290)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="8" loc="(370,210)" name="main"/>
+    <comp lib="0" loc="(400,260)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,190)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1#"/>
     </comp>
     <comp lib="0" loc="(240,230)" name="Pin">
       <a name="width" val="5"/>
@@ -4072,17 +3429,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="v0"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2#"/>
-    </comp>
-    <comp lib="0" loc="(320,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WE"/>
-      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="ALU_Wrapper">
@@ -4118,17 +3464,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(670,430)" to="(750,430)"/>
     <wire from="(630,490)" to="(630,540)"/>
     <wire from="(650,480)" to="(650,500)"/>
+    <comp lib="7" loc="(640,440)" name="ALU"/>
     <comp lib="0" loc="(560,480)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="Y"/>
     </comp>
-    <comp lib="0" loc="(560,400)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="7" loc="(640,440)" name="ALU"/>
     <comp lib="0" loc="(680,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -4141,6 +3482,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="32"/>
       <a name="label" val="Result"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(560,400)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="X"/>
     </comp>
     <comp lib="0" loc="(630,540)" name="Pin">
       <a name="facing" val="north"/>
@@ -4177,29 +3523,24 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(410,310)" to="(410,330)"/>
     <wire from="(410,330)" to="(410,350)"/>
     <wire from="(560,280)" to="(560,310)"/>
-    <comp lib="0" loc="(560,280)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(380,330)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Input"/>
+    <comp lib="0" loc="(480,350)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
     </comp>
     <comp lib="2" loc="(580,330)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
+    <comp lib="0" loc="(380,330)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Input"/>
+    </comp>
     <comp lib="0" loc="(480,310)" name="Bit Extender">
       <a name="in_width" val="16"/>
       <a name="out_width" val="32"/>
       <a name="type" val="sign"/>
-    </comp>
-    <comp lib="0" loc="(480,350)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
     </comp>
     <comp lib="0" loc="(630,330)" name="Pin">
       <a name="facing" val="west"/>
@@ -4208,6 +3549,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="Output"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(560,280)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ZeroExtend"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">
@@ -4326,109 +3672,29 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,600)" to="(1000,600)"/>
     <wire from="(900,550)" to="(910,550)"/>
     <wire from="(900,530)" to="(910,530)"/>
-    <comp lib="1" loc="(1290,430)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(150,130)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(980,350)" name="Constant">
+    <comp lib="0" loc="(980,560)" name="Constant">
       <a name="width" val="2"/>
-    </comp>
-    <comp lib="0" loc="(380,200)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
     </comp>
     <comp lib="0" loc="(900,320)" name="Constant">
       <a name="width" val="2"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(150,170)" name="Tunnel">
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="2" loc="(940,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(130,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="6" loc="(917,390)" name="Text">
-      <a name="text" val="Rs Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(160,250)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
+    <comp lib="1" loc="(1540,150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate0" val="true"/>
     </comp>
     <comp lib="6" loc="(1204,445)" name="Text">
       <a name="text" val="hasHazard"/>
     </comp>
-    <comp lib="0" loc="(1350,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1420,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(130,170)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteMEM"/>
+    <comp loc="(800,570)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(840,220)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadWriteMEM"/>
     </comp>
     <comp lib="0" loc="(130,130)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(740,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(900,340)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(150,210)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(570,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(1570,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(140,250)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="2" loc="(1020,550)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1550,150)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(940,330)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(1040,550)" name="Pin">
       <a name="facing" val="west"/>
@@ -4437,9 +3703,43 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RtOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(570,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp loc="(800,270)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(380,200)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="2" loc="(1020,550)" name="Multiplexer">
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(640,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(130,210)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RS"/>
+    </comp>
     <comp lib="1" loc="(1160,450)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(909,590)" name="Text">
+      <a name="text" val="Rt Hazard in EX"/>
+    </comp>
+    <comp lib="0" loc="(170,50)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(140,250)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="0" loc="(1540,510)" name="Pin">
       <a name="facing" val="west"/>
@@ -4448,45 +3748,48 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="BubbleNum"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="2" loc="(1020,340)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(922,290)" name="Text">
-      <a name="text" val="Rs Hazard in MEM"/>
-    </comp>
-    <comp lib="0" loc="(360,200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp loc="(800,570)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(1460,550)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(790,360)" name="Tunnel">
+    <comp lib="0" loc="(790,540)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="ReadRs"/>
+      <a name="label" val="ReadWriteEX"/>
     </comp>
-    <comp lib="0" loc="(360,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteEX"/>
+    <comp lib="0" loc="(160,250)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="0" loc="(820,250)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="0" loc="(900,550)" name="Constant">
+    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1350,180)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="0" loc="(1570,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(790,460)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(1550,150)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(900,530)" name="Constant">
       <a name="width" val="2"/>
-      <a name="value" val="0x2"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="1" loc="(1550,340)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(160,290)" name="Tunnel">
+    <comp lib="0" loc="(740,250)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="0" loc="(1040,340)" name="Pin">
       <a name="facing" val="west"/>
@@ -4495,35 +3798,68 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RsOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp loc="(800,470)" name="Hazard_Detector"/>
-    <comp lib="4" loc="(1480,510)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(790,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
     <comp lib="6" loc="(912,490)" name="Text">
       <a name="text" val="Rt Hazard in MEM"/>
     </comp>
-    <comp lib="0" loc="(130,50)" name="Pin">
+    <comp lib="0" loc="(130,290)" name="Pin">
+      <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
+      <a name="label" val="WriteReg#EX"/>
     </comp>
-    <comp lib="0" loc="(1350,180)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
+    <comp lib="2" loc="(940,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="6" loc="(909,590)" name="Text">
-      <a name="text" val="Rt Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(170,50)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(640,250)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(160,290)" name="Tunnel">
       <a name="width" val="5"/>
       <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(900,550)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(530,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(130,170)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="2" loc="(1020,340)" name="Multiplexer">
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1350,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(790,360)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(1210,410)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="IsLW"/>
+    </comp>
+    <comp lib="2" loc="(940,330)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(980,350)" name="Constant">
+      <a name="width" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1420,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="StallIF"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(1420,450)" name="Pin">
       <a name="facing" val="west"/>
@@ -4531,63 +3867,60 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="StallID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(790,540)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteEX"/>
-    </comp>
-    <comp loc="(800,370)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(790,460)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(360,200)" name="Pin">
+      <a name="tristate" val="false"/>
       <a name="label" val="ReadRt"/>
     </comp>
-    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1390,350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(130,290)" name="Pin">
+    <comp lib="0" loc="(160,330)" name="Tunnel">
       <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
+      <a name="label" val="RT"/>
     </comp>
-    <comp lib="0" loc="(380,240)" name="Tunnel">
-      <a name="label" val="ReadWriteEX"/>
+    <comp lib="0" loc="(900,340)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x2"/>
     </comp>
     <comp lib="0" loc="(790,340)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ReadWriteEX"/>
     </comp>
-    <comp lib="0" loc="(530,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
+    <comp lib="6" loc="(917,390)" name="Text">
+      <a name="text" val="Rs Hazard in EX"/>
     </comp>
-    <comp lib="0" loc="(980,560)" name="Constant">
-      <a name="width" val="2"/>
+    <comp lib="0" loc="(1460,550)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(840,220)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(790,440)" name="Tunnel">
+    <comp loc="(800,470)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(1390,350)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteMEM"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1210,410)" name="Pin">
+    <comp lib="1" loc="(1290,430)" name="AND Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(360,240)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="IsLW"/>
+      <a name="label" val="RegWriteEX"/>
     </comp>
-    <comp lib="1" loc="(1540,150)" name="AND Gate">
+    <comp lib="1" loc="(1550,340)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-      <a name="negate0" val="true"/>
     </comp>
-    <comp loc="(800,270)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(900,530)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(150,130)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(790,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(150,210)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp loc="(800,370)" name="Hazard_Detector"/>
+    <comp lib="4" loc="(1480,510)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
     <comp lib="0" loc="(130,330)" name="Pin">
       <a name="width" val="5"/>
@@ -4595,9 +3928,22 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RT"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(160,330)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
+    <comp lib="0" loc="(790,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(130,50)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(150,170)" name="Tunnel">
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="6" loc="(922,290)" name="Text">
+      <a name="text" val="Rs Hazard in MEM"/>
+    </comp>
+    <comp lib="0" loc="(380,240)" name="Tunnel">
+      <a name="label" val="ReadWriteEX"/>
     </comp>
   </circuit>
   <circuit name="RegisterRead_Detector">
@@ -5596,39 +4942,484 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(360,3430)" to="(360,3470)"/>
     <wire from="(220,3150)" to="(300,3150)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,250)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,2720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+    <comp lib="1" loc="(510,2310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,250)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,210)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(690,4550)" name="OR Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,4550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(320,1180)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+    <comp lib="1" loc="(410,690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,4690)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="0" loc="(40,580)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,1580)" name="NOT Gate">
@@ -5638,531 +5429,61 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="10"/>
     </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
-    </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="1" loc="(600,2450)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,4550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,830)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="9"/>
-    </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,430)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(690,4550)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,1490)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
       <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(320,370)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
       <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,530)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,580)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(600,2320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3640)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(40,130)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="op2"/>
       <a name="labelloc" val="north"/>
     </comp>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(320,2880)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+    <comp lib="1" loc="(520,4830)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,550)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(410,4260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="1" loc="(520,4510)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(730,1960)" name="Pin">
       <a name="facing" val="west"/>
@@ -6170,66 +5491,91 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ReadRs"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,1290)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+    <comp lib="1" loc="(510,2460)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(520,4790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,4750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(510,2390)" name="NOT Gate">
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,950)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,530)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
+      <a name="label" val="Funct4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(520,4790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(600,2320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
   </circuit>
   <circuit name="Hazard_Detector">
@@ -6264,26 +5610,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,300)" to="(610,300)"/>
     <wire from="(590,290)" to="(600,290)"/>
     <wire from="(600,340)" to="(610,340)"/>
-    <comp lib="0" loc="(400,340)" name="Pin">
+    <comp lib="3" loc="(490,330)" name="Comparator">
       <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg"/>
     </comp>
     <comp lib="1" loc="(530,330)" name="NOT Gate"/>
-    <comp lib="3" loc="(490,370)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(590,290)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Read"/>
-    </comp>
     <comp lib="0" loc="(700,320)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="Hazard"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="3" loc="(490,330)" name="Comparator">
+    <comp lib="0" loc="(590,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="3" loc="(490,370)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(430,320)" name="Constant">
@@ -6295,12 +5636,17 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="Register#"/>
     </comp>
+    <comp lib="0" loc="(400,340)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg"/>
+    </comp>
+    <comp lib="0" loc="(590,290)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Read"/>
+    </comp>
     <comp lib="1" loc="(660,320)" name="AND Gate">
       <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="0" loc="(590,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWrite"/>
     </comp>
   </circuit>
   <circuit name="CP0">
@@ -6496,6 +5842,120 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(850,680)" to="(850,730)"/>
     <wire from="(590,240)" to="(590,1190)"/>
     <wire from="(180,1050)" to="(180,1110)"/>
+    <comp lib="0" loc="(300,360)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(654,60)" name="Text">
+      <a name="text" val="Input &amp; Output"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="4" loc="(450,880)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(470,770)" name="Tunnel">
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(290,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="4" loc="(990,490)" name="Register">
+      <a name="width" val="32"/>
+      <a name="trigger" val="low"/>
+      <a name="label" val="EPC"/>
+    </comp>
+    <comp lib="2" loc="(770,490)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(880,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(280,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(150,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(400,390)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="0" loc="(750,410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="6" loc="(327,306)" name="Text">
+      <a name="text" val="Signal Decoding"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(220,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(953,342)" name="Text">
+      <a name="text" val="Registers"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(260,160)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExpBlock"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(340,850)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+    </comp>
+    <comp lib="0" loc="(410,460)" name="Tunnel">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(500,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
     <comp lib="0" loc="(1030,790)" name="Splitter">
       <a name="facing" val="south"/>
       <a name="fanout" val="1"/>
@@ -6533,133 +5993,48 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="1" loc="(790,1010)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(880,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(220,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(500,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
+    <comp lib="0" loc="(760,650)" name="Constant"/>
+    <comp lib="2" loc="(280,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(710,580)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ExRegWrite"/>
     </comp>
-    <comp lib="0" loc="(400,390)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(970,990)" name="Tunnel">
+    <comp lib="0" loc="(270,960)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(290,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(240,410)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Inst"/>
-    </comp>
-    <comp lib="2" loc="(770,650)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1170,950)" name="Tunnel">
-      <a name="label" val="BlockSrc1"/>
-    </comp>
-    <comp lib="0" loc="(740,1010)" name="Constant">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1150,110)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="6" loc="(306,664)" name="Text">
-      <a name="text" val="Exception Signals"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="2" loc="(280,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(940,520)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(870,180)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(740,1070)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x3"/>
-    </comp>
-    <comp lib="6" loc="(654,60)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="6" loc="(953,342)" name="Text">
-      <a name="text" val="Registers"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(550,160)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="HasExp"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(260,160)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
       <a name="label" val="ExpBlock"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(760,650)" name="Constant"/>
-    <comp lib="1" loc="(750,460)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(750,410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(260,860)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="0" loc="(1180,790)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Dout"/>
     </comp>
     <comp lib="2" loc="(210,1070)" name="Demultiplexer">
       <a name="facing" val="north"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1150,160)" name="Tunnel">
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="1" loc="(770,570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="0" loc="(780,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="4" loc="(1000,1070)" name="Register">
+    <comp lib="0" loc="(710,780)" name="Pin">
       <a name="width" val="32"/>
-      <a name="label" val="Cause"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
+    <comp lib="0" loc="(870,180)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(1130,840)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="0" loc="(430,920)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(790,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="4" loc="(990,950)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Block"/>
     </comp>
     <comp lib="1" loc="(390,460)" name="AND Gate">
       <a name="size" val="30"/>
@@ -6669,187 +6044,52 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="negate4" val="true"/>
       <a name="negate5" val="true"/>
     </comp>
-    <comp lib="0" loc="(490,110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(400,360)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(140,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(220,1030)" name="Constant">
+    <comp lib="1" loc="(750,460)" name="NOT Gate">
       <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="1" loc="(890,670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(810,100)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(740,1120)" name="Constant">
+    <comp lib="1" loc="(790,1070)" name="Controlled Buffer">
       <a name="width" val="32"/>
-      <a name="value" val="0x7"/>
     </comp>
-    <comp lib="0" loc="(870,100)" name="Tunnel">
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(710,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(1170,970)" name="Tunnel">
-      <a name="label" val="BlockSrc2"/>
-    </comp>
-    <comp lib="0" loc="(470,770)" name="Tunnel">
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(410,460)" name="Tunnel">
-      <a name="label" val="IsEret"/>
+    <comp lib="4" loc="(1000,1070)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Cause"/>
     </comp>
     <comp lib="4" loc="(990,780)" name="Register">
       <a name="width" val="32"/>
       <a name="label" val="Status"/>
     </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(980,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(260,860)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="label" val="ExpClick"/>
     </comp>
-    <comp lib="1" loc="(890,720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(260,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ExRegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(790,1120)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="1" loc="(490,900)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(710,780)" name="Pin">
+    <comp lib="0" loc="(240,410)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
+      <a name="label" val="Inst"/>
     </comp>
-    <comp lib="0" loc="(780,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(790,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="1" loc="(260,890)" name="AND Gate">
-      <a name="facing" val="north"/>
+    <comp lib="1" loc="(770,570)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
       <a name="negate1" val="true"/>
     </comp>
-    <comp lib="4" loc="(990,950)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Block"/>
+    <comp lib="0" loc="(390,760)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="2" loc="(1150,790)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(150,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(790,1070)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(290,390)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(327,306)" name="Text">
-      <a name="text" val="Signal Decoding"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="2" loc="(140,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(110,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc0"/>
-    </comp>
-    <comp lib="0" loc="(710,480)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCin"/>
-    </comp>
-    <comp lib="0" loc="(270,960)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="2" loc="(770,490)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(1150,160)" name="Tunnel">
+      <a name="label" val="enable"/>
     </comp>
     <comp lib="0" loc="(810,140)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ExpSrc1"/>
     </comp>
-    <comp lib="0" loc="(1030,810)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
+    <comp lib="2" loc="(770,650)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(390,760)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
+    <comp lib="1" loc="(790,1120)" name="Controlled Buffer">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(1180,490)" name="Pin">
       <a name="facing" val="west"/>
@@ -6858,24 +6098,58 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="PCout"/>
     </comp>
-    <comp lib="0" loc="(970,530)" name="Tunnel">
+    <comp lib="0" loc="(780,1130)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="4" loc="(340,850)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
+    <comp lib="0" loc="(1030,810)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
     </comp>
-    <comp lib="0" loc="(1170,930)" name="Tunnel">
-      <a name="label" val="BlockSrc0"/>
+    <comp lib="1" loc="(370,360)" name="NOT Gate"/>
+    <comp lib="0" loc="(230,110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExRegWrite"/>
     </comp>
-    <comp lib="0" loc="(870,140)" name="Tunnel">
+    <comp lib="0" loc="(740,1120)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x7"/>
+    </comp>
+    <comp lib="1" loc="(940,520)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(220,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(1180,790)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Dout"/>
+    </comp>
+    <comp lib="0" loc="(780,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="ExpSrc1"/>
     </comp>
-    <comp lib="0" loc="(1090,160)" name="Pin">
+    <comp lib="0" loc="(260,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExRegWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1150,110)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(890,670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(810,180)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="enable"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
     <comp lib="0" loc="(180,1110)" name="Tunnel">
       <a name="facing" val="north"/>
@@ -6918,28 +6192,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1090,110)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(200,960)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="4" loc="(990,490)" name="Register">
-      <a name="width" val="32"/>
-      <a name="trigger" val="low"/>
-      <a name="label" val="EPC"/>
-    </comp>
-    <comp lib="0" loc="(210,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(780,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
     <comp lib="0" loc="(1130,950)" name="Splitter">
       <a name="fanout" val="3"/>
       <a name="incoming" val="32"/>
@@ -6974,34 +6226,121 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(430,920)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="1" loc="(370,360)" name="NOT Gate"/>
-    <comp lib="0" loc="(810,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="4" loc="(450,880)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(230,110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="1" loc="(440,770)" name="AND Gate">
+    <comp lib="1" loc="(890,610)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(490,110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(1170,950)" name="Tunnel">
+      <a name="label" val="BlockSrc1"/>
+    </comp>
+    <comp lib="0" loc="(780,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(970,990)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(250,1110)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="BlockSrc2"/>
     </comp>
-    <comp lib="0" loc="(300,360)" name="Splitter">
+    <comp lib="0" loc="(870,100)" name="Tunnel">
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(140,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(710,480)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCin"/>
+    </comp>
+    <comp lib="1" loc="(890,720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(400,360)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="2" loc="(140,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(810,100)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="1" loc="(490,900)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="1" loc="(440,770)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(550,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(710,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(110,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="BlockSrc0"/>
+    </comp>
+    <comp lib="0" loc="(1090,160)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(1170,970)" name="Tunnel">
+      <a name="label" val="BlockSrc2"/>
+    </comp>
+    <comp lib="0" loc="(210,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="1" loc="(200,960)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="2" loc="(1150,790)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1170,930)" name="Tunnel">
+      <a name="label" val="BlockSrc0"/>
+    </comp>
+    <comp lib="1" loc="(790,1010)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(740,1010)" name="Constant">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(870,140)" name="Tunnel">
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="1" loc="(260,890)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(980,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="0" loc="(290,390)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -7016,8 +6355,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit8" val="none"/>
       <a name="bit9" val="none"/>
       <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
       <a name="bit13" val="none"/>
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
@@ -7028,7 +6367,7 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit20" val="none"/>
       <a name="bit21" val="none"/>
       <a name="bit22" val="none"/>
-      <a name="bit23" val="0"/>
+      <a name="bit23" val="none"/>
       <a name="bit24" val="none"/>
       <a name="bit25" val="none"/>
       <a name="bit26" val="none"/>
@@ -7038,24 +6377,31 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1130,840)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="1" loc="(890,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(280,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(550,110)" name="Pin">
+    <comp lib="0" loc="(550,160)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="IsEret"/>
+      <a name="label" val="HasExp"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(306,664)" name="Text">
+      <a name="text" val="Exception Signals"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(740,1070)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x3"/>
+    </comp>
+    <comp lib="0" loc="(1090,110)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(970,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
   </circuit>
   <circuit name="RegWrite_Decider">
@@ -7081,18 +6427,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="IsException"/>
     </comp>
-    <comp lib="0" loc="(460,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FinalRegWrite"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="2" loc="(450,250)" name="Multiplexer">
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(390,240)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWrite"/>
     </comp>
-    <comp lib="2" loc="(450,250)" name="Multiplexer">
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(460,250)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FinalRegWrite"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(390,260)" name="Pin">
       <a name="tristate" val="false"/>

--- a/src/pipeline_cpu_bubbling.circ
+++ b/src/pipeline_cpu_bubbling.circ
@@ -98,6 +98,7 @@
   <lib desc="file#common/alu.circ" name="7"/>
   <lib desc="file#common/regfile.circ" name="8"/>
   <lib desc="file#common/control.circ" name="9"/>
+  <lib desc="file#common/statistics.circ" name="10"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -448,44 +449,73 @@
     <wire from="(530,360)" to="(540,360)"/>
     <wire from="(560,870)" to="(570,870)"/>
     <wire from="(350,410)" to="(420,410)"/>
-    <comp lib="0" loc="(400,270)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-      <a name="bit16" val="4"/>
-      <a name="bit17" val="4"/>
-      <a name="bit18" val="4"/>
-      <a name="bit19" val="4"/>
-      <a name="bit20" val="5"/>
-      <a name="bit21" val="5"/>
-      <a name="bit22" val="5"/>
-      <a name="bit23" val="5"/>
-      <a name="bit24" val="6"/>
-      <a name="bit25" val="6"/>
-      <a name="bit26" val="6"/>
-      <a name="bit27" val="6"/>
-      <a name="bit28" val="7"/>
-      <a name="bit29" val="7"/>
-      <a name="bit30" val="7"/>
-      <a name="bit31" val="7"/>
+    <comp lib="2" loc="(2060,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(670,500)" name="Splitter">
+    <comp lib="5" loc="(460,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp loc="(780,820)" name="Immediate_Extend"/>
+    <comp lib="0" loc="(1750,1050)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(2080,450)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(2030,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="6" loc="(512,867)" name="Text">
+      <a name="text" val="PCPlus4IF"/>
+    </comp>
+    <comp lib="0" loc="(1410,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(990,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="2" loc="(910,690)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(150,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(860,700)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="2" loc="(1290,610)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(800,810)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="3" loc="(470,620)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(220,700)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(670,540)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -505,90 +535,11 @@
       <a name="bit13" val="none"/>
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(693,306)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(1510,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="1" loc="(580,1030)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(970,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="0" loc="(380,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="3" loc="(1440,920)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(1840,685)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="6" loc="(1035,755)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(780,460)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="2" loc="(1350,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(2010,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(670,320)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
       <a name="bit21" val="none"/>
       <a name="bit22" val="none"/>
       <a name="bit23" val="none"/>
@@ -601,72 +552,13 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="1" loc="(1450,330)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="6" loc="(1035,755)" name="Text">
+      <a name="text" val="JumpAddr"/>
     </comp>
-    <comp lib="0" loc="(490,670)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp loc="(1410,580)" name="ALU_Wrapper"/>
-    <comp lib="0" loc="(300,580)" name="Tunnel">
+    <comp loc="(2060,450)" name="Syscall_Decoder"/>
+    <comp lib="0" loc="(1540,920)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(590,120)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(1370,410)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="2" loc="(90,530)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1010,470)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="2" loc="(830,680)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1410,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(1520,920)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(2030,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="0" loc="(800,810)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="4" loc="(320,550)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="0" loc="(200,730)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(200,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(410,630)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
+      <a name="value" val="0x0"/>
     </comp>
     <comp lib="0" loc="(540,550)" name="Splitter">
       <a name="facing" val="north"/>
@@ -706,63 +598,126 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(1780,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="0" loc="(310,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="2" loc="(910,690)" name="Multiplexer">
+    <comp lib="2" loc="(2010,570)" name="Multiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
+      <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp loc="(510,350)" name="Statistics"/>
-    <comp lib="6" loc="(2028,981)" name="Text">
-      <a name="text" val="WB_DATA"/>
-    </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="label" val="Halt"/>
+    <comp lib="0" loc="(400,270)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+      <a name="bit11" val="2"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+      <a name="bit14" val="3"/>
+      <a name="bit15" val="3"/>
+      <a name="bit16" val="4"/>
+      <a name="bit17" val="4"/>
+      <a name="bit18" val="4"/>
+      <a name="bit19" val="4"/>
+      <a name="bit20" val="5"/>
+      <a name="bit21" val="5"/>
+      <a name="bit22" val="5"/>
+      <a name="bit23" val="5"/>
+      <a name="bit24" val="6"/>
+      <a name="bit25" val="6"/>
+      <a name="bit26" val="6"/>
+      <a name="bit27" val="6"/>
+      <a name="bit28" val="7"/>
+      <a name="bit29" val="7"/>
+      <a name="bit30" val="7"/>
+      <a name="bit31" val="7"/>
     </comp>
     <comp lib="5" loc="(420,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(670,760)" name="Splitter">
+    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(660,870)" name="Splitter">
+      <a name="facing" val="north"/>
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
       <a name="bit26" val="none"/>
       <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
     </comp>
+    <comp lib="0" loc="(420,720)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Bubble Number"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(1480,270)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1310,940)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="6" loc="(1035,833)" name="Text">
+      <a name="text" val="Immediate"/>
+    </comp>
+    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp loc="(1410,580)" name="ALU_Wrapper"/>
     <comp lib="0" loc="(670,840)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -799,71 +754,50 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="2" loc="(2060,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(530,360)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
+    <comp lib="0" loc="(670,240)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
     </comp>
-    <comp lib="6" loc="(414,100)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="0" loc="(2030,500)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp loc="(190,1060)" name="Hazard Unit"/>
+    <comp lib="3" loc="(1440,920)" name="Adder">
       <a name="width" val="32"/>
-      <a name="label" val="a0"/>
     </comp>
-    <comp lib="0" loc="(780,440)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="6" loc="(1005,925)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp lib="0" loc="(1900,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(2130,500)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="6" loc="(690,678)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="2" loc="(1290,610)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(230,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(270,700)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(810,750)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="9" loc="(720,140)" name="Control"/>
-    <comp loc="(1510,140)" name="EX/MEM"/>
-    <comp lib="6" loc="(997,944)" name="Text">
-      <a name="text" val="Jump Addr"/>
+    <comp lib="0" loc="(490,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="4" loc="(520,550)" name="ROM">
       <a name="addrWidth" val="10"/>
@@ -913,14 +847,103 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="6" loc="(1035,833)" name="Text">
-      <a name="text" val="Immediate"/>
+    <comp lib="0" loc="(1900,910)" name="Constant">
+      <a name="facing" val="north"/>
     </comp>
-    <comp loc="(950,480)" name="Regfile_Wrapper"/>
-    <comp lib="6" loc="(1044,617)" name="Text">
-      <a name="text" val="Shamt"/>
+    <comp loc="(1510,140)" name="EX/MEM"/>
+    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(670,240)" name="Splitter">
+    <comp lib="1" loc="(580,1030)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2030,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(670,320)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(300,580)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(670,760)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(692,230)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp lib="0" loc="(670,500)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -945,48 +968,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit18" val="none"/>
       <a name="bit19" val="none"/>
       <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(670,620)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
       <a name="bit26" val="none"/>
       <a name="bit27" val="none"/>
       <a name="bit28" val="none"/>
@@ -997,169 +983,64 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="6" loc="(1953,236)" name="Text">
       <a name="text" val="Ignored"/>
     </comp>
-    <comp lib="0" loc="(860,700)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
+    <comp lib="6" loc="(1005,925)" name="Text">
+      <a name="text" val="JR Addr"/>
     </comp>
-    <comp lib="0" loc="(810,710)" name="Tunnel">
+    <comp lib="0" loc="(1090,910)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="label" val="RegDstID"/>
     </comp>
-    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
+    <comp lib="0" loc="(230,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(850,760)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="1"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="1"/>
-      <a name="bit9" val="1"/>
-      <a name="bit10" val="1"/>
-      <a name="bit11" val="1"/>
-      <a name="bit12" val="1"/>
-      <a name="bit13" val="1"/>
-      <a name="bit14" val="1"/>
-      <a name="bit15" val="1"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="2"/>
-      <a name="bit29" val="2"/>
-      <a name="bit30" val="2"/>
-      <a name="bit31" val="2"/>
-    </comp>
-    <comp lib="4" loc="(440,300)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp loc="(2060,450)" name="Syscall_Decoder"/>
     <comp lib="6" loc="(1973,684)" name="Text">
       <a name="text" val="WriteReg#WB"/>
     </comp>
-    <comp lib="0" loc="(1020,620)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(480,730)" name="Clock">
+    <comp lib="0" loc="(450,450)" name="Probe">
       <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
     </comp>
-    <comp loc="(190,1060)" name="Hazard Unit"/>
-    <comp lib="0" loc="(2080,450)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="6" loc="(512,867)" name="Text">
-      <a name="text" val="PCPlus4IF"/>
-    </comp>
-    <comp lib="6" loc="(689,491)" name="Text">
-      <a name="text" val="RS"/>
-    </comp>
-    <comp lib="6" loc="(692,230)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="4" loc="(370,320)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="6" loc="(687,529)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(1670,580)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="1" loc="(1480,270)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(500,730)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
-    <comp lib="0" loc="(1750,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(420,720)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Bubble Number"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp loc="(780,820)" name="Immediate_Extend"/>
-    <comp lib="4" loc="(220,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="0" loc="(1540,920)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
+    <comp lib="10" loc="(510,350)" name="statistics"/>
     <comp lib="0" loc="(350,420)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="4" loc="(220,700)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
+    <comp lib="1" loc="(1370,410)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
     </comp>
-    <comp lib="0" loc="(1090,910)" name="Constant">
+    <comp lib="2" loc="(90,530)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(180,1080)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1510,1050)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(810,750)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="9" loc="(720,140)" name="Control"/>
+    <comp lib="6" loc="(1044,617)" name="Text">
+      <a name="text" val="Shamt"/>
+    </comp>
+    <comp lib="0" loc="(1920,910)" name="Constant">
       <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(997,944)" name="Text">
+      <a name="text" val="Jump Addr"/>
     </comp>
     <comp lib="0" loc="(670,690)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1198,189 +1079,171 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="5" loc="(460,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
     <comp lib="4" loc="(300,330)" name="Counter">
       <a name="width" val="32"/>
       <a name="max" val="0xffffffff"/>
     </comp>
-    <comp lib="6" loc="(1454,655)" name="Text">
-      <a name="text" val="WriteDataEX"/>
-    </comp>
-    <comp lib="3" loc="(470,620)" name="Adder">
+    <comp lib="2" loc="(200,550)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1760,630)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(1830,580)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1920,910)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(310,450)" name="Probe">
+    <comp lib="0" loc="(380,450)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
+      <a name="label" val="R"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="2" loc="(150,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="0" loc="(480,730)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(410,630)" name="Constant">
       <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="4" loc="(220,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
+    </comp>
+    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
+    <comp lib="2" loc="(830,680)" name="Multiplexer">
+      <a name="width" val="5"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(990,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="3" loc="(1360,930)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="2" loc="(1260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(570,130)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
+    <comp lib="6" loc="(1309,1055)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
     </comp>
     <comp lib="6" loc="(1040,682)" name="Text">
       <a name="text" val="WriteReg#"/>
-    </comp>
-    <comp lib="6" loc="(995,966)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="2" loc="(490,680)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(180,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(660,870)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
     </comp>
     <comp lib="5" loc="(300,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(670,540)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1310,940)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(450,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="6" loc="(1033,862)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp loc="(1890,130)" name="MEM/WB"/>
-    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
+    <comp loc="(950,480)" name="Regfile_Wrapper"/>
+    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
+    </comp>
+    <comp loc="(1080,130)" name="ID/EX"/>
+    <comp lib="6" loc="(689,491)" name="Text">
+      <a name="text" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(850,760)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="1"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+      <a name="bit11" val="1"/>
+      <a name="bit12" val="1"/>
+      <a name="bit13" val="1"/>
+      <a name="bit14" val="1"/>
+      <a name="bit15" val="1"/>
+      <a name="bit16" val="1"/>
+      <a name="bit17" val="1"/>
+      <a name="bit18" val="1"/>
+      <a name="bit19" val="1"/>
+      <a name="bit20" val="1"/>
+      <a name="bit21" val="1"/>
+      <a name="bit22" val="1"/>
+      <a name="bit23" val="1"/>
+      <a name="bit24" val="1"/>
+      <a name="bit25" val="1"/>
+      <a name="bit26" val="1"/>
+      <a name="bit27" val="1"/>
+      <a name="bit28" val="2"/>
+      <a name="bit29" val="2"/>
+      <a name="bit30" val="2"/>
+      <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="4" loc="(370,320)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(780,460)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(270,700)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(810,710)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="2" loc="(490,680)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(590,120)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="6" loc="(414,100)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp lib="6" loc="(1840,685)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="0" loc="(970,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="6" loc="(995,966)" name="Text">
+      <a name="text" val="Branch Addr"/>
+    </comp>
+    <comp lib="6" loc="(693,306)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
+    <comp lib="2" loc="(1260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(1830,580)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="0" loc="(780,440)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="6" loc="(1454,655)" name="Text">
+      <a name="text" val="WriteDataEX"/>
+    </comp>
+    <comp lib="0" loc="(1520,920)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="4" loc="(320,550)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(1760,630)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(2130,500)" name="Tunnel">
+      <a name="label" val="Halt"/>
     </comp>
     <comp lib="0" loc="(350,550)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1419,10 +1282,148 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="6" loc="(1309,1055)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
+    <comp lib="1" loc="(1450,330)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp loc="(1080,130)" name="ID/EX"/>
+    <comp lib="0" loc="(530,360)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="1" loc="(1010,470)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="6" loc="(687,529)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="6" loc="(2028,981)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="4" loc="(440,300)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(670,620)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1020,620)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="2" loc="(1350,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(570,130)" name="IF/ID">
+      <a name="labelfont" val="Monaco bold 44"/>
+    </comp>
+    <comp lib="0" loc="(1780,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp loc="(1890,130)" name="MEM/WB"/>
+    <comp lib="0" loc="(1670,580)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(200,730)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(1033,862)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="3" loc="(1360,930)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(500,730)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(690,678)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
   </circuit>
   <circuit name="Syscall_Decoder">
     <a name="circuit" val="Syscall_Decoder"/>
@@ -1457,11 +1458,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(480,290)" to="(480,320)"/>
     <wire from="(170,440)" to="(300,440)"/>
     <wire from="(640,420)" to="(650,420)"/>
-    <comp lib="0" loc="(480,320)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(650,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Halt"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(310,130)" name="Pin">
+      <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(470,130)" name="Tunnel">
+    <comp lib="3" loc="(340,450)" name="Comparator">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(440,130)" name="Pin">
+      <a name="tristate" val="false"/>
       <a name="label" val="Enable"/>
     </comp>
     <comp lib="0" loc="(420,270)" name="Pin">
@@ -1469,32 +1480,9 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="a0"/>
     </comp>
-    <comp lib="0" loc="(440,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Enable"/>
-    </comp>
     <comp lib="4" loc="(640,420)" name="D Flip-Flop"/>
-    <comp lib="0" loc="(470,430)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
     <comp lib="0" loc="(580,420)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(650,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Halt"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(510,440)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(500,270)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(310,130)" name="Pin">
-      <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(660,270)" name="Pin">
@@ -1503,6 +1491,26 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="32"/>
       <a name="label" val="Hex"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(320,130)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(470,430)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(510,440)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(500,270)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(440,320)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="Enable"/>
+    </comp>
+    <comp lib="0" loc="(480,320)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(270,460)" name="Constant">
       <a name="width" val="32"/>
@@ -1513,673 +1521,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="v0"/>
     </comp>
-    <comp lib="0" loc="(440,320)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(470,130)" name="Tunnel">
       <a name="label" val="Enable"/>
-    </comp>
-    <comp lib="0" loc="(320,130)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="3" loc="(340,450)" name="Comparator">
-      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(510,480)" name="Tunnel">
       <a name="label" val="Enable"/>
-    </comp>
-  </circuit>
-  <circuit name="Statistics">
-    <a name="circuit" val="Statistics"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#ff01b2" height="60" stroke="none" width="30" x="50" y="55"/>
-      <circ-port height="8" pin="40,30" width="8" x="76" y="56"/>
-      <circ-port height="8" pin="40,80" width="8" x="76" y="66"/>
-      <circ-port height="8" pin="40,140" width="8" x="76" y="76"/>
-      <circ-port height="8" pin="40,190" width="8" x="76" y="86"/>
-      <circ-port height="8" pin="40,250" width="8" x="76" y="96"/>
-      <circ-port height="8" pin="40,310" width="8" x="76" y="106"/>
-      <circ-port height="10" pin="420,670" width="10" x="45" y="65"/>
-      <circ-port height="10" pin="420,1490" width="10" x="45" y="75"/>
-      <circ-port height="10" pin="420,1750" width="10" x="45" y="85"/>
-      <circ-anchor facing="east" height="6" width="6" x="77" y="77"/>
-    </appear>
-    <wire from="(290,1320)" to="(350,1320)"/>
-    <wire from="(120,190)" to="(180,190)"/>
-    <wire from="(200,190)" to="(260,190)"/>
-    <wire from="(230,150)" to="(230,160)"/>
-    <wire from="(230,470)" to="(230,480)"/>
-    <wire from="(220,1500)" to="(220,1510)"/>
-    <wire from="(340,710)" to="(340,1180)"/>
-    <wire from="(140,250)" to="(140,340)"/>
-    <wire from="(230,1510)" to="(230,1540)"/>
-    <wire from="(140,630)" to="(180,630)"/>
-    <wire from="(240,960)" to="(240,990)"/>
-    <wire from="(240,1120)" to="(240,1150)"/>
-    <wire from="(200,930)" to="(240,930)"/>
-    <wire from="(200,1090)" to="(240,1090)"/>
-    <wire from="(200,1570)" to="(240,1570)"/>
-    <wire from="(200,1730)" to="(240,1730)"/>
-    <wire from="(200,690)" to="(240,690)"/>
-    <wire from="(290,1020)" to="(330,1020)"/>
-    <wire from="(80,720)" to="(180,720)"/>
-    <wire from="(240,480)" to="(240,510)"/>
-    <wire from="(100,170)" to="(260,170)"/>
-    <wire from="(230,330)" to="(260,330)"/>
-    <wire from="(200,780)" to="(230,780)"/>
-    <wire from="(230,90)" to="(260,90)"/>
-    <wire from="(230,730)" to="(260,730)"/>
-    <wire from="(230,1690)" to="(260,1690)"/>
-    <wire from="(230,1850)" to="(260,1850)"/>
-    <wire from="(240,990)" to="(260,990)"/>
-    <wire from="(240,1150)" to="(260,1150)"/>
-    <wire from="(240,910)" to="(260,910)"/>
-    <wire from="(350,620)" to="(370,620)"/>
-    <wire from="(400,670)" to="(420,670)"/>
-    <wire from="(240,240)" to="(240,280)"/>
-    <wire from="(240,1600)" to="(240,1640)"/>
-    <wire from="(240,1760)" to="(240,1800)"/>
-    <wire from="(160,510)" to="(180,510)"/>
-    <wire from="(160,1390)" to="(180,1390)"/>
-    <wire from="(200,1510)" to="(220,1510)"/>
-    <wire from="(100,440)" to="(180,440)"/>
-    <wire from="(100,1480)" to="(180,1480)"/>
-    <wire from="(240,1520)" to="(240,1570)"/>
-    <wire from="(120,610)" to="(260,610)"/>
-    <wire from="(310,1670)" to="(310,1740)"/>
-    <wire from="(80,80)" to="(80,150)"/>
-    <wire from="(40,310)" to="(160,310)"/>
-    <wire from="(230,200)" to="(230,210)"/>
-    <wire from="(240,210)" to="(240,220)"/>
-    <wire from="(290,180)" to="(340,180)"/>
-    <wire from="(320,690)" to="(370,690)"/>
-    <wire from="(80,270)" to="(80,410)"/>
-    <wire from="(80,1150)" to="(80,1290)"/>
-    <wire from="(100,1170)" to="(100,1310)"/>
-    <wire from="(120,1190)" to="(120,1330)"/>
-    <wire from="(160,510)" to="(160,660)"/>
-    <wire from="(240,130)" to="(240,150)"/>
-    <wire from="(200,660)" to="(240,660)"/>
-    <wire from="(200,820)" to="(240,820)"/>
-    <wire from="(40,250)" to="(140,250)"/>
-    <wire from="(240,690)" to="(240,720)"/>
-    <wire from="(80,850)" to="(180,850)"/>
-    <wire from="(200,990)" to="(230,990)"/>
-    <wire from="(200,270)" to="(230,270)"/>
-    <wire from="(230,620)" to="(260,620)"/>
-    <wire from="(200,30)" to="(230,30)"/>
-    <wire from="(230,860)" to="(260,860)"/>
-    <wire from="(200,1150)" to="(230,1150)"/>
-    <wire from="(200,1630)" to="(230,1630)"/>
-    <wire from="(200,1790)" to="(230,1790)"/>
-    <wire from="(80,990)" to="(80,1150)"/>
-    <wire from="(80,1630)" to="(80,1790)"/>
-    <wire from="(100,1010)" to="(100,1170)"/>
-    <wire from="(120,1030)" to="(120,1190)"/>
-    <wire from="(230,1340)" to="(260,1340)"/>
-    <wire from="(240,1520)" to="(260,1520)"/>
-    <wire from="(240,480)" to="(260,480)"/>
-    <wire from="(240,720)" to="(260,720)"/>
-    <wire from="(40,190)" to="(120,190)"/>
-    <wire from="(120,1510)" to="(120,1690)"/>
-    <wire from="(160,1390)" to="(160,1570)"/>
-    <wire from="(310,600)" to="(310,660)"/>
-    <wire from="(120,760)" to="(120,890)"/>
-    <wire from="(140,780)" to="(140,910)"/>
-    <wire from="(160,800)" to="(160,930)"/>
-    <wire from="(80,720)" to="(80,850)"/>
-    <wire from="(100,740)" to="(100,870)"/>
-    <wire from="(310,680)" to="(310,750)"/>
-    <wire from="(120,1330)" to="(180,1330)"/>
-    <wire from="(200,1330)" to="(260,1330)"/>
-    <wire from="(60,1420)" to="(180,1420)"/>
-    <wire from="(230,330)" to="(230,340)"/>
-    <wire from="(60,1260)" to="(180,1260)"/>
-    <wire from="(220,80)" to="(220,90)"/>
-    <wire from="(60,380)" to="(180,380)"/>
-    <wire from="(60,540)" to="(180,540)"/>
-    <wire from="(230,570)" to="(230,580)"/>
-    <wire from="(60,130)" to="(240,130)"/>
-    <wire from="(230,1290)" to="(230,1300)"/>
-    <wire from="(220,1680)" to="(220,1690)"/>
-    <wire from="(220,1840)" to="(220,1850)"/>
-    <wire from="(230,1450)" to="(230,1470)"/>
-    <wire from="(230,1690)" to="(230,1710)"/>
-    <wire from="(230,1850)" to="(230,1870)"/>
-    <wire from="(240,1860)" to="(240,1880)"/>
-    <wire from="(240,340)" to="(240,360)"/>
-    <wire from="(60,540)" to="(60,690)"/>
-    <wire from="(230,90)" to="(230,110)"/>
-    <wire from="(240,100)" to="(240,120)"/>
-    <wire from="(230,410)" to="(230,430)"/>
-    <wire from="(240,820)" to="(240,850)"/>
-    <wire from="(240,1700)" to="(240,1730)"/>
-    <wire from="(350,720)" to="(350,1320)"/>
-    <wire from="(230,430)" to="(260,430)"/>
-    <wire from="(100,590)" to="(260,590)"/>
-    <wire from="(200,720)" to="(230,720)"/>
-    <wire from="(200,1360)" to="(230,1360)"/>
-    <wire from="(60,380)" to="(60,540)"/>
-    <wire from="(200,480)" to="(230,480)"/>
-    <wire from="(60,1260)" to="(60,1420)"/>
-    <wire from="(100,1310)" to="(260,1310)"/>
-    <wire from="(60,30)" to="(60,130)"/>
-    <wire from="(120,90)" to="(120,190)"/>
-    <wire from="(140,110)" to="(140,210)"/>
-    <wire from="(230,1470)" to="(260,1470)"/>
-    <wire from="(240,850)" to="(260,850)"/>
-    <wire from="(350,720)" to="(370,720)"/>
-    <wire from="(160,930)" to="(180,930)"/>
-    <wire from="(160,1090)" to="(180,1090)"/>
-    <wire from="(200,90)" to="(220,90)"/>
-    <wire from="(200,1690)" to="(220,1690)"/>
-    <wire from="(200,1850)" to="(220,1850)"/>
-    <wire from="(240,210)" to="(260,210)"/>
-    <wire from="(160,1570)" to="(180,1570)"/>
-    <wire from="(160,1730)" to="(180,1730)"/>
-    <wire from="(100,60)" to="(180,60)"/>
-    <wire from="(100,300)" to="(180,300)"/>
-    <wire from="(160,120)" to="(240,120)"/>
-    <wire from="(100,1660)" to="(180,1660)"/>
-    <wire from="(100,1820)" to="(180,1820)"/>
-    <wire from="(160,360)" to="(240,360)"/>
-    <wire from="(160,1240)" to="(240,1240)"/>
-    <wire from="(160,1880)" to="(240,1880)"/>
-    <wire from="(60,1420)" to="(60,1600)"/>
-    <wire from="(230,620)" to="(230,630)"/>
-    <wire from="(80,850)" to="(80,990)"/>
-    <wire from="(100,870)" to="(100,1010)"/>
-    <wire from="(120,890)" to="(120,1030)"/>
-    <wire from="(330,310)" to="(330,640)"/>
-    <wire from="(230,1340)" to="(230,1360)"/>
-    <wire from="(140,910)" to="(140,1060)"/>
-    <wire from="(160,1090)" to="(160,1240)"/>
-    <wire from="(160,1730)" to="(160,1880)"/>
-    <wire from="(140,780)" to="(180,780)"/>
-    <wire from="(220,1500)" to="(260,1500)"/>
-    <wire from="(80,150)" to="(180,150)"/>
-    <wire from="(240,630)" to="(240,660)"/>
-    <wire from="(200,850)" to="(230,850)"/>
-    <wire from="(230,160)" to="(260,160)"/>
-    <wire from="(120,1690)" to="(120,1850)"/>
-    <wire from="(140,1710)" to="(140,1870)"/>
-    <wire from="(160,930)" to="(160,1090)"/>
-    <wire from="(160,1570)" to="(160,1730)"/>
-    <wire from="(230,1040)" to="(260,1040)"/>
-    <wire from="(230,1200)" to="(260,1200)"/>
-    <wire from="(240,1700)" to="(260,1700)"/>
-    <wire from="(240,1860)" to="(260,1860)"/>
-    <wire from="(240,1460)" to="(260,1460)"/>
-    <wire from="(290,1670)" to="(310,1670)"/>
-    <wire from="(290,1830)" to="(310,1830)"/>
-    <wire from="(140,210)" to="(140,250)"/>
-    <wire from="(240,1350)" to="(240,1390)"/>
-    <wire from="(160,660)" to="(180,660)"/>
-    <wire from="(240,100)" to="(260,100)"/>
-    <wire from="(240,420)" to="(260,420)"/>
-    <wire from="(240,340)" to="(260,340)"/>
-    <wire from="(160,310)" to="(160,360)"/>
-    <wire from="(120,760)" to="(260,760)"/>
-    <wire from="(320,690)" to="(320,880)"/>
-    <wire from="(310,660)" to="(370,660)"/>
-    <wire from="(360,1750)" to="(420,1750)"/>
-    <wire from="(120,1030)" to="(180,1030)"/>
-    <wire from="(120,1190)" to="(180,1190)"/>
-    <wire from="(120,1510)" to="(180,1510)"/>
-    <wire from="(200,1030)" to="(260,1030)"/>
-    <wire from="(200,1190)" to="(260,1190)"/>
-    <wire from="(60,240)" to="(180,240)"/>
-    <wire from="(60,960)" to="(180,960)"/>
-    <wire from="(230,990)" to="(230,1000)"/>
-    <wire from="(60,1120)" to="(180,1120)"/>
-    <wire from="(60,1600)" to="(180,1600)"/>
-    <wire from="(60,1760)" to="(180,1760)"/>
-    <wire from="(320,450)" to="(320,650)"/>
-    <wire from="(60,1120)" to="(60,1260)"/>
-    <wire from="(60,240)" to="(60,380)"/>
-    <wire from="(230,1150)" to="(230,1160)"/>
-    <wire from="(160,660)" to="(160,800)"/>
-    <wire from="(230,1630)" to="(230,1650)"/>
-    <wire from="(230,1790)" to="(230,1810)"/>
-    <wire from="(120,460)" to="(120,610)"/>
-    <wire from="(140,480)" to="(140,630)"/>
-    <wire from="(230,270)" to="(230,290)"/>
-    <wire from="(230,30)" to="(230,50)"/>
-    <wire from="(100,440)" to="(100,590)"/>
-    <wire from="(330,700)" to="(370,700)"/>
-    <wire from="(100,140)" to="(100,170)"/>
-    <wire from="(200,340)" to="(230,340)"/>
-    <wire from="(230,50)" to="(260,50)"/>
-    <wire from="(60,960)" to="(60,1120)"/>
-    <wire from="(60,1600)" to="(60,1760)"/>
-    <wire from="(230,290)" to="(260,290)"/>
-    <wire from="(230,770)" to="(260,770)"/>
-    <wire from="(200,1060)" to="(230,1060)"/>
-    <wire from="(200,1220)" to="(230,1220)"/>
-    <wire from="(200,1540)" to="(230,1540)"/>
-    <wire from="(100,1010)" to="(260,1010)"/>
-    <wire from="(100,1170)" to="(260,1170)"/>
-    <wire from="(350,70)" to="(350,620)"/>
-    <wire from="(140,110)" to="(230,110)"/>
-    <wire from="(140,910)" to="(230,910)"/>
-    <wire from="(140,1710)" to="(230,1710)"/>
-    <wire from="(140,1870)" to="(230,1870)"/>
-    <wire from="(230,1650)" to="(260,1650)"/>
-    <wire from="(230,1810)" to="(260,1810)"/>
-    <wire from="(290,600)" to="(310,600)"/>
-    <wire from="(240,1350)" to="(260,1350)"/>
-    <wire from="(310,1740)" to="(330,1740)"/>
-    <wire from="(40,30)" to="(60,30)"/>
-    <wire from="(60,130)" to="(60,240)"/>
-    <wire from="(240,150)" to="(260,150)"/>
-    <wire from="(240,630)" to="(260,630)"/>
-    <wire from="(160,220)" to="(240,220)"/>
-    <wire from="(100,1480)" to="(100,1660)"/>
-    <wire from="(140,1360)" to="(140,1540)"/>
-    <wire from="(80,150)" to="(80,270)"/>
-    <wire from="(100,170)" to="(100,300)"/>
-    <wire from="(120,190)" to="(120,320)"/>
-    <wire from="(60,690)" to="(60,820)"/>
-    <wire from="(200,440)" to="(260,440)"/>
-    <wire from="(200,1480)" to="(260,1480)"/>
-    <wire from="(60,690)" to="(180,690)"/>
-    <wire from="(230,720)" to="(230,730)"/>
-    <wire from="(290,1180)" to="(340,1180)"/>
-    <wire from="(320,650)" to="(370,650)"/>
-    <wire from="(230,1200)" to="(230,1220)"/>
-    <wire from="(100,60)" to="(100,140)"/>
-    <wire from="(230,1040)" to="(230,1060)"/>
-    <wire from="(240,1210)" to="(240,1240)"/>
-    <wire from="(140,1360)" to="(180,1360)"/>
-    <wire from="(140,480)" to="(180,480)"/>
-    <wire from="(200,1260)" to="(240,1260)"/>
-    <wire from="(200,1420)" to="(240,1420)"/>
-    <wire from="(220,80)" to="(260,80)"/>
-    <wire from="(200,380)" to="(240,380)"/>
-    <wire from="(200,540)" to="(240,540)"/>
-    <wire from="(290,310)" to="(330,310)"/>
-    <wire from="(220,1680)" to="(260,1680)"/>
-    <wire from="(220,1840)" to="(260,1840)"/>
-    <wire from="(80,410)" to="(180,410)"/>
-    <wire from="(80,570)" to="(180,570)"/>
-    <wire from="(240,10)" to="(240,40)"/>
-    <wire from="(80,1290)" to="(180,1290)"/>
-    <wire from="(80,1450)" to="(180,1450)"/>
-    <wire from="(200,150)" to="(230,150)"/>
-    <wire from="(200,630)" to="(230,630)"/>
-    <wire from="(230,580)" to="(260,580)"/>
-    <wire from="(100,740)" to="(260,740)"/>
-    <wire from="(230,900)" to="(260,900)"/>
-    <wire from="(290,880)" to="(320,880)"/>
-    <wire from="(230,1300)" to="(260,1300)"/>
-    <wire from="(160,120)" to="(160,220)"/>
-    <wire from="(240,1640)" to="(260,1640)"/>
-    <wire from="(240,1800)" to="(260,1800)"/>
-    <wire from="(240,1050)" to="(240,1090)"/>
-    <wire from="(240,40)" to="(260,40)"/>
-    <wire from="(240,280)" to="(260,280)"/>
-    <wire from="(120,460)" to="(260,460)"/>
-    <wire from="(310,680)" to="(370,680)"/>
-    <wire from="(310,1760)" to="(310,1830)"/>
-    <wire from="(120,90)" to="(180,90)"/>
-    <wire from="(330,700)" to="(330,1020)"/>
-    <wire from="(120,890)" to="(180,890)"/>
-    <wire from="(120,1690)" to="(180,1690)"/>
-    <wire from="(120,1850)" to="(180,1850)"/>
-    <wire from="(200,890)" to="(260,890)"/>
-    <wire from="(60,820)" to="(180,820)"/>
-    <wire from="(230,850)" to="(230,860)"/>
-    <wire from="(230,770)" to="(230,780)"/>
-    <wire from="(60,10)" to="(240,10)"/>
-    <wire from="(100,300)" to="(100,440)"/>
-    <wire from="(120,320)" to="(120,460)"/>
-    <wire from="(60,820)" to="(60,960)"/>
-    <wire from="(140,340)" to="(140,480)"/>
-    <wire from="(140,1220)" to="(140,1360)"/>
-    <wire from="(240,780)" to="(240,800)"/>
-    <wire from="(160,360)" to="(160,510)"/>
-    <wire from="(160,1240)" to="(160,1390)"/>
-    <wire from="(240,1260)" to="(240,1290)"/>
-    <wire from="(200,1390)" to="(240,1390)"/>
-    <wire from="(200,510)" to="(240,510)"/>
-    <wire from="(240,540)" to="(240,570)"/>
-    <wire from="(330,640)" to="(370,640)"/>
-    <wire from="(230,470)" to="(260,470)"/>
-    <wire from="(100,870)" to="(260,870)"/>
-    <wire from="(100,1660)" to="(100,1820)"/>
-    <wire from="(140,1060)" to="(140,1220)"/>
-    <wire from="(140,210)" to="(230,210)"/>
-    <wire from="(290,450)" to="(320,450)"/>
-    <wire from="(230,1510)" to="(260,1510)"/>
-    <wire from="(240,1290)" to="(260,1290)"/>
-    <wire from="(240,1050)" to="(260,1050)"/>
-    <wire from="(240,1210)" to="(260,1210)"/>
-    <wire from="(140,1540)" to="(140,1710)"/>
-    <wire from="(310,1760)" to="(330,1760)"/>
-    <wire from="(240,380)" to="(240,420)"/>
-    <wire from="(240,1420)" to="(240,1460)"/>
-    <wire from="(240,570)" to="(260,570)"/>
-    <wire from="(160,800)" to="(240,800)"/>
-    <wire from="(290,1490)" to="(420,1490)"/>
-    <wire from="(290,70)" to="(350,70)"/>
-    <wire from="(40,140)" to="(100,140)"/>
-    <wire from="(200,60)" to="(260,60)"/>
-    <wire from="(340,180)" to="(340,630)"/>
-    <wire from="(200,1660)" to="(260,1660)"/>
-    <wire from="(200,1820)" to="(260,1820)"/>
-    <wire from="(200,300)" to="(260,300)"/>
-    <wire from="(230,900)" to="(230,910)"/>
-    <wire from="(240,910)" to="(240,930)"/>
-    <wire from="(60,10)" to="(60,30)"/>
-    <wire from="(120,610)" to="(120,760)"/>
-    <wire from="(140,630)" to="(140,780)"/>
-    <wire from="(80,570)" to="(80,720)"/>
-    <wire from="(100,590)" to="(100,740)"/>
-    <wire from="(40,80)" to="(80,80)"/>
-    <wire from="(160,220)" to="(160,310)"/>
-    <wire from="(140,340)" to="(180,340)"/>
-    <wire from="(140,1060)" to="(180,1060)"/>
-    <wire from="(140,1220)" to="(180,1220)"/>
-    <wire from="(140,1540)" to="(180,1540)"/>
-    <wire from="(200,240)" to="(240,240)"/>
-    <wire from="(200,960)" to="(240,960)"/>
-    <wire from="(200,1120)" to="(240,1120)"/>
-    <wire from="(200,1600)" to="(240,1600)"/>
-    <wire from="(200,1760)" to="(240,1760)"/>
-    <wire from="(80,30)" to="(180,30)"/>
-    <wire from="(80,990)" to="(180,990)"/>
-    <wire from="(80,1150)" to="(180,1150)"/>
-    <wire from="(80,270)" to="(180,270)"/>
-    <wire from="(80,1630)" to="(180,1630)"/>
-    <wire from="(80,1790)" to="(180,1790)"/>
-    <wire from="(200,410)" to="(230,410)"/>
-    <wire from="(200,570)" to="(230,570)"/>
-    <wire from="(80,410)" to="(80,570)"/>
-    <wire from="(230,200)" to="(260,200)"/>
-    <wire from="(230,1000)" to="(260,1000)"/>
-    <wire from="(200,1290)" to="(230,1290)"/>
-    <wire from="(200,1450)" to="(230,1450)"/>
-    <wire from="(80,1290)" to="(80,1450)"/>
-    <wire from="(230,1160)" to="(260,1160)"/>
-    <wire from="(340,710)" to="(370,710)"/>
-    <wire from="(340,630)" to="(370,630)"/>
-    <wire from="(240,780)" to="(260,780)"/>
-    <wire from="(290,750)" to="(310,750)"/>
-    <wire from="(100,1310)" to="(100,1480)"/>
-    <wire from="(80,30)" to="(80,80)"/>
-    <wire from="(80,1450)" to="(80,1630)"/>
-    <wire from="(120,320)" to="(260,320)"/>
-    <wire from="(120,1330)" to="(120,1510)"/>
-    <comp lib="1" loc="(200,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,90)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="i"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(420,1750)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="j"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(360,1750)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(200,1600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,190)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(400,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(200,60)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,70)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(290,310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1730)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1760)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,30)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,890)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(420,1490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="r"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,310)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(200,990)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,1790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(290,880)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(200,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(200,1480)" name="NOT Gate">
-      <a name="size" val="20"/>
     </comp>
   </circuit>
   <circuit name="IF/ID">
@@ -2218,6 +1564,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(310,470)" to="(350,470)"/>
     <wire from="(370,520)" to="(570,520)"/>
     <wire from="(370,420)" to="(570,420)"/>
+    <comp lib="0" loc="(310,470)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
+    </comp>
     <comp lib="0" loc="(310,370)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
@@ -2225,20 +1576,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     </comp>
     <comp lib="4" loc="(380,370)" name="Register">
       <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(160,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(410,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4IF"/>
-      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(410,370)" name="Pin">
       <a name="facing" val="west"/>
@@ -2251,22 +1588,31 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="4" loc="(380,470)" name="Register">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
     <comp lib="0" loc="(340,590)" name="Pin">
       <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(310,470)" name="Pin">
+    <comp lib="0" loc="(410,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
+      <a name="label" val="PCPlus4IF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(570,350)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(160,350)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
   </circuit>
   <circuit name="ID/EX">
@@ -2548,76 +1894,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(900,630)" to="(980,630)"/>
     <wire from="(900,390)" to="(980,390)"/>
     <wire from="(1230,410)" to="(1250,410)"/>
-    <comp lib="0" loc="(930,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="0" loc="(930,480)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1240,650)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
     <comp lib="0" loc="(1180,470)" name="Pin">
       <a name="label" val="BranchID"/>
+    </comp>
+    <comp lib="4" loc="(570,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(590,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ShamtEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(240,560)" name="Pin">
       <a name="facing" val="west"/>
@@ -2626,88 +1914,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R2EX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
+    <comp lib="4" loc="(910,480)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(520,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="0" loc="(240,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R1EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(180,640)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,420)" name="Pin">
-      <a name="label" val="IsShamtID"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(1180,650)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
     </comp>
     <comp lib="0" loc="(590,560)" name="Pin">
       <a name="facing" val="west"/>
@@ -2716,32 +1928,18 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlusEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(520,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
     </comp>
     <comp lib="4" loc="(1230,650)" name="Register">
       <a name="width" val="4"/>
     </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(860,420)" name="Pin">
+      <a name="label" val="IsShamtID"/>
     </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
+    <comp lib="4" loc="(220,560)" name="Register">
       <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(240,360)" name="Pin">
@@ -2751,43 +1949,66 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ImmEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
+    <comp lib="4" loc="(220,460)" name="Register">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(100,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
+    <comp lib="0" loc="(520,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="JumpAddr"/>
     </comp>
     <comp lib="0" loc="(860,720)" name="Pin">
       <a name="label" val="IsExceptionID"/>
     </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
+    <comp lib="4" loc="(570,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(170,360)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
+      <a name="label" val="ImmID"/>
     </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
+    <comp lib="0" loc="(240,460)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
+      <a name="label" val="R1EX"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,480)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(180,640)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1180,350)" name="Pin">
+      <a name="label" val="MemWriteID"/>
+    </comp>
+    <comp lib="0" loc="(860,480)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
+    </comp>
+    <comp lib="4" loc="(910,420)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(170,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(1180,530)" name="Pin">
+      <a name="label" val="IsJRID"/>
     </comp>
     <comp lib="0" loc="(590,460)" name="Pin">
       <a name="facing" val="west"/>
@@ -2796,31 +2017,61 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpAddr"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
+    <comp lib="4" loc="(910,720)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
+    <comp lib="4" loc="(910,540)" name="Register">
+      <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
+    <comp lib="4" loc="(1230,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1240,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,660)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
+    </comp>
+    <comp lib="4" loc="(1230,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1230,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(520,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ShamtID"/>
     </comp>
     <comp lib="4" loc="(1230,590)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(930,780)" name="Pin">
+    <comp lib="0" loc="(920,360)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="MemReadEX"/>
+      <a name="label" val="IsJALEX"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
     </comp>
     <comp lib="0" loc="(1180,710)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="WriteReg#ID"/>
+    </comp>
+    <comp lib="4" loc="(1230,530)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1230,710)" name="Register">
+      <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(1250,350)" name="Pin">
       <a name="facing" val="west"/>
@@ -2828,17 +2079,112 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemWriteEX"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(1250,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJREX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(570,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(860,540)" name="Pin">
+      <a name="label" val="RegWriteID"/>
+    </comp>
+    <comp lib="0" loc="(930,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BranchEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2ID"/>
+    </comp>
+    <comp lib="0" loc="(930,540)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,590)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,780)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,410)" name="Pin">
+      <a name="label" val="JumpID"/>
+    </comp>
     <comp lib="0" loc="(930,660)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="ALUSrcEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
+    <comp lib="0" loc="(60,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="4" loc="(910,540)" name="Register">
+    <comp lib="0" loc="(1240,650)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,600)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="0" loc="(860,780)" name="Pin">
+      <a name="label" val="MemReadID"/>
+    </comp>
+    <comp lib="4" loc="(910,660)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1250,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="JumpEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1180,590)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="0" loc="(930,600)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeqEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(910,600)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,360)" name="Pin">
+      <a name="label" val="IsJALID"/>
+    </comp>
+    <comp lib="4" loc="(910,780)" name="Register">
       <a name="width" val="1"/>
     </comp>
   </circuit>
@@ -2941,11 +2287,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,360)" to="(860,390)"/>
     <wire from="(860,160)" to="(860,190)"/>
     <wire from="(560,70)" to="(980,70)"/>
+    <wire from="(470,500)" to="(560,500)"/>
+    <wire from="(470,260)" to="(560,260)"/>
     <wire from="(870,240)" to="(890,240)"/>
     <wire from="(470,140)" to="(560,140)"/>
     <wire from="(470,380)" to="(560,380)"/>
-    <wire from="(470,260)" to="(560,260)"/>
-    <wire from="(470,500)" to="(560,500)"/>
     <wire from="(640,290)" to="(850,290)"/>
     <wire from="(300,80)" to="(640,80)"/>
     <wire from="(980,190)" to="(980,290)"/>
@@ -2968,10 +2314,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(300,320)" to="(300,380)"/>
     <wire from="(300,200)" to="(300,260)"/>
     <wire from="(300,80)" to="(300,140)"/>
+    <wire from="(440,300)" to="(440,360)"/>
     <wire from="(440,420)" to="(440,480)"/>
     <wire from="(830,250)" to="(840,250)"/>
     <wire from="(440,180)" to="(440,240)"/>
-    <wire from="(440,300)" to="(440,360)"/>
     <wire from="(440,580)" to="(830,580)"/>
     <wire from="(860,390)" to="(980,390)"/>
     <wire from="(860,190)" to="(980,190)"/>
@@ -2993,11 +2339,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(430,530)" to="(450,530)"/>
     <wire from="(430,410)" to="(450,410)"/>
     <wire from="(830,350)" to="(830,580)"/>
-    <comp lib="0" loc="(500,530)" name="Pin">
+    <comp lib="0" loc="(820,140)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="0" loc="(820,340)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrEX"/>
+    </comp>
+    <comp lib="4" loc="(870,240)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(820,240)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataEX"/>
+    </comp>
+    <comp lib="0" loc="(430,530)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(430,110)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(890,340)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(890,240)" name="Pin">
@@ -3013,67 +2382,14 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsExceptionMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(480,530)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
-    </comp>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(500,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
     <comp lib="4" loc="(870,340)" name="Register">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
+    <comp lib="0" loc="(500,350)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
+      <a name="label" val="MemReadMEM"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(350,60)" name="Pin">
       <a name="facing" val="south"/>
@@ -3081,47 +2397,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="clr"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(430,530)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
     <comp lib="0" loc="(500,230)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(500,110)" name="Pin">
@@ -3130,27 +2409,94 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsJALMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(500,350)" name="Pin">
+    <comp lib="0" loc="(500,530)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="MemReadMEM"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
+    <comp lib="0" loc="(430,350)" name="Pin">
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="4" loc="(480,110)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(890,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
+      <a name="label" val="ALUResultMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(480,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(870,140)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(480,170)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(480,530)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(500,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,230)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(300,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="4" loc="(480,350)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
+    <comp lib="0" loc="(500,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteMEM"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(430,410)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
     </comp>
-    <comp lib="4" loc="(480,170)" name="Register">
+    <comp lib="0" loc="(440,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(430,170)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
+    </comp>
+    <comp lib="0" loc="(430,470)" name="Pin">
+      <a name="label" val="IsSyscallEX"/>
+    </comp>
+    <comp lib="4" loc="(480,290)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,290)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
+    </comp>
+    <comp lib="0" loc="(500,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallMEM"/>
+      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="MEM/WB">
@@ -3280,115 +2626,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(250,290)" to="(390,290)"/>
     <wire from="(290,200)" to="(490,200)"/>
     <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="0" loc="(290,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,560)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(720,390)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,380)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(370,620)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
-    </comp>
     <comp lib="0" loc="(430,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="IsSyscallWB"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
-    </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="0" loc="(790,500)" name="Pin">
       <a name="facing" val="west"/>
@@ -3397,23 +2639,127 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(790,390)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(410,560)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
     <comp lib="0" loc="(430,440)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="IsExceptionWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(250,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(360,440)" name="Pin">
+      <a name="label" val="IsExceptionMEM"/>
+    </comp>
+    <comp lib="0" loc="(370,620)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
     <comp lib="4" loc="(770,500)" name="Register">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
+    <comp lib="4" loc="(410,500)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(360,380)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(720,500)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(790,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="4" loc="(410,380)" name="Register">
       <a name="width" val="1"/>
     </comp>
+    <comp lib="0" loc="(430,380)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,560)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="4" loc="(410,320)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(770,390)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(430,260)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(290,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(410,440)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="4" loc="(770,290)" name="Register">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(410,260)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(360,260)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
+    <comp lib="0" loc="(720,390)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataMEM"/>
+    </comp>
+    <comp lib="0" loc="(360,500)" name="Pin">
+      <a name="label" val="IsSyscallMEM"/>
+    </comp>
+    <comp lib="0" loc="(720,290)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
     </comp>
   </circuit>
   <circuit name="Regfile_Wrapper">
@@ -3460,17 +2806,31 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(240,190)" to="(280,190)"/>
     <wire from="(240,230)" to="(280,230)"/>
     <wire from="(320,90)" to="(320,180)"/>
-    <comp lib="0" loc="(240,190)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1#"/>
-    </comp>
+    <comp lib="8" loc="(370,210)" name="main"/>
     <comp lib="0" loc="(400,140)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="R1"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,230)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RW"/>
+    </comp>
+    <comp lib="0" loc="(240,210)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2#"/>
+    </comp>
+    <comp lib="0" loc="(400,260)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(300,80)" name="Pin">
@@ -3481,18 +2841,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="v0"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(240,230)" name="Pin">
+    <comp lib="0" loc="(240,190)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="RW"/>
-    </comp>
-    <comp lib="0" loc="(400,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2"/>
-      <a name="labelloc" val="east"/>
+      <a name="label" val="R1#"/>
     </comp>
     <comp lib="0" loc="(300,350)" name="Pin">
       <a name="facing" val="north"/>
@@ -3500,23 +2852,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="Din"/>
     </comp>
-    <comp lib="0" loc="(320,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WE"/>
-      <a name="labelloc" val="south"/>
-    </comp>
     <comp lib="0" loc="(350,290)" name="Pin">
       <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
       <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="8" loc="(370,210)" name="main"/>
-    <comp lib="0" loc="(240,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2#"/>
     </comp>
     <comp lib="0" loc="(400,80)" name="Pin">
       <a name="facing" val="south"/>
@@ -3525,6 +2865,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="a0"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(320,290)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WE"/>
+      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="ALU_Wrapper">
@@ -3560,6 +2906,20 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(670,430)" to="(750,430)"/>
     <wire from="(630,490)" to="(630,540)"/>
     <wire from="(650,480)" to="(650,500)"/>
+    <comp lib="7" loc="(640,440)" name="ALU"/>
+    <comp lib="0" loc="(630,540)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="AluOP"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(680,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Equal"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="0" loc="(750,430)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -3567,7 +2927,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Result"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="7" loc="(640,440)" name="ALU"/>
     <comp lib="0" loc="(560,480)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
@@ -3577,19 +2936,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="X"/>
-    </comp>
-    <comp lib="0" loc="(680,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Equal"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(630,540)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="AluOP"/>
-      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="Immediate_Extend">
@@ -3619,25 +2965,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(560,280)" to="(560,310)"/>
     <wire from="(410,300)" to="(410,330)"/>
     <wire from="(490,340)" to="(490,370)"/>
-    <comp lib="0" loc="(480,370)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(380,330)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Input"/>
-    </comp>
-    <comp lib="0" loc="(480,300)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="32"/>
-      <a name="type" val="sign"/>
-    </comp>
-    <comp lib="2" loc="(580,330)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
     <comp lib="0" loc="(560,280)" name="Pin">
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
@@ -3650,6 +2977,25 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="Output"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(480,370)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(380,330)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Input"/>
+    </comp>
+    <comp lib="2" loc="(580,330)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(480,300)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="32"/>
+      <a name="type" val="sign"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">
@@ -3772,49 +3118,73 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,390)" to="(610,390)"/>
     <wire from="(600,470)" to="(610,470)"/>
     <wire from="(600,510)" to="(610,510)"/>
-    <comp lib="3" loc="(470,390)" name="Comparator">
+    <comp lib="3" loc="(470,430)" name="Comparator">
       <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(320,460)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
     </comp>
     <comp lib="0" loc="(820,390)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWriteEX"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="3" loc="(470,430)" name="Comparator">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(730,130)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1060,340)" name="Pin">
+    <comp lib="1" loc="(600,350)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1060,300)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="StallID"/>
+      <a name="label" val="StallIF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="3" loc="(470,350)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(540,270)" name="Pin">
+    <comp lib="0" loc="(1180,400)" name="Pin">
       <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="BubbleNum"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(820,310)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWriteMEM"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(510,270)" name="Pin">
+    <comp lib="1" loc="(600,510)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(760,330)" name="AND Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(340,130)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(320,340)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="1" loc="(980,320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="3" loc="(470,350)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="1" loc="(600,390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(600,470)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(50,300)" name="Pin">
       <a name="facing" val="south"/>
@@ -3823,12 +3193,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RT"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(1060,300)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(140,300)" name="Pin">
       <a name="facing" val="south"/>
       <a name="width" val="5"/>
@@ -3836,60 +3200,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RS"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(730,150)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="0" loc="(1030,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(730,130)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(320,340)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(410,300)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(660,370)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1100,440)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(980,320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(340,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(600,510)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(600,390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(1120,400)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="3" loc="(470,310)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
     <comp lib="1" loc="(920,120)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
@@ -3898,18 +3208,58 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(380,130)" name="Tunnel">
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="1" loc="(600,470)" name="AND Gate">
-      <a name="size" val="30"/>
+    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
+    <comp lib="0" loc="(410,300)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(740,450)" name="AND Gate">
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1210,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
     </comp>
     <comp lib="1" loc="(870,320)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
-    <comp lib="1" loc="(870,400)" name="AND Gate">
+    <comp lib="3" loc="(470,310)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="3" loc="(470,470)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="3" loc="(470,390)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(540,270)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(1190,230)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(660,490)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(320,460)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(510,270)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(410,420)" name="Constant">
       <a name="width" val="5"/>
@@ -3921,40 +3271,36 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="FlushIF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(740,450)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1190,230)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(760,330)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1210,240)" name="Pin">
+    <comp lib="0" loc="(1060,340)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="FlushID"/>
+      <a name="label" val="StallID"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(730,150)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
     <comp lib="3" loc="(470,510)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="0" loc="(1180,400)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="BubbleNum"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(1100,440)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="3" loc="(470,470)" name="Comparator">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(1030,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="1" loc="(600,350)" name="AND Gate">
-      <a name="size" val="30"/>
+    <comp lib="1" loc="(660,370)" name="OR Gate">
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(660,490)" name="OR Gate">
+    <comp lib="4" loc="(1120,400)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="1" loc="(870,400)" name="AND Gate">
+      <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
   </circuit>
@@ -4931,133 +4277,15 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(100,2410)" to="(490,2410)"/>
     <wire from="(160,2470)" to="(550,2470)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,4470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(710,1960)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
+      <a name="inputs" val="7"/>
     </comp>
     <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4470)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
-    </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(730,1960)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -5066,328 +4294,48 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct5"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2130)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,250)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
     <comp lib="1" loc="(410,950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
     <comp lib="1" loc="(520,2720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,430)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(600,2550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(600,2260)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,3020)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+    <comp lib="1" loc="(510,2290)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
+    <comp lib="1" loc="(410,550)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,230)" name="Pin">
@@ -5395,167 +4343,565 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
+    <comp lib="1" loc="(410,250)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+    <comp lib="1" loc="(510,2410)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,1050)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(520,4510)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,530)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+    <comp lib="1" loc="(510,2600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
+    <comp lib="1" loc="(410,690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(510,2560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,830)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="9"/>
     </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,3640)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2450)" name="NOT Gate">
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,1290)" name="AND Gate">
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2420)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,4260)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,530)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2130)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(690,4470)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="1" loc="(510,2450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,4470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(600,1610)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
   </circuit>
 </project>


### PR DESCRIPTION
This PR moves statistics component, which is responsible for counting the number of cycles for different instructions as well as the sum of them to the output, to the `common` folder. 

Pipelined MIPS-CPUs share this component.