### PR TITLE
Re-organize the apperance of ALU to remove ALU wrapper component.

### DIFF
--- a/src/common/alu.circ
+++ b/src/common/alu.circ
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project source="2.7.1" version="1.0">
-This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
-<lib desc="#Wiring" name="0">
+  This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
+
+  <lib desc="#Wiring" name="0">
     <tool name="Splitter">
       <a name="facing" val="north"/>
     </tool>
@@ -147,20 +148,20 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <polyline fill="none" points="71,140 130,112" stroke="#000000" stroke-width="2"/>
       <text font-family="SansSerif" font-size="12" text-anchor="middle" x="76" y="45">X</text>
       <text font-family="SansSerif" font-size="12" text-anchor="middle" x="75" y="125">Y</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="91" y="123">S</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="139" y="67">R</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="142" y="104">R2</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="107" y="116">=</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="90" y="48">OF</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="109" y="59">CF</text>
-      <circ-port height="8" pin="340,90" width="8" x="86" y="126"/>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="110" y="59">S</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="140" y="70">R</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="144" y="117">R2</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="90" y="44">=</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="90" y="120">OF</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="110" y="110">CF</text>
+      <circ-port height="8" pin="340,90" width="8" x="106" y="36"/>
       <circ-port height="8" pin="110,90" width="8" x="66" y="36"/>
-      <circ-port height="10" pin="680,110" width="10" x="105" y="115"/>
-      <circ-port height="10" pin="440,120" width="10" x="125" y="65"/>
-      <circ-port height="10" pin="680,50" width="10" x="85" y="25"/>
+      <circ-port height="10" pin="680,110" width="10" x="85" y="25"/>
+      <circ-port height="10" pin="440,120" width="10" x="125" y="75"/>
+      <circ-port height="10" pin="680,50" width="10" x="85" y="125"/>
       <circ-port height="8" pin="240,90" width="8" x="66" y="116"/>
-      <circ-port height="10" pin="560,120" width="10" x="125" y="85"/>
-      <circ-port height="10" pin="680,80" width="10" x="105" y="35"/>
+      <circ-port height="10" pin="560,120" width="10" x="125" y="95"/>
+      <circ-port height="10" pin="680,80" width="10" x="105" y="115"/>
       <circ-anchor facing="east" height="6" width="6" x="97" y="77"/>
     </appear>
     <wire from="(660,1220)" to="(660,1230)"/>
@@ -170,6 +171,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(580,1220)" to="(580,1230)"/>
     <wire from="(40,790)" to="(40,860)"/>
     <wire from="(780,860)" to="(780,870)"/>
+    <wire from="(530,1250)" to="(580,1250)"/>
     <wire from="(200,510)" to="(260,510)"/>
     <wire from="(70,420)" to="(70,490)"/>
     <wire from="(300,1110)" to="(670,1110)"/>
@@ -193,7 +195,9 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(70,560)" to="(260,560)"/>
     <wire from="(40,440)" to="(40,510)"/>
     <wire from="(70,630)" to="(70,700)"/>
+    <wire from="(480,1250)" to="(530,1250)"/>
     <wire from="(450,1220)" to="(450,1230)"/>
+    <wire from="(530,1250)" to="(530,1320)"/>
     <wire from="(270,800)" to="(270,820)"/>
     <wire from="(700,810)" to="(700,980)"/>
     <wire from="(40,790)" to="(260,790)"/>
@@ -247,7 +251,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(40,860)" to="(40,930)"/>
     <wire from="(70,490)" to="(70,560)"/>
     <wire from="(430,1220)" to="(430,1230)"/>
-    <wire from="(510,1250)" to="(510,1320)"/>
     <wire from="(350,1220)" to="(350,1230)"/>
     <wire from="(340,1210)" to="(340,1220)"/>
     <wire from="(280,590)" to="(280,610)"/>
@@ -264,7 +267,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(440,230)" to="(450,230)"/>
     <wire from="(390,1220)" to="(400,1220)"/>
     <wire from="(290,1040)" to="(300,1040)"/>
-    <wire from="(510,1250)" to="(580,1250)"/>
     <wire from="(40,440)" to="(180,440)"/>
     <wire from="(630,1220)" to="(640,1220)"/>
     <wire from="(710,1220)" to="(720,1220)"/>
@@ -370,7 +372,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(690,800)" to="(790,800)"/>
     <wire from="(40,930)" to="(260,930)"/>
     <wire from="(40,1170)" to="(260,1170)"/>
-    <wire from="(480,1250)" to="(510,1250)"/>
     <wire from="(710,1170)" to="(730,1170)"/>
     <wire from="(280,670)" to="(620,670)"/>
     <wire from="(110,90)" to="(130,90)"/>
@@ -385,64 +386,65 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(670,1220)" to="(680,1220)"/>
     <wire from="(40,1110)" to="(40,1170)"/>
     <wire from="(590,1220)" to="(600,1220)"/>
-    <comp lib="1" loc="(290,920)" name="OR Gate">
+    <comp lib="0" loc="(220,190)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="1" loc="(300,980)" name="XOR Gate">
       <a name="width" val="32"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(340,1210)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="3" loc="(300,1160)" name="Comparator">
-      <a name="width" val="32"/>
-      <a name="mode" val="unsigned"/>
-    </comp>
-    <comp lib="0" loc="(350,190)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp lib="0" loc="(70,330)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="2" loc="(830,800)" name="Multiplexer">
-      <a name="select" val="4"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(810,900)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="width" val="4"/>
       <a name="label" val="S"/>
     </comp>
-    <comp lib="2" loc="(660,1270)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="select" val="4"/>
+    <comp lib="0" loc="(560,130)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+      <a name="label" val="Result2"/>
     </comp>
-    <comp lib="0" loc="(440,120)" name="Pin">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(680,50)" name="Pin">
+      <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-      <a name="labelloc" val="north"/>
+      <a name="label" val="Signed Overflow"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="5" loc="(99,346)" name="Text"/>
+    <comp loc="(260,760)" name="32-bit Subtractor with Overflow Detection"/>
+    <comp lib="0" loc="(450,190)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(70,190)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
     </comp>
     <comp lib="0" loc="(40,330)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="width" val="32"/>
       <a name="label" val="Y"/>
     </comp>
-    <comp lib="5" loc="(752,245)" name="Text">
-      <a name="text" val="探测区域"/>
-      <a name="font" val="SansSerif bold 12"/>
+    <comp lib="0" loc="(130,90)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="X"/>
     </comp>
-    <comp lib="0" loc="(660,110)" name="Tunnel">
+    <comp lib="3" loc="(300,1100)" name="Comparator">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="5" loc="(681,250)" name="Text">
+      <a name="text" val="Debug"/>
+      <a name="font" val="SansSerif plain 24"/>
+    </comp>
+    <comp lib="0" loc="(600,190)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="Equal"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result2"/>
+    </comp>
+    <comp lib="0" loc="(450,230)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10unsigned"/>
     </comp>
     <comp lib="0" loc="(180,440)" name="Splitter">
       <a name="incoming" val="32"/>
@@ -479,36 +481,222 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(620,190)" name="Probe">
+    <comp loc="(260,690)" name="32-bit Adder with Overflow Detection"/>
+    <comp lib="0" loc="(650,80)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="CF"/>
+    </comp>
+    <comp lib="0" loc="(410,1330)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="CF"/>
+    </comp>
+    <comp lib="3" loc="(300,500)" name="Shifter">
+      <a name="width" val="32"/>
+      <a name="shift" val="lr"/>
+    </comp>
+    <comp lib="2" loc="(660,1270)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="select" val="4"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="3" loc="(300,570)" name="Multiplier">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="5" loc="(694,148)" name="Text">
+      <a name="text" val="Output"/>
+      <a name="font" val="SansSerif plain 24"/>
+    </comp>
+    <comp lib="0" loc="(560,120)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result 2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(350,90)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="S"/>
+    </comp>
+    <comp lib="0" loc="(430,190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+    </comp>
+    <comp lib="0" loc="(440,130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+    </comp>
+    <comp lib="0" loc="(680,110)" name="Pin">
       <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Equal"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(290,1040)" name="OR Gate">
+      <a name="width" val="32"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="1" loc="(290,850)" name="AND Gate">
       <a name="width" val="32"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
+    <comp lib="0" loc="(570,1220)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="5" loc="(269,422)" name="Text"/>
+    <comp lib="3" loc="(300,640)" name="Divider">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(220,230)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10unsigned"/>
+    </comp>
+    <comp lib="1" loc="(330,1040)" name="NOT Gate">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="5" loc="(308,53)" name="Text">
+      <a name="text" val="Input"/>
+      <a name="font" val="SansSerif plain 24"/>
+    </comp>
+    <comp lib="0" loc="(840,800)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+    </comp>
+    <comp lib="0" loc="(440,120)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(660,1330)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Result2"/>
+    </comp>
+    <comp lib="0" loc="(70,330)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="X"/>
+    </comp>
+    <comp lib="0" loc="(620,190)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10unsigned"/>
+    </comp>
+    <comp lib="0" loc="(330,190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="S"/>
+    </comp>
+    <comp lib="0" loc="(70,230)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10unsigned"/>
+    </comp>
+    <comp lib="3" loc="(300,1160)" name="Comparator">
+      <a name="width" val="32"/>
+      <a name="mode" val="unsigned"/>
+    </comp>
+    <comp lib="0" loc="(660,110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="0" loc="(330,750)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(200,190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Y"/>
+    </comp>
     <comp lib="0" loc="(380,1330)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="OF"/>
     </comp>
-    <comp loc="(260,760)" name="32位溢出检测减法"/>
-    <comp lib="0" loc="(450,230)" name="Probe">
+    <comp lib="0" loc="(110,90)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="X"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(290,920)" name="OR Gate">
+      <a name="width" val="32"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="3" loc="(300,430)" name="Shifter">
+      <a name="width" val="32"/>
+      <a name="shift" val="ar"/>
+    </comp>
+    <comp lib="0" loc="(50,190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="X"/>
+    </comp>
+    <comp lib="0" loc="(240,90)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Y"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(310,1160)" name="Tunnel">
+      <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="0" loc="(680,1210)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(830,800)" name="Multiplexer">
+      <a name="select" val="4"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(400,1270)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="select" val="4"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(350,190)" name="Probe">
       <a name="facing" val="west"/>
       <a name="radix" val="10unsigned"/>
+    </comp>
+    <comp lib="0" loc="(680,80)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="UnSigned Overflow"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(710,1110)" name="Bit Extender">
+      <a name="in_width" val="1"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="3" loc="(300,360)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(430,1210)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(260,90)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="Y"/>
+    </comp>
+    <comp lib="0" loc="(710,1170)" name="Bit Extender">
+      <a name="in_width" val="1"/>
+      <a name="out_width" val="32"/>
     </comp>
     <comp lib="0" loc="(650,50)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="OF"/>
-    </comp>
-    <comp lib="0" loc="(450,190)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(430,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
     </comp>
     <comp lib="0" loc="(180,370)" name="Splitter">
       <a name="incoming" val="32"/>
@@ -545,45 +733,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(130,90)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="0" loc="(220,190)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(790,950)" name="Constant">
-      <a name="facing" val="west"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(300,980)" name="XOR Gate">
-      <a name="width" val="32"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(300,360)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(110,90)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="X"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(220,230)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp lib="0" loc="(440,130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-    </comp>
-    <comp lib="3" loc="(300,570)" name="Multiplier">
-      <a name="width" val="32"/>
-    </comp>
     <comp lib="0" loc="(180,510)" name="Splitter">
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -619,197 +768,39 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(560,120)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result 2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="5" loc="(269,422)" name="Text"/>
-    <comp lib="2" loc="(400,1270)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="select" val="4"/>
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(330,750)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="5" loc="(191,153)" name="Text">
-      <a name="text" val="不要改变此引脚区域内容，也不要改变ALU封装形式"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(660,1330)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result2"/>
-    </comp>
-    <comp lib="0" loc="(330,820)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(510,1320)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="label" val="S"/>
-    </comp>
-    <comp lib="0" loc="(350,90)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="S"/>
-    </comp>
-    <comp lib="5" loc="(694,148)" name="Text">
-      <a name="text" val="输出引脚"/>
-      <a name="font" val="SansSerif bold 12"/>
-    </comp>
-    <comp lib="0" loc="(710,1170)" name="Bit Extender">
-      <a name="in_width" val="1"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(840,800)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-    </comp>
-    <comp lib="5" loc="(293,45)" name="Text">
-      <a name="text" val="输入引脚"/>
-      <a name="font" val="SansSerif bold 12"/>
-    </comp>
-    <comp lib="0" loc="(330,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="S"/>
-    </comp>
-    <comp lib="3" loc="(300,640)" name="Divider">
-      <a name="width" val="32"/>
-    </comp>
     <comp lib="0" loc="(340,90)" name="Pin">
       <a name="width" val="4"/>
       <a name="tristate" val="false"/>
       <a name="label" val="AluOP"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(680,50)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Signed Overflow"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(70,230)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp lib="5" loc="(384,291)" name="Text">
-      <a name="text" val="华中科技大学计算机学院 计算机组成原理，鸣谢加州大学伯克利CS61C课程"/>
-    </comp>
-    <comp lib="1" loc="(290,1040)" name="OR Gate">
-      <a name="width" val="32"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(650,80)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="CF"/>
-    </comp>
-    <comp lib="0" loc="(600,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result2"/>
-    </comp>
-    <comp lib="0" loc="(680,80)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="UnSigned Overflow"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="3" loc="(300,500)" name="Shifter">
-      <a name="width" val="32"/>
-      <a name="shift" val="lr"/>
-    </comp>
-    <comp lib="0" loc="(560,130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result2"/>
-    </comp>
-    <comp lib="0" loc="(70,190)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(430,1210)" name="Constant">
+    <comp lib="0" loc="(340,1210)" name="Constant">
       <a name="facing" val="south"/>
       <a name="width" val="2"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="3" loc="(300,430)" name="Shifter">
-      <a name="width" val="32"/>
-      <a name="shift" val="ar"/>
+    <comp lib="0" loc="(330,820)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(570,1220)" name="Constant">
+    <comp lib="0" loc="(790,950)" name="Constant">
+      <a name="facing" val="west"/>
       <a name="width" val="32"/>
       <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(310,1160)" name="Tunnel">
-      <a name="label" val="Equal"/>
-    </comp>
-    <comp lib="0" loc="(710,1110)" name="Bit Extender">
-      <a name="in_width" val="1"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(50,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="5" loc="(99,346)" name="Text"/>
-    <comp lib="1" loc="(330,1040)" name="NOT Gate">
-      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(400,1290)" name="Splitter">
       <a name="facing" val="south"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(240,90)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Y"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(680,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Equal"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(200,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Y"/>
-    </comp>
-    <comp lib="0" loc="(260,90)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="Y"/>
-    </comp>
-    <comp lib="0" loc="(680,1210)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp loc="(260,690)" name="32位溢出检测加法"/>
-    <comp lib="0" loc="(410,1330)" name="Tunnel">
+    <comp lib="0" loc="(530,1320)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="CF"/>
-    </comp>
-    <comp lib="3" loc="(300,1100)" name="Comparator">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="5" loc="(378,263)" name="Text">
-      <a name="text" val="请在下方利用上方输入输出引脚的隧道信号构建ALU电路，ctrl+d复制选择部件"/>
+      <a name="width" val="4"/>
+      <a name="label" val="S"/>
     </comp>
   </circuit>
-  <circuit name="32位溢出检测加法">
-    <a name="circuit" val="32位溢出检测加法"/>
-    <a name="clabel" val="加法器"/>
+  <circuit name="32-bit Adder with Overflow Detection">
+    <a name="circuit" val="32-bit Adder with Overflow Detection"/>
+    <a name="clabel" val="+"/>
     <a name="clabelup" val="north"/>
     <a name="clabelfont" val="SansSerif plain 12"/>
     <appear>
@@ -864,15 +855,88 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(90,290)" to="(100,290)"/>
     <wire from="(370,110)" to="(370,170)"/>
     <wire from="(170,110)" to="(170,170)"/>
+    <comp lib="0" loc="(550,330)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+    </comp>
+    <comp lib="0" loc="(790,110)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="OF"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(420,480)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="0" loc="(570,170)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(90,270)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="X"/>
+    </comp>
+    <comp lib="0" loc="(90,290)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="Y"/>
+    </comp>
+    <comp lib="0" loc="(190,110)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="X"/>
+    </comp>
+    <comp lib="3" loc="(300,270)" name="Adder">
+      <a name="width" val="31"/>
+    </comp>
+    <comp lib="0" loc="(510,330)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="1"/>
+    </comp>
+    <comp lib="0" loc="(810,110)" name="Tunnel">
+      <a name="label" val="OF"/>
+    </comp>
+    <comp lib="0" loc="(720,110)" name="Tunnel">
+      <a name="label" val="CF"/>
     </comp>
     <comp lib="0" loc="(250,410)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="CF"/>
     </comp>
-    <comp lib="0" loc="(100,290)" name="Splitter">
+    <comp lib="0" loc="(100,270)" name="Splitter">
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit1" val="0"/>
@@ -914,12 +978,42 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="Result of the operation"/>
       <a name="labelloc" val="north"/>
     </comp>
+    <comp lib="0" loc="(350,110)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Y"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(590,110)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="Result"/>
+    </comp>
     <comp lib="0" loc="(740,180)" name="Tunnel">
       <a name="label" val="cin"/>
+    </comp>
+    <comp lib="0" loc="(150,110)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="X"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(370,170)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(170,170)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
     </comp>
     <comp lib="0" loc="(390,110)" name="Tunnel">
       <a name="width" val="32"/>
       <a name="label" val="Y"/>
+    </comp>
+    <comp lib="0" loc="(700,180)" name="Pin">
+      <a name="tristate" val="false"/>
+    </comp>
+    <comp lib="3" loc="(300,370)" name="Adder">
+      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(700,110)" name="Pin">
       <a name="output" val="true"/>
@@ -927,65 +1021,11 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="CF"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(170,170)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
+    <comp lib="0" loc="(280,240)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="cin"/>
     </comp>
-    <comp lib="3" loc="(300,270)" name="Adder">
-      <a name="width" val="31"/>
-    </comp>
-    <comp lib="0" loc="(550,330)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-    </comp>
-    <comp lib="0" loc="(790,110)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="OF"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(90,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Y"/>
-    </comp>
-    <comp lib="0" loc="(100,270)" name="Splitter">
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="1"/>
-    </comp>
-    <comp lib="0" loc="(510,330)" name="Splitter">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(100,290)" name="Splitter">
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit1" val="0"/>
@@ -1023,59 +1063,10 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <comp lib="0" loc="(440,480)" name="Tunnel">
       <a name="label" val="OF"/>
     </comp>
-    <comp lib="0" loc="(350,110)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Y"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(720,110)" name="Tunnel">
-      <a name="label" val="CF"/>
-    </comp>
-    <comp lib="0" loc="(90,270)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="0" loc="(150,110)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="X"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(590,110)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-    </comp>
-    <comp lib="0" loc="(280,240)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="cin"/>
-    </comp>
-    <comp lib="1" loc="(420,480)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(300,370)" name="Adder">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(810,110)" name="Tunnel">
-      <a name="label" val="OF"/>
-    </comp>
-    <comp lib="0" loc="(190,110)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="0" loc="(370,170)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(700,180)" name="Pin">
-      <a name="tristate" val="false"/>
-    </comp>
   </circuit>
-  <circuit name="32位溢出检测减法">
-    <a name="circuit" val="32位溢出检测减法"/>
-    <a name="clabel" val="减法器"/>
+  <circuit name="32-bit Subtractor with Overflow Detection">
+    <a name="circuit" val="32-bit Subtractor with Overflow Detection"/>
+    <a name="clabel" val="-"/>
     <a name="clabelup" val="north"/>
     <a name="clabelfont" val="SansSerif plain 12"/>
     <appear>
@@ -1130,24 +1121,9 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(90,290)" to="(100,290)"/>
     <wire from="(370,110)" to="(370,170)"/>
     <wire from="(170,110)" to="(170,170)"/>
-    <comp lib="0" loc="(170,170)" name="Probe">
+    <comp lib="0" loc="(370,170)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(550,330)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-    </comp>
-    <comp lib="0" loc="(790,110)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="OF"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(90,290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Y"/>
     </comp>
     <comp lib="0" loc="(100,270)" name="Splitter">
       <a name="incoming" val="32"/>
@@ -1219,36 +1195,43 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit30" val="0"/>
       <a name="bit31" val="1"/>
     </comp>
-    <comp lib="0" loc="(550,110)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Result of the operation"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(280,240)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="bin"/>
-    </comp>
-    <comp lib="3" loc="(300,370)" name="Subtractor">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(740,180)" name="Tunnel">
-      <a name="label" val="bin"/>
-    </comp>
-    <comp lib="0" loc="(370,170)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
     <comp lib="1" loc="(420,480)" name="XOR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(720,110)" name="Tunnel">
+    <comp lib="0" loc="(810,110)" name="Tunnel">
+      <a name="label" val="OF"/>
+    </comp>
+    <comp lib="0" loc="(740,180)" name="Tunnel">
+      <a name="label" val="bin"/>
+    </comp>
+    <comp lib="0" loc="(790,110)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="OF"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(700,110)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="tristate" val="false"/>
       <a name="label" val="CF"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(150,110)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="X"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(440,480)" name="Tunnel">
       <a name="label" val="OF"/>
+    </comp>
+    <comp lib="0" loc="(720,110)" name="Tunnel">
+      <a name="label" val="CF"/>
+    </comp>
+    <comp lib="0" loc="(170,170)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
     </comp>
     <comp lib="0" loc="(510,330)" name="Splitter">
       <a name="facing" val="west"/>
@@ -1286,24 +1269,48 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit30" val="0"/>
       <a name="bit31" val="1"/>
     </comp>
-    <comp lib="0" loc="(390,110)" name="Tunnel">
+    <comp lib="0" loc="(550,110)" name="Pin">
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="Y"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Result of the operation"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(90,270)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="32"/>
       <a name="label" val="X"/>
     </comp>
+    <comp lib="0" loc="(250,410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="CF"/>
+    </comp>
+    <comp lib="3" loc="(300,370)" name="Subtractor">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="0" loc="(590,110)" name="Tunnel">
       <a name="width" val="32"/>
       <a name="label" val="Result"/>
     </comp>
-    <comp lib="0" loc="(150,110)" name="Pin">
+    <comp lib="0" loc="(90,290)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
+      <a name="label" val="Y"/>
+    </comp>
+    <comp lib="3" loc="(300,270)" name="Subtractor">
+      <a name="width" val="31"/>
+    </comp>
+    <comp lib="0" loc="(570,170)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(390,110)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="Y"/>
+    </comp>
+    <comp lib="0" loc="(190,110)" name="Tunnel">
+      <a name="width" val="32"/>
       <a name="label" val="X"/>
-      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(350,110)" name="Pin">
       <a name="width" val="32"/>
@@ -1314,456 +1321,13 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <comp lib="0" loc="(700,180)" name="Pin">
       <a name="tristate" val="false"/>
     </comp>
-    <comp lib="0" loc="(190,110)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="3" loc="(300,270)" name="Subtractor">
-      <a name="width" val="31"/>
-    </comp>
-    <comp lib="0" loc="(570,170)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(250,410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="CF"/>
-    </comp>
-    <comp lib="0" loc="(810,110)" name="Tunnel">
-      <a name="label" val="OF"/>
-    </comp>
-    <comp lib="0" loc="(700,110)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CF"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-  </circuit>
-  <circuit name="演示电路">
-    <a name="circuit" val="演示电路"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <wire from="(440,260)" to="(500,260)"/>
-    <wire from="(150,170)" to="(210,170)"/>
-    <wire from="(250,90)" to="(310,90)"/>
-    <wire from="(250,190)" to="(310,190)"/>
-    <wire from="(390,120)" to="(440,120)"/>
-    <wire from="(270,120)" to="(390,120)"/>
-    <wire from="(270,140)" to="(440,140)"/>
-    <wire from="(120,240)" to="(230,240)"/>
-    <wire from="(440,180)" to="(440,260)"/>
-    <wire from="(230,60)" to="(230,80)"/>
-    <wire from="(250,170)" to="(250,190)"/>
-    <wire from="(440,90)" to="(440,120)"/>
-    <wire from="(140,90)" to="(140,310)"/>
-    <wire from="(150,270)" to="(250,270)"/>
-    <wire from="(230,240)" to="(260,240)"/>
-    <wire from="(150,170)" to="(150,270)"/>
-    <wire from="(140,310)" to="(140,350)"/>
-    <wire from="(250,310)" to="(250,350)"/>
-    <wire from="(250,270)" to="(250,310)"/>
-    <wire from="(390,310)" to="(390,350)"/>
-    <wire from="(440,140)" to="(440,180)"/>
-    <wire from="(130,170)" to="(150,170)"/>
-    <wire from="(440,180)" to="(450,180)"/>
-    <wire from="(390,310)" to="(400,310)"/>
-    <wire from="(390,350)" to="(400,350)"/>
-    <wire from="(440,90)" to="(450,90)"/>
-    <wire from="(500,310)" to="(510,310)"/>
-    <wire from="(230,60)" to="(310,60)"/>
-    <wire from="(130,90)" to="(140,90)"/>
-    <wire from="(140,310)" to="(150,310)"/>
-    <wire from="(140,350)" to="(150,350)"/>
-    <wire from="(250,310)" to="(260,310)"/>
-    <wire from="(250,350)" to="(260,350)"/>
-    <wire from="(500,260)" to="(500,310)"/>
-    <wire from="(140,90)" to="(210,90)"/>
-    <wire from="(390,120)" to="(390,310)"/>
-    <wire from="(230,180)" to="(230,240)"/>
-    <comp lib="0" loc="(510,310)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="Result2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(150,350)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp lib="0" loc="(130,90)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="0" loc="(130,170)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Y"/>
-    </comp>
-    <comp lib="0" loc="(400,350)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp lib="0" loc="(400,310)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Result"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(150,310)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="X"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(120,240)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ALUOP"/>
-    </comp>
-    <comp lib="0" loc="(310,190)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Equal"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(260,240)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp loc="(240,130)" name="ALU"/>
-    <comp lib="0" loc="(260,310)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Y"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(310,90)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Unsigned overflow"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(450,90)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(550,330)" name="Tunnel">
       <a name="width" val="32"/>
       <a name="label" val="Result"/>
-      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(260,350)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10unsigned"/>
-    </comp>
-    <comp lib="0" loc="(310,60)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Signed Overflow"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(450,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result 2"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-  </circuit>
-  <circuit name="等差数列求和">
-    <a name="circuit" val="等差数列求和"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <wire from="(250,90)" to="(250,220)"/>
-    <wire from="(580,340)" to="(580,350)"/>
-    <wire from="(250,440)" to="(250,510)"/>
-    <wire from="(300,570)" to="(550,570)"/>
-    <wire from="(630,110)" to="(630,120)"/>
-    <wire from="(630,270)" to="(630,280)"/>
-    <wire from="(610,470)" to="(610,480)"/>
-    <wire from="(380,340)" to="(380,350)"/>
-    <wire from="(50,420)" to="(50,500)"/>
-    <wire from="(660,110)" to="(700,110)"/>
-    <wire from="(660,270)" to="(700,270)"/>
-    <wire from="(550,480)" to="(550,570)"/>
-    <wire from="(80,230)" to="(190,230)"/>
-    <wire from="(200,240)" to="(200,260)"/>
-    <wire from="(190,410)" to="(190,430)"/>
-    <wire from="(300,350)" to="(300,570)"/>
-    <wire from="(200,290)" to="(200,380)"/>
-    <wire from="(640,100)" to="(640,120)"/>
-    <wire from="(640,260)" to="(640,280)"/>
-    <wire from="(140,320)" to="(240,320)"/>
-    <wire from="(220,220)" to="(250,220)"/>
-    <wire from="(140,90)" to="(140,320)"/>
-    <wire from="(580,350)" to="(580,460)"/>
-    <wire from="(540,160)" to="(540,320)"/>
-    <wire from="(650,410)" to="(680,410)"/>
-    <wire from="(520,530)" to="(680,530)"/>
-    <wire from="(20,570)" to="(300,570)"/>
-    <wire from="(540,320)" to="(570,320)"/>
-    <wire from="(220,340)" to="(220,380)"/>
-    <wire from="(680,410)" to="(680,530)"/>
-    <wire from="(20,520)" to="(20,570)"/>
-    <wire from="(350,330)" to="(360,330)"/>
-    <wire from="(40,500)" to="(50,500)"/>
-    <wire from="(140,510)" to="(210,510)"/>
-    <wire from="(580,460)" to="(590,460)"/>
-    <wire from="(250,350)" to="(250,410)"/>
-    <wire from="(660,110)" to="(660,120)"/>
-    <wire from="(660,270)" to="(660,280)"/>
-    <wire from="(660,250)" to="(660,260)"/>
-    <wire from="(660,90)" to="(660,100)"/>
-    <wire from="(420,280)" to="(480,280)"/>
-    <wire from="(620,90)" to="(620,100)"/>
-    <wire from="(620,250)" to="(620,260)"/>
-    <wire from="(500,90)" to="(500,350)"/>
-    <wire from="(80,320)" to="(140,320)"/>
-    <wire from="(580,110)" to="(630,110)"/>
-    <wire from="(580,270)" to="(630,270)"/>
-    <wire from="(140,430)" to="(190,430)"/>
-    <wire from="(50,420)" to="(100,420)"/>
-    <wire from="(520,460)" to="(520,530)"/>
-    <wire from="(50,500)" to="(100,500)"/>
-    <wire from="(300,570)" to="(300,590)"/>
-    <wire from="(250,250)" to="(360,250)"/>
-    <wire from="(70,520)" to="(70,540)"/>
-    <wire from="(480,380)" to="(590,380)"/>
-    <wire from="(90,440)" to="(90,460)"/>
-    <wire from="(540,160)" to="(650,160)"/>
-    <wire from="(210,510)" to="(250,510)"/>
-    <wire from="(580,90)" to="(580,110)"/>
-    <wire from="(580,250)" to="(580,270)"/>
-    <wire from="(650,140)" to="(650,160)"/>
-    <wire from="(650,100)" to="(650,120)"/>
-    <wire from="(650,260)" to="(650,280)"/>
-    <wire from="(650,300)" to="(650,320)"/>
-    <wire from="(250,220)" to="(250,250)"/>
-    <wire from="(700,90)" to="(700,110)"/>
-    <wire from="(700,250)" to="(700,270)"/>
-    <wire from="(480,280)" to="(480,380)"/>
-    <wire from="(70,520)" to="(100,520)"/>
-    <wire from="(520,460)" to="(540,460)"/>
-    <wire from="(620,100)" to="(640,100)"/>
-    <wire from="(620,260)" to="(640,260)"/>
-    <wire from="(210,410)" to="(210,510)"/>
-    <wire from="(320,330)" to="(350,330)"/>
-    <wire from="(270,330)" to="(290,330)"/>
-    <wire from="(170,210)" to="(190,210)"/>
-    <wire from="(220,340)" to="(240,340)"/>
-    <wire from="(580,320)" to="(650,320)"/>
-    <wire from="(350,90)" to="(350,330)"/>
-    <wire from="(500,350)" to="(580,350)"/>
-    <wire from="(90,440)" to="(100,440)"/>
-    <wire from="(570,460)" to="(580,460)"/>
-    <wire from="(650,100)" to="(660,100)"/>
-    <wire from="(650,260)" to="(660,260)"/>
-    <wire from="(220,380)" to="(480,380)"/>
-    <comp lib="1" loc="(200,260)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(80,320)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Initial Value"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(140,90)" name="Probe">
+    <comp lib="0" loc="(280,240)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Initial Value"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="6" loc="(580,90)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="6" loc="(700,250)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="4" loc="(40,500)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="trigger" val="falling"/>
-      <a name="label" val="Count"/>
-    </comp>
-    <comp lib="2" loc="(270,330)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(660,250)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="0" loc="(650,140)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-    </comp>
-    <comp lib="6" loc="(620,90)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="0" loc="(90,460)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(610,480)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="value" val="0x5"/>
-    </comp>
-    <comp lib="0" loc="(350,90)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Current Number"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(650,300)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-    </comp>
-    <comp loc="(620,420)" name="ALU"/>
-    <comp lib="0" loc="(80,230)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Difference Value"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(250,410)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(380,350)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="value" val="0x5"/>
-    </comp>
-    <comp lib="4" loc="(320,330)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Current Number"/>
-    </comp>
-    <comp lib="3" loc="(140,430)" name="Comparator">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="3" loc="(140,510)" name="Comparator">
-      <a name="width" val="32"/>
-    </comp>
-    <comp loc="(390,290)" name="ALU"/>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Sum"/>
-    </comp>
-    <comp lib="1" loc="(200,380)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(500,90)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Sum"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="6" loc="(620,250)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="0" loc="(70,540)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(220,220)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(660,90)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="6" loc="(700,90)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="0" loc="(170,210)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(300,590)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(250,90)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Difference Value"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="6" loc="(580,250)" name="Hex Digit Display">
-      <a name="offcolor" val="#ffffff"/>
-    </comp>
-    <comp lib="0" loc="(580,340)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="1"/>
-      <a name="bit29" val="1"/>
-      <a name="bit30" val="1"/>
-      <a name="bit31" val="1"/>
+      <a name="label" val="bin"/>
     </comp>
   </circuit>
 </project>

--- a/src/pipeline_cpu.circ
+++ b/src/pipeline_cpu.circ
@@ -53,7 +53,7 @@
   </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
-      <a name="width" val="32"/>
+      <a name="select" val="3"/>
     </tool>
     <tool name="Demultiplexer">
       <a name="select" val="5"/>
@@ -78,7 +78,7 @@
   </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
-      <a name="width" val="32"/>
+      <a name="width" val="16"/>
     </tool>
     <tool name="ROM">
       <a name="contents">addr/data: 8 8
@@ -729,7 +729,6 @@
       <a name="facing" val="south"/>
       <a name="label" val="IsCOP0"/>
     </comp>
-    <comp loc="(1670,590)" name="ALU_Wrapper"/>
     <comp lib="5" loc="(670,180)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
@@ -991,6 +990,7 @@
     <comp lib="0" loc="(250,1300)" name="Tunnel">
       <a name="label" val="Halt"/>
     </comp>
+    <comp lib="7" loc="(1670,590)" name="ALU"/>
     <comp lib="0" loc="(870,1320)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="ReadRs"/>
@@ -3329,71 +3329,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
       <a name="labelloc" val="south"/>
-    </comp>
-  </circuit>
-  <circuit name="ALU_Wrapper">
-    <a name="circuit" val="ALU_Wrapper"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <polyline fill="none" points="142,251 142,212" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="142,171 142,131" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="143,131 202,163" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="202,164 202,222" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="153,183 153,201" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="153,182 143,172" stroke="#000000" stroke-width="2"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="159" y="155">=</text>
-      <polyline fill="none" points="143,251 202,223" stroke="#000000" stroke-width="2"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="148" y="156">X</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="209" y="184">R</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="147" y="236">Y</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="180" y="168">S</text>
-      <polyline fill="none" points="143,211 153,201" stroke="#000000" stroke-width="2"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="176" y="196">ALU</text>
-      <circ-port height="8" pin="560,400" width="8" x="136" y="146"/>
-      <circ-port height="8" pin="560,480" width="8" x="136" y="226"/>
-      <circ-port height="8" pin="630,540" width="8" x="176" y="146"/>
-      <circ-port height="10" pin="680,500" width="10" x="155" y="135"/>
-      <circ-port height="10" pin="750,430" width="10" x="195" y="185"/>
-      <circ-anchor facing="east" height="6" width="6" x="167" y="187"/>
-    </appear>
-    <wire from="(560,400)" to="(610,400)"/>
-    <wire from="(560,480)" to="(610,480)"/>
-    <wire from="(650,500)" to="(680,500)"/>
-    <wire from="(670,430)" to="(750,430)"/>
-    <wire from="(630,490)" to="(630,540)"/>
-    <wire from="(650,480)" to="(650,500)"/>
-    <comp lib="0" loc="(630,540)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="AluOP"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(560,480)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Y"/>
-    </comp>
-    <comp lib="7" loc="(640,440)" name="ALU"/>
-    <comp lib="0" loc="(680,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Equal"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(750,430)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(560,400)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="X"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">

--- a/src/pipeline_cpu_bubbling.circ
+++ b/src/pipeline_cpu_bubbling.circ
@@ -53,7 +53,7 @@
   </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
-      <a name="width" val="32"/>
+      <a name="select" val="3"/>
     </tool>
     <tool name="Demultiplexer">
       <a name="select" val="5"/>
@@ -78,7 +78,7 @@
   </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
-      <a name="width" val="32"/>
+      <a name="width" val="16"/>
     </tool>
     <tool name="ROM">
       <a name="contents">addr/data: 8 8
@@ -141,8 +141,8 @@
     <a name="clabelfont" val="SansSerif plain 12"/>
     <wire from="(2100,420)" to="(2100,450)"/>
     <wire from="(1930,180)" to="(1970,180)"/>
-    <wire from="(1330,380)" to="(1330,600)"/>
     <wire from="(1350,160)" to="(1350,380)"/>
+    <wire from="(1330,380)" to="(1330,600)"/>
     <wire from="(180,60)" to="(1130,60)"/>
     <wire from="(100,510)" to="(100,710)"/>
     <wire from="(670,620)" to="(670,690)"/>
@@ -159,8 +159,8 @@
     <wire from="(380,220)" to="(380,250)"/>
     <wire from="(1440,920)" to="(1450,920)"/>
     <wire from="(1420,360)" to="(1420,540)"/>
-    <wire from="(1310,630)" to="(1320,630)"/>
     <wire from="(540,360)" to="(540,530)"/>
+    <wire from="(1310,630)" to="(1320,630)"/>
     <wire from="(520,550)" to="(540,550)"/>
     <wire from="(1120,280)" to="(1130,280)"/>
     <wire from="(2060,580)" to="(2070,580)"/>
@@ -569,7 +569,6 @@
     <comp lib="6" loc="(692,230)" name="Text">
       <a name="text" val="OP"/>
     </comp>
-    <comp loc="(1410,580)" name="ALU_Wrapper"/>
     <comp lib="0" loc="(420,720)" name="Probe">
       <a name="facing" val="south"/>
       <a name="radix" val="10signed"/>
@@ -1118,6 +1117,7 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="32"/>
       <a name="label" val="PC"/>
     </comp>
+    <comp lib="7" loc="(1410,580)" name="ALU"/>
     <comp lib="0" loc="(670,840)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -2769,71 +2769,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="R1"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-  </circuit>
-  <circuit name="ALU_Wrapper">
-    <a name="circuit" val="ALU_Wrapper"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <polyline fill="none" points="142,251 142,212" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="142,171 142,131" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="143,131 202,163" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="202,164 202,222" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="153,183 153,201" stroke="#000000" stroke-width="2"/>
-      <polyline fill="none" points="153,182 143,172" stroke="#000000" stroke-width="2"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="159" y="155">=</text>
-      <polyline fill="none" points="143,251 202,223" stroke="#000000" stroke-width="2"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="148" y="156">X</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="209" y="184">R</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="147" y="236">Y</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="180" y="168">S</text>
-      <polyline fill="none" points="143,211 153,201" stroke="#000000" stroke-width="2"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="176" y="196">ALU</text>
-      <circ-port height="8" pin="560,400" width="8" x="136" y="146"/>
-      <circ-port height="8" pin="560,480" width="8" x="136" y="226"/>
-      <circ-port height="8" pin="630,540" width="8" x="176" y="146"/>
-      <circ-port height="10" pin="680,500" width="10" x="155" y="135"/>
-      <circ-port height="10" pin="750,430" width="10" x="195" y="185"/>
-      <circ-anchor facing="east" height="6" width="6" x="167" y="187"/>
-    </appear>
-    <wire from="(560,400)" to="(610,400)"/>
-    <wire from="(560,480)" to="(610,480)"/>
-    <wire from="(650,500)" to="(680,500)"/>
-    <wire from="(670,430)" to="(750,430)"/>
-    <wire from="(630,490)" to="(630,540)"/>
-    <wire from="(650,480)" to="(650,500)"/>
-    <comp lib="0" loc="(630,540)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="AluOP"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(750,430)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Result"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(560,400)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="X"/>
-    </comp>
-    <comp lib="0" loc="(560,480)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Y"/>
-    </comp>
-    <comp lib="7" loc="(640,440)" name="ALU"/>
-    <comp lib="0" loc="(680,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Equal"/>
       <a name="labelloc" val="east"/>
     </comp>
   </circuit>

--- a/src/single_cycle_cpu.circ
+++ b/src/single_cycle_cpu.circ
@@ -53,7 +53,7 @@
   </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
-      <a name="width" val="32"/>
+      <a name="select" val="3"/>
     </tool>
     <tool name="Demultiplexer">
       <a name="select" val="5"/>
@@ -78,7 +78,7 @@
   </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
-      <a name="width" val="32"/>
+      <a name="width" val="16"/>
     </tool>
     <tool name="ROM">
       <a name="contents">addr/data: 8 8
@@ -144,7 +144,9 @@
     <wire from="(1130,580)" to="(1130,790)"/>
     <wire from="(1150,510)" to="(1150,530)"/>
     <wire from="(1230,110)" to="(1230,130)"/>
+    <wire from="(1450,570)" to="(1450,600)"/>
     <wire from="(200,680)" to="(200,690)"/>
+    <wire from="(1520,480)" to="(1520,510)"/>
     <wire from="(950,370)" to="(950,500)"/>
     <wire from="(1330,380)" to="(1370,380)"/>
     <wire from="(540,570)" to="(540,660)"/>
@@ -168,17 +170,16 @@
     <wire from="(40,550)" to="(60,550)"/>
     <wire from="(1610,130)" to="(1620,130)"/>
     <wire from="(1290,330)" to="(1290,390)"/>
+    <wire from="(1320,550)" to="(1320,660)"/>
+    <wire from="(1520,510)" to="(1540,510)"/>
     <wire from="(1370,330)" to="(1370,370)"/>
     <wire from="(520,560)" to="(530,560)"/>
-    <wire from="(1570,510)" to="(1610,510)"/>
     <wire from="(1100,340)" to="(1210,340)"/>
     <wire from="(630,840)" to="(630,850)"/>
     <wire from="(790,920)" to="(790,930)"/>
     <wire from="(820,1030)" to="(820,1040)"/>
     <wire from="(120,570)" to="(120,580)"/>
     <wire from="(1370,380)" to="(1370,410)"/>
-    <wire from="(1390,560)" to="(1390,590)"/>
-    <wire from="(1500,520)" to="(1540,520)"/>
     <wire from="(380,270)" to="(380,280)"/>
     <wire from="(560,220)" to="(600,220)"/>
     <wire from="(1530,330)" to="(1530,400)"/>
@@ -209,16 +210,15 @@
     <wire from="(690,950)" to="(690,960)"/>
     <wire from="(1410,390)" to="(1410,410)"/>
     <wire from="(1150,530)" to="(1150,550)"/>
-    <wire from="(1610,510)" to="(1610,1040)"/>
     <wire from="(80,980)" to="(80,990)"/>
     <wire from="(1400,380)" to="(1400,410)"/>
     <wire from="(800,570)" to="(800,890)"/>
+    <wire from="(1320,550)" to="(1360,550)"/>
     <wire from="(630,580)" to="(670,580)"/>
     <wire from="(950,660)" to="(950,880)"/>
     <wire from="(1180,150)" to="(1240,150)"/>
     <wire from="(1400,380)" to="(1450,380)"/>
     <wire from="(450,180)" to="(450,270)"/>
-    <wire from="(1550,530)" to="(1550,540)"/>
     <wire from="(600,220)" to="(600,240)"/>
     <wire from="(1300,120)" to="(1350,120)"/>
     <wire from="(930,260)" to="(930,340)"/>
@@ -228,7 +228,6 @@
     <wire from="(850,580)" to="(870,580)"/>
     <wire from="(900,140)" to="(900,570)"/>
     <wire from="(320,120)" to="(350,120)"/>
-    <wire from="(1330,470)" to="(1330,520)"/>
     <wire from="(480,160)" to="(480,320)"/>
     <wire from="(690,90)" to="(720,90)"/>
     <wire from="(740,80)" to="(1410,80)"/>
@@ -251,18 +250,17 @@
     <wire from="(930,340)" to="(930,480)"/>
     <wire from="(1620,40)" to="(1620,130)"/>
     <wire from="(800,1030)" to="(800,1040)"/>
-    <wire from="(1450,560)" to="(1450,590)"/>
     <wire from="(280,890)" to="(280,1030)"/>
     <wire from="(110,740)" to="(110,750)"/>
     <wire from="(870,530)" to="(930,530)"/>
-    <wire from="(1520,470)" to="(1520,500)"/>
     <wire from="(950,500)" to="(1140,500)"/>
-    <wire from="(1230,580)" to="(1230,610)"/>
     <wire from="(280,890)" to="(400,890)"/>
     <wire from="(290,200)" to="(290,220)"/>
     <wire from="(360,190)" to="(360,210)"/>
     <wire from="(70,1020)" to="(70,1040)"/>
+    <wire from="(1330,480)" to="(1520,480)"/>
     <wire from="(180,730)" to="(180,750)"/>
+    <wire from="(1270,530)" to="(1330,530)"/>
     <wire from="(820,570)" to="(820,590)"/>
     <wire from="(1250,760)" to="(1250,770)"/>
     <wire from="(1210,450)" to="(1390,450)"/>
@@ -274,7 +272,6 @@
     <wire from="(650,420)" to="(680,420)"/>
     <wire from="(650,180)" to="(680,180)"/>
     <wire from="(650,260)" to="(680,260)"/>
-    <wire from="(1320,540)" to="(1320,660)"/>
     <wire from="(160,670)" to="(170,670)"/>
     <wire from="(100,1010)" to="(110,1010)"/>
     <wire from="(120,630)" to="(130,630)"/>
@@ -282,7 +279,6 @@
     <wire from="(210,550)" to="(280,550)"/>
     <wire from="(1390,370)" to="(1410,370)"/>
     <wire from="(950,550)" to="(1090,550)"/>
-    <wire from="(1520,500)" to="(1540,500)"/>
     <wire from="(770,560)" to="(780,560)"/>
     <wire from="(750,1020)" to="(760,1020)"/>
     <wire from="(280,140)" to="(350,140)"/>
@@ -297,7 +293,7 @@
     <wire from="(1360,150)" to="(1360,220)"/>
     <wire from="(280,1030)" to="(390,1030)"/>
     <wire from="(570,240)" to="(570,320)"/>
-    <wire from="(1250,570)" to="(1250,580)"/>
+    <wire from="(1230,470)" to="(1230,480)"/>
     <wire from="(1100,580)" to="(1100,590)"/>
     <wire from="(590,790)" to="(1020,790)"/>
     <wire from="(570,530)" to="(570,550)"/>
@@ -307,6 +303,7 @@
     <wire from="(930,480)" to="(1140,480)"/>
     <wire from="(320,660)" to="(540,660)"/>
     <wire from="(670,950)" to="(670,990)"/>
+    <wire from="(1330,530)" to="(1340,530)"/>
     <wire from="(1330,330)" to="(1330,380)"/>
     <wire from="(820,1040)" to="(1610,1040)"/>
     <wire from="(1490,330)" to="(1490,390)"/>
@@ -322,7 +319,6 @@
     <wire from="(680,690)" to="(680,700)"/>
     <wire from="(430,890)" to="(610,890)"/>
     <wire from="(80,730)" to="(80,740)"/>
-    <wire from="(1320,540)" to="(1360,540)"/>
     <wire from="(40,40)" to="(1620,40)"/>
     <wire from="(1250,330)" to="(1250,400)"/>
     <wire from="(120,610)" to="(120,630)"/>
@@ -348,11 +344,13 @@
     <wire from="(720,530)" to="(730,530)"/>
     <wire from="(310,270)" to="(380,270)"/>
     <wire from="(580,790)" to="(590,790)"/>
+    <wire from="(1250,490)" to="(1270,490)"/>
+    <wire from="(1570,520)" to="(1610,520)"/>
     <wire from="(1440,140)" to="(1440,160)"/>
     <wire from="(70,680)" to="(130,680)"/>
+    <wire from="(1390,570)" to="(1390,600)"/>
+    <wire from="(1500,530)" to="(1540,530)"/>
     <wire from="(160,220)" to="(160,240)"/>
-    <wire from="(1330,470)" to="(1520,470)"/>
-    <wire from="(1270,520)" to="(1330,520)"/>
     <wire from="(430,170)" to="(430,200)"/>
     <wire from="(570,320)" to="(570,530)"/>
     <wire from="(930,340)" to="(1040,340)"/>
@@ -382,12 +380,14 @@
     <wire from="(1170,490)" to="(1210,490)"/>
     <wire from="(1170,570)" to="(1210,570)"/>
     <wire from="(410,180)" to="(410,320)"/>
+    <wire from="(1230,470)" to="(1270,470)"/>
     <wire from="(1410,80)" to="(1410,110)"/>
     <wire from="(590,530)" to="(650,530)"/>
     <wire from="(930,260)" to="(1570,260)"/>
     <wire from="(900,570)" to="(1090,570)"/>
     <wire from="(570,790)" to="(570,860)"/>
     <wire from="(1250,400)" to="(1350,400)"/>
+    <wire from="(1610,520)" to="(1610,1040)"/>
     <wire from="(390,130)" to="(690,130)"/>
     <wire from="(190,570)" to="(190,650)"/>
     <wire from="(770,560)" to="(770,590)"/>
@@ -395,11 +395,12 @@
     <wire from="(1380,130)" to="(1430,130)"/>
     <wire from="(1080,310)" to="(1080,320)"/>
     <wire from="(120,630)" to="(120,660)"/>
+    <wire from="(1550,540)" to="(1550,550)"/>
     <wire from="(1440,190)" to="(1440,200)"/>
     <wire from="(290,220)" to="(510,220)"/>
     <wire from="(1350,220)" to="(1360,220)"/>
-    <wire from="(1330,520)" to="(1340,520)"/>
     <wire from="(1100,370)" to="(1110,370)"/>
+    <wire from="(1330,480)" to="(1330,530)"/>
     <wire from="(650,380)" to="(680,380)"/>
     <wire from="(650,460)" to="(680,460)"/>
     <wire from="(1280,140)" to="(1350,140)"/>
@@ -508,43 +509,6 @@
       <a name="facing" val="north"/>
       <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(1340,520)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
     <comp lib="4" loc="(500,480)" name="ROM">
       <a name="addrWidth" val="9"/>
       <a name="dataWidth" val="32"/>
@@ -629,6 +593,43 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit29" val="2"/>
       <a name="bit30" val="2"/>
       <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1340,530)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
     <comp lib="2" loc="(810,1000)" name="Multiplexer">
       <a name="facing" val="north"/>
@@ -739,11 +740,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit29" val="0"/>
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="4" loc="(1500,520)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
     </comp>
     <comp lib="0" loc="(1120,240)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -914,10 +910,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(680,400)" name="Tunnel">
       <a name="label" val="IsShamt"/>
     </comp>
-    <comp lib="2" loc="(1570,510)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
     <comp lib="4" loc="(210,550)" name="Register">
       <a name="width" val="32"/>
       <a name="label" val="PC"/>
@@ -1014,6 +1006,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="1" loc="(200,690)" name="NOT Gate">
       <a name="facing" val="north"/>
     </comp>
+    <comp lib="0" loc="(1450,600)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemRead"/>
+    </comp>
     <comp lib="5" loc="(1490,330)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
@@ -1031,10 +1027,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(70,1040)" name="Clock">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(1390,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemWrite"/>
-    </comp>
     <comp lib="0" loc="(220,320)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10signed"/>
@@ -1047,10 +1039,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(910,910)" name="Tunnel">
       <a name="label" val="IsCOP0"/>
     </comp>
-    <comp lib="0" loc="(1430,560)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
     <comp lib="4" loc="(470,160)" name="Counter">
       <a name="width" val="32"/>
       <a name="max" val="0xffffffff"/>
@@ -1062,6 +1050,7 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(680,320)" name="Tunnel">
       <a name="label" val="BneOrBeq"/>
     </comp>
+    <comp lib="7" loc="(1240,530)" name="ALU"/>
     <comp lib="0" loc="(480,320)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10unsigned"/>
@@ -1075,6 +1064,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(570,940)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1550,550)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemtoReg"/>
     </comp>
     <comp lib="5" loc="(1300,760)" name="Button">
       <a name="facing" val="south"/>
@@ -1091,6 +1084,9 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit4" val="1"/>
       <a name="bit5" val="0"/>
     </comp>
+    <comp lib="0" loc="(1270,470)" name="Tunnel">
+      <a name="label" val="Equal"/>
+    </comp>
     <comp lib="0" loc="(1250,770)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="ExpSrc0"/>
@@ -1103,7 +1099,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="2"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="7" loc="(1240,530)" name="ALU"/>
     <comp lib="0" loc="(130,630)" name="Tunnel">
       <a name="label" val="HasExp"/>
     </comp>
@@ -1121,6 +1116,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(660,840)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1270,490)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUop"/>
     </comp>
     <comp lib="0" loc="(570,790)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1174,6 +1173,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     </comp>
     <comp lib="0" loc="(680,220)" name="Tunnel">
       <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="2" loc="(1570,520)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(630,840)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -1310,10 +1313,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="facing" val="south"/>
       <a name="label" val="ZeroExtend"/>
     </comp>
-    <comp lib="0" loc="(1250,580)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Equal"/>
-    </comp>
     <comp lib="0" loc="(740,620)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="IsSyscall"/>
@@ -1359,10 +1358,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit29" val="0"/>
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1550,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemtoReg"/>
     </comp>
     <comp lib="2" loc="(80,990)" name="Multiplexer">
       <a name="facing" val="north"/>
@@ -1425,6 +1420,10 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
+    <comp lib="0" loc="(1390,600)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemWrite"/>
+    </comp>
     <comp lib="0" loc="(720,960)" name="Tunnel">
       <a name="label" val="ExpBlock"/>
     </comp>
@@ -1436,6 +1435,10 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
     <comp lib="0" loc="(1120,220)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="0" loc="(1430,570)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(1590,200)" name="Tunnel">
       <a name="facing" val="north"/>
@@ -1453,6 +1456,11 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
     </comp>
     <comp lib="3" loc="(390,130)" name="Adder">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(1500,530)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
     </comp>
     <comp lib="4" loc="(430,890)" name="Register">
       <a name="width" val="32"/>
@@ -1507,11 +1515,6 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
     <comp lib="0" loc="(680,240)" name="Tunnel">
       <a name="label" val="MemWrite"/>
     </comp>
-    <comp lib="0" loc="(1230,610)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-    </comp>
     <comp lib="0" loc="(750,1020)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="IsJAL"/>
@@ -1519,10 +1522,6 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
     <comp lib="0" loc="(410,950)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(1450,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemRead"/>
     </comp>
     <comp lib="2" loc="(1120,560)" name="Multiplexer">
       <a name="width" val="32"/>


### PR DESCRIPTION
I could not change the given appearance of the ALU due to course requirement. In order to have a decently clean organization of pipelined CPUs, I had to create an ALU wrapper component that wraps the ALU and expose the desired appearance. Obviously, this is not the case anymore and this PR simply fixed the appearance for easier wire management in pipelined CPUs:

<img width="104" alt="Screenshot 2022-07-16 at 8 11 49 PM" src="https://user-images.githubusercontent.com/10323518/179375799-482e0ff3-58d8-4296-9dd2-4adbc94438cb.png">

The ALU_Wrapper component in pipelined CPUs are therefore removed for simplicity.

Additionally, the wiring in the single cycle CPU is updated to match the new appearance of this ALU.