### PR TITLE
Remove regfile wrappers.

### DIFF
--- a/src/common/regfile.circ
+++ b/src/common/regfile.circ
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project source="2.7.1" version="1.0">
-This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
-<lib desc="#Wiring" name="0">
+  This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
+
+  <lib desc="#Wiring" name="0">
     <tool name="Splitter">
       <a name="facing" val="north"/>
     </tool>
@@ -24,8 +25,32 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <tool name="Constant">
       <a name="value" val="0x0"/>
     </tool>
+    <tool name="Bit Extender">
+      <a name="type" val="sign"/>
+    </tool>
   </lib>
-  <lib desc="#Gates" name="1"/>
+  <lib desc="#Gates" name="1">
+    <tool name="Buffer">
+      <a name="width" val="3"/>
+    </tool>
+    <tool name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="OR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="NOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="XOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="Odd Parity">
+      <a name="facing" val="south"/>
+      <a name="inputs" val="3"/>
+    </tool>
+  </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
       <a name="width" val="32"/>
@@ -34,7 +59,23 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="select" val="5"/>
     </tool>
   </lib>
-  <lib desc="#Arithmetic" name="3"/>
+  <lib desc="#Arithmetic" name="3">
+    <tool name="Subtractor">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Multiplier">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Divider">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Negator">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Comparator">
+      <a name="width" val="32"/>
+    </tool>
+  </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
       <a name="width" val="32"/>
@@ -54,7 +95,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="valign" val="base"/>
     </tool>
   </lib>
-  <main name="main"/>
+  <main name="Regfile"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
     <a name="simlimit" val="1000"/>
@@ -76,575 +117,776 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     </tool>
     <sep/>
     <tool lib="0" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
       <a name="tristate" val="false"/>
     </tool>
     <tool lib="0" name="Pin">
-      <a name="facing" val="south"/>
+      <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="16"/>
       <a name="labelloc" val="east"/>
     </tool>
-    <tool lib="1" name="NOT Gate">
-      <a name="size" val="20"/>
-    </tool>
+    <tool lib="1" name="NOT Gate"/>
     <tool lib="1" name="AND Gate"/>
-    <tool lib="1" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </tool>
+    <tool lib="1" name="OR Gate"/>
   </toolbar>
-  <circuit name="main">
-    <a name="circuit" val="main"/>
+  <circuit name="Regfile">
+    <a name="circuit" val="Regfile"/>
     <a name="clabel" val=""/>
     <a name="clabelup" val="east"/>
     <a name="clabelfont" val="SansSerif plain 12"/>
     <appear>
-      <rect fill="none" height="59" stroke="#000000" stroke-width="2" width="89" x="51" y="51"/>
-      <polyline fill="none" points="123,109 120,106" stroke="#000000"/>
-      <polyline fill="none" points="117,109 120,106" stroke="#000000"/>
-      <text font-family="SansSerif" font-size="12" font-weight="bold" text-anchor="middle" x="103" y="83">RegFile</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="65" y="66">R1#</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="65" y="84">R2#</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="63" y="100">RW</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="71" y="108">Din</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="99" y="109">WE</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="131" y="71">R1</text>
-      <text font-family="SansSerif" font-size="10" text-anchor="middle" x="130" y="95">R2</text>
-      <circ-port height="8" pin="130,40" width="8" x="46" y="56"/>
-      <circ-port height="8" pin="130,70" width="8" x="46" y="76"/>
-      <circ-port height="8" pin="130,100" width="8" x="46" y="96"/>
-      <circ-port height="8" pin="130,160" width="8" x="66" y="106"/>
-      <circ-port height="8" pin="130,220" width="8" x="86" y="106"/>
-      <circ-port height="8" pin="130,250" width="8" x="116" y="106"/>
-      <circ-port height="10" pin="300,80" width="10" x="135" y="65"/>
-      <circ-port height="10" pin="300,180" width="10" x="135" y="85"/>
-      <circ-port height="10" pin="560,150" width="10" x="65" y="45"/>
-      <circ-port height="10" pin="650,150" width="10" x="105" y="45"/>
-      <circ-port height="10" pin="740,150" width="10" x="125" y="45"/>
-      <circ-port height="10" pin="470,150" width="10" x="85" y="45"/>
-      <circ-anchor facing="east" height="6" width="6" x="137" y="77"/>
+      <rect fill="#b4ff80" height="120" stroke="none" width="108" x="240" y="160"/>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="257" y="255">RW</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="258" y="275">Din</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="337" y="215">R1</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="336" y="231">R2</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="258" y="184">R1#</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="259" y="225">R2#</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="300" y="177">clk</text>
+      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="328" y="175">WE</text>
+      <text font-family="SansSerif" font-size="16" font-weight="bold" text-anchor="middle" x="318" y="272">RegFile</text>
+      <circ-port height="8" pin="140,40" width="8" x="236" y="176"/>
+      <circ-port height="8" pin="140,70" width="8" x="236" y="216"/>
+      <circ-port height="8" pin="140,100" width="8" x="236" y="246"/>
+      <circ-port height="10" pin="340,80" width="10" x="345" y="205"/>
+      <circ-port height="10" pin="340,180" width="10" x="345" y="225"/>
+      <circ-port height="8" pin="140,160" width="8" x="236" y="266"/>
+      <circ-port height="8" pin="140,220" width="8" x="326" y="156"/>
+      <circ-port height="8" pin="140,260" width="8" x="296" y="156"/>
+      <circ-port height="10" pin="540,180" width="10" x="255" y="155"/>
+      <circ-port height="10" pin="540,80" width="10" x="275" y="155"/>
+      <circ-anchor facing="east" height="6" width="6" x="237" y="157"/>
     </appear>
-    <wire from="(1320,280)" to="(1320,810)"/>
-    <wire from="(640,350)" to="(640,420)"/>
-    <wire from="(910,750)" to="(1010,750)"/>
-    <wire from="(250,690)" to="(490,690)"/>
-    <wire from="(580,1220)" to="(680,1220)"/>
-    <wire from="(410,440)" to="(410,520)"/>
-    <wire from="(540,570)" to="(540,650)"/>
-    <wire from="(410,1210)" to="(510,1210)"/>
-    <wire from="(710,900)" to="(710,980)"/>
-    <wire from="(250,720)" to="(790,720)"/>
-    <wire from="(590,430)" to="(590,470)"/>
-    <wire from="(340,1010)" to="(340,1110)"/>
-    <wire from="(780,650)" to="(780,760)"/>
-    <wire from="(680,1110)" to="(700,1110)"/>
-    <wire from="(540,1030)" to="(1390,1030)"/>
-    <wire from="(280,1110)" to="(280,1220)"/>
-    <wire from="(1060,1220)" to="(1060,1280)"/>
-    <wire from="(470,150)" to="(470,190)"/>
-    <wire from="(250,1140)" to="(390,1140)"/>
-    <wire from="(290,890)" to="(300,890)"/>
-    <wire from="(200,480)" to="(210,480)"/>
-    <wire from="(1060,990)" to="(1060,1220)"/>
-    <wire from="(1050,980)" to="(1050,1210)"/>
-    <wire from="(790,430)" to="(800,430)"/>
-    <wire from="(830,1110)" to="(840,1110)"/>
-    <wire from="(1390,280)" to="(1390,1030)"/>
-    <wire from="(530,650)" to="(540,650)"/>
-    <wire from="(90,830)" to="(220,830)"/>
-    <wire from="(1280,280)" to="(1280,620)"/>
-    <wire from="(940,380)" to="(1190,380)"/>
-    <wire from="(890,890)" to="(890,960)"/>
-    <wire from="(250,1170)" to="(690,1170)"/>
-    <wire from="(1040,850)" to="(1040,880)"/>
-    <wire from="(880,530)" to="(980,530)"/>
-    <wire from="(710,520)" to="(810,520)"/>
-    <wire from="(230,520)" to="(230,540)"/>
-    <wire from="(1010,750)" to="(1050,750)"/>
-    <wire from="(510,670)" to="(510,750)"/>
-    <wire from="(250,1200)" to="(990,1200)"/>
-    <wire from="(380,990)" to="(480,990)"/>
-    <wire from="(810,1130)" to="(810,1210)"/>
-    <wire from="(980,420)" to="(1000,420)"/>
-    <wire from="(880,880)" to="(880,990)"/>
-    <wire from="(10,280)" to="(230,280)"/>
-    <wire from="(1350,280)" to="(1350,840)"/>
-    <wire from="(580,420)" to="(580,530)"/>
-    <wire from="(940,1070)" to="(940,1110)"/>
-    <wire from="(480,880)" to="(500,880)"/>
-    <wire from="(390,1120)" to="(400,1120)"/>
-    <wire from="(330,420)" to="(340,420)"/>
-    <wire from="(690,660)" to="(690,710)"/>
-    <wire from="(540,830)" to="(540,880)"/>
-    <wire from="(890,660)" to="(900,660)"/>
-    <wire from="(340,1010)" to="(1370,1010)"/>
-    <wire from="(630,880)" to="(640,880)"/>
-    <wire from="(1040,620)" to="(1280,620)"/>
-    <wire from="(220,830)" to="(220,900)"/>
-    <wire from="(220,1120)" to="(220,1130)"/>
-    <wire from="(810,750)" to="(910,750)"/>
-    <wire from="(540,800)" to="(540,830)"/>
-    <wire from="(490,430)" to="(490,460)"/>
-    <wire from="(610,900)" to="(610,980)"/>
-    <wire from="(310,1210)" to="(410,1210)"/>
-    <wire from="(1420,280)" to="(1420,1060)"/>
-    <wire from="(740,360)" to="(1170,360)"/>
-    <wire from="(480,1220)" to="(580,1220)"/>
-    <wire from="(250,440)" to="(290,440)"/>
-    <wire from="(990,1120)" to="(990,1200)"/>
-    <wire from="(980,1110)" to="(980,1220)"/>
-    <wire from="(1140,280)" to="(1140,330)"/>
-    <wire from="(680,650)" to="(680,760)"/>
-    <wire from="(580,1110)" to="(600,1110)"/>
-    <wire from="(250,470)" to="(590,470)"/>
-    <wire from="(280,650)" to="(300,650)"/>
-    <wire from="(430,650)" to="(440,650)"/>
-    <wire from="(790,890)" to="(790,950)"/>
-    <wire from="(740,360)" to="(740,420)"/>
-    <wire from="(990,890)" to="(1000,890)"/>
-    <wire from="(690,430)" to="(700,430)"/>
-    <wire from="(730,1110)" to="(740,1110)"/>
-    <wire from="(250,500)" to="(890,500)"/>
-    <wire from="(170,790)" to="(230,790)"/>
-    <wire from="(170,1110)" to="(230,1110)"/>
-    <wire from="(1050,1210)" to="(1090,1210)"/>
-    <wire from="(640,580)" to="(640,650)"/>
-    <wire from="(780,530)" to="(880,530)"/>
-    <wire from="(840,600)" to="(1260,600)"/>
-    <wire from="(910,980)" to="(1010,980)"/>
-    <wire from="(250,920)" to="(490,920)"/>
-    <wire from="(610,520)" to="(710,520)"/>
-    <wire from="(410,670)" to="(410,750)"/>
-    <wire from="(540,340)" to="(1150,340)"/>
-    <wire from="(280,990)" to="(380,990)"/>
-    <wire from="(710,1130)" to="(710,1210)"/>
-    <wire from="(1210,280)" to="(1210,550)"/>
-    <wire from="(440,1020)" to="(440,1110)"/>
-    <wire from="(70,780)" to="(70,810)"/>
-    <wire from="(560,150)" to="(560,190)"/>
-    <wire from="(250,950)" to="(790,950)"/>
-    <wire from="(880,420)" to="(900,420)"/>
-    <wire from="(590,660)" to="(590,700)"/>
-    <wire from="(780,880)" to="(780,990)"/>
-    <wire from="(480,420)" to="(480,530)"/>
-    <wire from="(380,880)" to="(400,880)"/>
-    <wire from="(290,1120)" to="(300,1120)"/>
-    <wire from="(1450,1140)" to="(1480,1140)"/>
-    <wire from="(200,710)" to="(210,710)"/>
-    <wire from="(440,830)" to="(440,880)"/>
-    <wire from="(1030,420)" to="(1040,420)"/>
-    <wire from="(790,660)" to="(800,660)"/>
-    <wire from="(530,880)" to="(540,880)"/>
-    <wire from="(1170,280)" to="(1170,360)"/>
-    <wire from="(1040,1080)" to="(1040,1100)"/>
-    <wire from="(890,1120)" to="(890,1190)"/>
-    <wire from="(10,10)" to="(10,280)"/>
-    <wire from="(880,760)" to="(980,760)"/>
-    <wire from="(390,430)" to="(390,450)"/>
-    <wire from="(710,750)" to="(810,750)"/>
-    <wire from="(1010,980)" to="(1050,980)"/>
-    <wire from="(510,900)" to="(510,980)"/>
-    <wire from="(380,1220)" to="(480,1220)"/>
-    <wire from="(1010,440)" to="(1010,520)"/>
-    <wire from="(640,580)" to="(1240,580)"/>
-    <wire from="(980,650)" to="(1000,650)"/>
-    <wire from="(880,1110)" to="(880,1220)"/>
-    <wire from="(520,830)" to="(540,830)"/>
-    <wire from="(580,650)" to="(580,760)"/>
-    <wire from="(940,840)" to="(1350,840)"/>
-    <wire from="(480,1110)" to="(500,1110)"/>
-    <wire from="(230,750)" to="(230,790)"/>
-    <wire from="(340,320)" to="(1130,320)"/>
-    <wire from="(330,650)" to="(340,650)"/>
-    <wire from="(690,890)" to="(690,940)"/>
-    <wire from="(890,890)" to="(900,890)"/>
-    <wire from="(630,1110)" to="(640,1110)"/>
-    <wire from="(1240,280)" to="(1240,580)"/>
-    <wire from="(590,430)" to="(600,430)"/>
-    <wire from="(230,280)" to="(420,280)"/>
-    <wire from="(1350,840)" to="(1350,1120)"/>
-    <wire from="(810,980)" to="(910,980)"/>
-    <wire from="(510,520)" to="(610,520)"/>
-    <wire from="(310,670)" to="(310,750)"/>
-    <wire from="(680,530)" to="(780,530)"/>
-    <wire from="(490,660)" to="(490,690)"/>
-    <wire from="(610,1130)" to="(610,1210)"/>
-    <wire from="(1360,850)" to="(1360,1120)"/>
-    <wire from="(1310,280)" to="(1310,800)"/>
-    <wire from="(250,670)" to="(290,670)"/>
-    <wire from="(780,420)" to="(800,420)"/>
-    <wire from="(1040,1080)" to="(1440,1080)"/>
-    <wire from="(1320,810)" to="(1320,1120)"/>
-    <wire from="(680,880)" to="(680,990)"/>
-    <wire from="(280,80)" to="(300,80)"/>
-    <wire from="(250,700)" to="(590,700)"/>
-    <wire from="(280,880)" to="(300,880)"/>
-    <wire from="(380,420)" to="(380,530)"/>
-    <wire from="(430,880)" to="(440,880)"/>
-    <wire from="(790,1120)" to="(790,1180)"/>
-    <wire from="(1380,280)" to="(1380,1020)"/>
-    <wire from="(440,560)" to="(1220,560)"/>
-    <wire from="(1340,830)" to="(1340,1120)"/>
-    <wire from="(740,590)" to="(740,650)"/>
-    <wire from="(340,830)" to="(340,880)"/>
-    <wire from="(930,420)" to="(940,420)"/>
-    <wire from="(1330,820)" to="(1330,1120)"/>
-    <wire from="(990,1120)" to="(1000,1120)"/>
-    <wire from="(740,820)" to="(1330,820)"/>
-    <wire from="(690,660)" to="(700,660)"/>
-    <wire from="(1200,280)" to="(1200,390)"/>
-    <wire from="(840,370)" to="(840,420)"/>
-    <wire from="(980,530)" to="(1060,530)"/>
-    <wire from="(250,730)" to="(890,730)"/>
-    <wire from="(160,530)" to="(220,530)"/>
-    <wire from="(170,540)" to="(230,540)"/>
-    <wire from="(1290,780)" to="(1290,1120)"/>
-    <wire from="(420,10)" to="(790,10)"/>
-    <wire from="(1200,390)" to="(1200,1120)"/>
-    <wire from="(220,520)" to="(220,530)"/>
-    <wire from="(640,810)" to="(640,880)"/>
-    <wire from="(230,10)" to="(230,280)"/>
-    <wire from="(290,430)" to="(290,440)"/>
-    <wire from="(780,760)" to="(880,760)"/>
-    <wire from="(910,1210)" to="(1010,1210)"/>
-    <wire from="(250,1150)" to="(490,1150)"/>
-    <wire from="(1310,800)" to="(1310,1120)"/>
-    <wire from="(610,750)" to="(710,750)"/>
-    <wire from="(410,900)" to="(410,980)"/>
-    <wire from="(280,1220)" to="(380,1220)"/>
-    <wire from="(540,1030)" to="(540,1110)"/>
-    <wire from="(1270,280)" to="(1270,610)"/>
-    <wire from="(910,440)" to="(910,520)"/>
-    <wire from="(1300,790)" to="(1300,1120)"/>
-    <wire from="(250,1180)" to="(790,1180)"/>
-    <wire from="(650,150)" to="(650,190)"/>
-    <wire from="(880,650)" to="(900,650)"/>
-    <wire from="(590,890)" to="(590,930)"/>
-    <wire from="(780,1110)" to="(780,1220)"/>
-    <wire from="(480,650)" to="(480,760)"/>
-    <wire from="(1170,360)" to="(1170,1120)"/>
-    <wire from="(380,1110)" to="(400,1110)"/>
-    <wire from="(420,830)" to="(440,830)"/>
-    <wire from="(490,430)" to="(500,430)"/>
-    <wire from="(840,1060)" to="(1420,1060)"/>
-    <wire from="(1340,280)" to="(1340,830)"/>
-    <wire from="(200,940)" to="(210,940)"/>
-    <wire from="(1190,380)" to="(1190,1120)"/>
-    <wire from="(540,800)" to="(1310,800)"/>
-    <wire from="(1030,650)" to="(1040,650)"/>
-    <wire from="(790,890)" to="(800,890)"/>
-    <wire from="(1180,370)" to="(1180,1120)"/>
-    <wire from="(530,1110)" to="(540,1110)"/>
-    <wire from="(1140,330)" to="(1140,1120)"/>
-    <wire from="(420,10)" to="(420,280)"/>
-    <wire from="(880,990)" to="(980,990)"/>
-    <wire from="(390,660)" to="(390,680)"/>
-    <wire from="(1160,350)" to="(1160,1120)"/>
-    <wire from="(580,530)" to="(680,530)"/>
-    <wire from="(710,980)" to="(810,980)"/>
-    <wire from="(1010,1210)" to="(1050,1210)"/>
-    <wire from="(1410,280)" to="(1410,1050)"/>
-    <wire from="(510,1130)" to="(510,1210)"/>
-    <wire from="(410,520)" to="(510,520)"/>
-    <wire from="(1150,340)" to="(1150,1120)"/>
-    <wire from="(1010,670)" to="(1010,750)"/>
-    <wire from="(340,320)" to="(340,420)"/>
-    <wire from="(980,880)" to="(1000,880)"/>
-    <wire from="(680,420)" to="(700,420)"/>
-    <wire from="(580,880)" to="(580,990)"/>
-    <wire from="(280,180)" to="(300,180)"/>
-    <wire from="(280,420)" to="(280,530)"/>
-    <wire from="(250,450)" to="(390,450)"/>
-    <wire from="(1130,320)" to="(1130,1120)"/>
-    <wire from="(330,880)" to="(340,880)"/>
-    <wire from="(690,1120)" to="(690,1170)"/>
-    <wire from="(890,1120)" to="(900,1120)"/>
-    <wire from="(1130,280)" to="(1130,320)"/>
-    <wire from="(830,420)" to="(840,420)"/>
-    <wire from="(590,660)" to="(600,660)"/>
-    <wire from="(640,1040)" to="(1400,1040)"/>
-    <wire from="(250,480)" to="(690,480)"/>
-    <wire from="(340,780)" to="(1290,780)"/>
-    <wire from="(810,1210)" to="(910,1210)"/>
-    <wire from="(230,1110)" to="(230,1130)"/>
-    <wire from="(510,750)" to="(610,750)"/>
-    <wire from="(370,760)" to="(480,760)"/>
-    <wire from="(310,900)" to="(310,980)"/>
-    <wire from="(680,760)" to="(780,760)"/>
-    <wire from="(250,510)" to="(990,510)"/>
-    <wire from="(490,890)" to="(490,920)"/>
-    <wire from="(160,840)" to="(160,1120)"/>
-    <wire from="(810,440)" to="(810,520)"/>
-    <wire from="(250,900)" to="(290,900)"/>
-    <wire from="(780,650)" to="(800,650)"/>
-    <wire from="(680,1110)" to="(680,1220)"/>
-    <wire from="(940,380)" to="(940,420)"/>
-    <wire from="(250,930)" to="(590,930)"/>
-    <wire from="(280,1110)" to="(300,1110)"/>
-    <wire from="(320,830)" to="(340,830)"/>
-    <wire from="(130,160)" to="(150,160)"/>
-    <wire from="(390,430)" to="(400,430)"/>
-    <wire from="(1040,390)" to="(1200,390)"/>
-    <wire from="(430,1110)" to="(440,1110)"/>
-    <wire from="(1440,280)" to="(1440,1080)"/>
-    <wire from="(740,820)" to="(740,880)"/>
-    <wire from="(930,650)" to="(940,650)"/>
-    <wire from="(90,840)" to="(160,840)"/>
-    <wire from="(690,890)" to="(700,890)"/>
-    <wire from="(980,760)" to="(1060,760)"/>
-    <wire from="(840,600)" to="(840,650)"/>
-    <wire from="(250,960)" to="(890,960)"/>
-    <wire from="(1290,220)" to="(1290,240)"/>
-    <wire from="(640,1040)" to="(640,1110)"/>
-    <wire from="(290,660)" to="(290,670)"/>
-    <wire from="(780,990)" to="(880,990)"/>
-    <wire from="(440,1020)" to="(1380,1020)"/>
-    <wire from="(610,980)" to="(710,980)"/>
-    <wire from="(410,1130)" to="(410,1210)"/>
-    <wire from="(1160,280)" to="(1160,350)"/>
-    <wire from="(480,530)" to="(580,530)"/>
-    <wire from="(910,670)" to="(910,750)"/>
-    <wire from="(990,430)" to="(990,510)"/>
-    <wire from="(980,420)" to="(980,530)"/>
-    <wire from="(880,880)" to="(900,880)"/>
-    <wire from="(590,1120)" to="(590,1160)"/>
-    <wire from="(840,370)" to="(1180,370)"/>
-    <wire from="(740,150)" to="(740,190)"/>
-    <wire from="(580,420)" to="(600,420)"/>
-    <wire from="(1030,880)" to="(1040,880)"/>
-    <wire from="(480,880)" to="(480,990)"/>
-    <wire from="(230,790)" to="(230,900)"/>
-    <wire from="(1300,280)" to="(1300,790)"/>
-    <wire from="(1230,280)" to="(1230,570)"/>
-    <wire from="(490,660)" to="(500,660)"/>
-    <wire from="(200,1170)" to="(210,1170)"/>
-    <wire from="(790,1120)" to="(800,1120)"/>
-    <wire from="(90,810)" to="(160,810)"/>
-    <wire from="(730,420)" to="(740,420)"/>
-    <wire from="(60,750)" to="(60,810)"/>
-    <wire from="(220,750)" to="(220,820)"/>
-    <wire from="(1370,280)" to="(1370,1010)"/>
-    <wire from="(880,1220)" to="(980,1220)"/>
-    <wire from="(390,890)" to="(390,910)"/>
-    <wire from="(580,760)" to="(680,760)"/>
-    <wire from="(710,1210)" to="(810,1210)"/>
-    <wire from="(710,440)" to="(710,520)"/>
-    <wire from="(410,750)" to="(510,750)"/>
-    <wire from="(440,330)" to="(440,420)"/>
-    <wire from="(1010,900)" to="(1010,980)"/>
-    <wire from="(130,250)" to="(160,250)"/>
-    <wire from="(340,550)" to="(340,650)"/>
-    <wire from="(980,1110)" to="(1000,1110)"/>
-    <wire from="(10,10)" to="(230,10)"/>
-    <wire from="(680,650)" to="(700,650)"/>
-    <wire from="(370,650)" to="(400,650)"/>
-    <wire from="(580,1110)" to="(580,1220)"/>
-    <wire from="(280,650)" to="(280,760)"/>
-    <wire from="(130,100)" to="(150,100)"/>
-    <wire from="(250,680)" to="(390,680)"/>
-    <wire from="(290,430)" to="(300,430)"/>
-    <wire from="(640,350)" to="(1160,350)"/>
-    <wire from="(330,1110)" to="(340,1110)"/>
-    <wire from="(1190,280)" to="(1190,380)"/>
-    <wire from="(1050,520)" to="(1050,750)"/>
-    <wire from="(1060,530)" to="(1060,760)"/>
-    <wire from="(940,610)" to="(1270,610)"/>
-    <wire from="(830,650)" to="(840,650)"/>
-    <wire from="(590,890)" to="(600,890)"/>
-    <wire from="(170,790)" to="(170,1110)"/>
-    <wire from="(1330,280)" to="(1330,820)"/>
-    <wire from="(890,430)" to="(890,500)"/>
-    <wire from="(250,710)" to="(690,710)"/>
-    <wire from="(1040,390)" to="(1040,420)"/>
-    <wire from="(1260,280)" to="(1260,600)"/>
-    <wire from="(510,980)" to="(610,980)"/>
-    <wire from="(310,1130)" to="(310,1210)"/>
-    <wire from="(680,990)" to="(780,990)"/>
-    <wire from="(250,740)" to="(990,740)"/>
-    <wire from="(490,1120)" to="(490,1150)"/>
-    <wire from="(380,530)" to="(480,530)"/>
-    <wire from="(810,670)" to="(810,750)"/>
-    <wire from="(250,1130)" to="(290,1130)"/>
-    <wire from="(130,220)" to="(160,220)"/>
-    <wire from="(780,880)" to="(800,880)"/>
-    <wire from="(280,760)" to="(370,760)"/>
-    <wire from="(880,420)" to="(880,530)"/>
-    <wire from="(940,610)" to="(940,650)"/>
-    <wire from="(380,880)" to="(380,990)"/>
-    <wire from="(250,1160)" to="(590,1160)"/>
-    <wire from="(480,420)" to="(500,420)"/>
-    <wire from="(1400,280)" to="(1400,1040)"/>
-    <wire from="(130,70)" to="(150,70)"/>
-    <wire from="(390,660)" to="(400,660)"/>
-    <wire from="(80,710)" to="(80,760)"/>
-    <wire from="(1450,260)" to="(1480,260)"/>
-    <wire from="(740,1050)" to="(740,1110)"/>
-    <wire from="(930,880)" to="(940,880)"/>
-    <wire from="(690,1120)" to="(700,1120)"/>
-    <wire from="(630,420)" to="(640,420)"/>
-    <wire from="(980,990)" to="(1060,990)"/>
-    <wire from="(840,830)" to="(840,880)"/>
-    <wire from="(90,820)" to="(220,820)"/>
-    <wire from="(440,330)" to="(1140,330)"/>
-    <wire from="(250,1190)" to="(890,1190)"/>
-    <wire from="(740,590)" to="(1250,590)"/>
-    <wire from="(290,890)" to="(290,900)"/>
-    <wire from="(780,1220)" to="(880,1220)"/>
-    <wire from="(1040,850)" to="(1360,850)"/>
-    <wire from="(610,1210)" to="(710,1210)"/>
-    <wire from="(610,440)" to="(610,520)"/>
-    <wire from="(310,750)" to="(410,750)"/>
-    <wire from="(480,760)" to="(580,760)"/>
-    <wire from="(910,900)" to="(910,980)"/>
-    <wire from="(990,660)" to="(990,740)"/>
-    <wire from="(980,650)" to="(980,760)"/>
-    <wire from="(880,1110)" to="(900,1110)"/>
-    <wire from="(1430,1070)" to="(1430,1120)"/>
-    <wire from="(580,650)" to="(600,650)"/>
-    <wire from="(1030,1110)" to="(1040,1110)"/>
-    <wire from="(480,1110)" to="(480,1220)"/>
-    <wire from="(1420,1060)" to="(1420,1120)"/>
-    <wire from="(130,40)" to="(150,40)"/>
-    <wire from="(1360,280)" to="(1360,850)"/>
-    <wire from="(790,430)" to="(790,490)"/>
-    <wire from="(490,890)" to="(500,890)"/>
-    <wire from="(1040,1100)" to="(1070,1100)"/>
-    <wire from="(340,780)" to="(340,830)"/>
-    <wire from="(170,540)" to="(170,790)"/>
-    <wire from="(990,430)" to="(1000,430)"/>
-    <wire from="(730,650)" to="(740,650)"/>
-    <wire from="(1440,1080)" to="(1440,1120)"/>
-    <wire from="(840,830)" to="(1340,830)"/>
-    <wire from="(1430,280)" to="(1430,1070)"/>
-    <wire from="(1400,1040)" to="(1400,1120)"/>
-    <wire from="(160,1120)" to="(220,1120)"/>
-    <wire from="(540,570)" to="(1230,570)"/>
-    <wire from="(420,280)" to="(790,280)"/>
-    <wire from="(1390,1030)" to="(1390,1120)"/>
-    <wire from="(910,520)" to="(1010,520)"/>
-    <wire from="(390,1120)" to="(390,1140)"/>
-    <wire from="(1410,1050)" to="(1410,1120)"/>
-    <wire from="(250,460)" to="(490,460)"/>
-    <wire from="(580,990)" to="(680,990)"/>
-    <wire from="(280,530)" to="(380,530)"/>
-    <wire from="(540,340)" to="(540,420)"/>
-    <wire from="(410,980)" to="(510,980)"/>
-    <wire from="(160,530)" to="(160,810)"/>
-    <wire from="(710,670)" to="(710,750)"/>
-    <wire from="(440,560)" to="(440,650)"/>
-    <wire from="(1010,1130)" to="(1010,1210)"/>
-    <wire from="(250,490)" to="(790,490)"/>
-    <wire from="(780,420)" to="(780,530)"/>
-    <wire from="(680,880)" to="(700,880)"/>
-    <wire from="(1280,620)" to="(1280,1120)"/>
-    <wire from="(380,420)" to="(400,420)"/>
-    <wire from="(280,880)" to="(280,990)"/>
-    <wire from="(370,650)" to="(370,760)"/>
-    <wire from="(1270,610)" to="(1270,1120)"/>
-    <wire from="(1150,280)" to="(1150,340)"/>
-    <wire from="(250,910)" to="(390,910)"/>
-    <wire from="(1380,1020)" to="(1380,1120)"/>
-    <wire from="(290,660)" to="(300,660)"/>
-    <wire from="(1050,750)" to="(1050,980)"/>
-    <wire from="(1060,760)" to="(1060,990)"/>
-    <wire from="(830,880)" to="(840,880)"/>
-    <wire from="(1370,1010)" to="(1370,1120)"/>
-    <wire from="(530,420)" to="(540,420)"/>
-    <wire from="(590,1120)" to="(600,1120)"/>
-    <wire from="(230,10)" to="(420,10)"/>
-    <wire from="(1250,590)" to="(1250,1120)"/>
-    <wire from="(790,10)" to="(790,280)"/>
-    <wire from="(1220,280)" to="(1220,560)"/>
-    <wire from="(890,660)" to="(890,730)"/>
-    <wire from="(80,780)" to="(80,790)"/>
-    <wire from="(250,940)" to="(690,940)"/>
-    <wire from="(1040,620)" to="(1040,650)"/>
-    <wire from="(1240,580)" to="(1240,1120)"/>
-    <wire from="(640,810)" to="(1320,810)"/>
-    <wire from="(510,1210)" to="(610,1210)"/>
-    <wire from="(680,1220)" to="(780,1220)"/>
-    <wire from="(510,440)" to="(510,520)"/>
-    <wire from="(1010,520)" to="(1050,520)"/>
-    <wire from="(250,970)" to="(990,970)"/>
-    <wire from="(940,1070)" to="(1430,1070)"/>
-    <wire from="(1040,1100)" to="(1040,1110)"/>
-    <wire from="(1260,600)" to="(1260,1120)"/>
-    <wire from="(810,900)" to="(810,980)"/>
-    <wire from="(340,550)" to="(1210,550)"/>
-    <wire from="(780,1110)" to="(800,1110)"/>
-    <wire from="(1220,560)" to="(1220,1120)"/>
-    <wire from="(880,650)" to="(880,760)"/>
-    <wire from="(940,840)" to="(940,880)"/>
-    <wire from="(80,790)" to="(170,790)"/>
-    <wire from="(1290,280)" to="(1290,780)"/>
-    <wire from="(380,1110)" to="(380,1220)"/>
-    <wire from="(1210,550)" to="(1210,1120)"/>
-    <wire from="(480,650)" to="(500,650)"/>
-    <wire from="(390,890)" to="(400,890)"/>
-    <wire from="(1230,570)" to="(1230,1120)"/>
-    <wire from="(690,430)" to="(690,480)"/>
-    <wire from="(930,1110)" to="(940,1110)"/>
-    <wire from="(890,430)" to="(900,430)"/>
-    <wire from="(630,650)" to="(640,650)"/>
-    <wire from="(980,1220)" to="(1060,1220)"/>
-    <wire from="(840,1060)" to="(840,1110)"/>
-    <wire from="(1290,1160)" to="(1290,1180)"/>
-    <wire from="(1180,280)" to="(1180,370)"/>
-    <wire from="(290,1120)" to="(290,1130)"/>
-    <wire from="(810,520)" to="(910,520)"/>
-    <wire from="(610,670)" to="(610,750)"/>
-    <wire from="(310,980)" to="(410,980)"/>
-    <wire from="(480,990)" to="(580,990)"/>
-    <wire from="(910,1130)" to="(910,1210)"/>
-    <wire from="(990,890)" to="(990,970)"/>
-    <wire from="(980,880)" to="(980,990)"/>
-    <wire from="(440,790)" to="(1300,790)"/>
-    <wire from="(680,420)" to="(680,530)"/>
-    <wire from="(580,880)" to="(600,880)"/>
-    <wire from="(1250,280)" to="(1250,590)"/>
-    <wire from="(280,420)" to="(300,420)"/>
-    <wire from="(740,1050)" to="(1410,1050)"/>
-    <wire from="(440,790)" to="(440,830)"/>
-    <wire from="(430,420)" to="(440,420)"/>
-    <wire from="(790,660)" to="(790,720)"/>
-    <wire from="(490,1120)" to="(500,1120)"/>
-    <wire from="(40,830)" to="(50,830)"/>
-    <wire from="(990,660)" to="(1000,660)"/>
-    <wire from="(730,880)" to="(740,880)"/>
-    <comp lib="4" loc="(730,1110)" name="Register">
+    <wire from="(1320,1160)" to="(1320,1180)"/>
+    <wire from="(1210,280)" to="(1210,370)"/>
+    <wire from="(140,220)" to="(190,220)"/>
+    <wire from="(320,1120)" to="(320,1130)"/>
+    <wire from="(840,520)" to="(940,520)"/>
+    <wire from="(510,990)" to="(610,990)"/>
+    <wire from="(340,980)" to="(440,980)"/>
+    <wire from="(640,670)" to="(640,750)"/>
+    <wire from="(140,70)" to="(180,70)"/>
+    <wire from="(940,1130)" to="(940,1210)"/>
+    <wire from="(1020,890)" to="(1020,970)"/>
+    <wire from="(1010,880)" to="(1010,990)"/>
+    <wire from="(470,790)" to="(1330,790)"/>
+    <wire from="(710,420)" to="(710,530)"/>
+    <wire from="(1280,280)" to="(1280,590)"/>
+    <wire from="(610,880)" to="(630,880)"/>
+    <wire from="(310,420)" to="(330,420)"/>
+    <wire from="(770,1050)" to="(1440,1050)"/>
+    <wire from="(470,790)" to="(470,830)"/>
+    <wire from="(820,660)" to="(820,720)"/>
+    <wire from="(460,420)" to="(470,420)"/>
+    <wire from="(70,830)" to="(80,830)"/>
+    <wire from="(1020,660)" to="(1030,660)"/>
+    <wire from="(760,880)" to="(770,880)"/>
+    <wire from="(520,1120)" to="(530,1120)"/>
+    <wire from="(1350,280)" to="(1350,810)"/>
+    <wire from="(670,350)" to="(670,420)"/>
+    <wire from="(940,750)" to="(1040,750)"/>
+    <wire from="(280,690)" to="(520,690)"/>
+    <wire from="(610,1220)" to="(710,1220)"/>
+    <wire from="(440,440)" to="(440,520)"/>
+    <wire from="(570,570)" to="(570,650)"/>
+    <wire from="(140,40)" to="(180,40)"/>
+    <wire from="(30,290)" to="(260,290)"/>
+    <wire from="(740,900)" to="(740,980)"/>
+    <wire from="(440,1210)" to="(540,1210)"/>
+    <wire from="(500,80)" to="(540,80)"/>
+    <wire from="(280,720)" to="(820,720)"/>
+    <wire from="(620,430)" to="(620,470)"/>
+    <wire from="(370,1010)" to="(370,1110)"/>
+    <wire from="(810,650)" to="(810,760)"/>
+    <wire from="(710,1110)" to="(730,1110)"/>
+    <wire from="(570,1030)" to="(1420,1030)"/>
+    <wire from="(310,1110)" to="(310,1220)"/>
+    <wire from="(1090,1220)" to="(1090,1280)"/>
+    <wire from="(280,1140)" to="(420,1140)"/>
+    <wire from="(320,890)" to="(330,890)"/>
+    <wire from="(230,480)" to="(240,480)"/>
+    <wire from="(1090,990)" to="(1090,1220)"/>
+    <wire from="(1080,980)" to="(1080,1210)"/>
+    <wire from="(820,430)" to="(830,430)"/>
+    <wire from="(860,1110)" to="(870,1110)"/>
+    <wire from="(1420,280)" to="(1420,1030)"/>
+    <wire from="(120,830)" to="(250,830)"/>
+    <wire from="(560,650)" to="(570,650)"/>
+    <wire from="(1310,280)" to="(1310,620)"/>
+    <wire from="(1040,750)" to="(1080,750)"/>
+    <wire from="(970,380)" to="(1220,380)"/>
+    <wire from="(920,890)" to="(920,960)"/>
+    <wire from="(280,1170)" to="(720,1170)"/>
+    <wire from="(1070,850)" to="(1070,880)"/>
+    <wire from="(260,520)" to="(260,540)"/>
+    <wire from="(910,530)" to="(1010,530)"/>
+    <wire from="(740,520)" to="(840,520)"/>
+    <wire from="(540,670)" to="(540,750)"/>
+    <wire from="(280,1200)" to="(1020,1200)"/>
+    <wire from="(410,990)" to="(510,990)"/>
+    <wire from="(840,1130)" to="(840,1210)"/>
+    <wire from="(910,880)" to="(910,990)"/>
+    <wire from="(1010,420)" to="(1030,420)"/>
+    <wire from="(510,880)" to="(530,880)"/>
+    <wire from="(1380,280)" to="(1380,840)"/>
+    <wire from="(970,1070)" to="(970,1110)"/>
+    <wire from="(610,420)" to="(610,530)"/>
+    <wire from="(420,1120)" to="(430,1120)"/>
+    <wire from="(360,420)" to="(370,420)"/>
+    <wire from="(920,660)" to="(930,660)"/>
+    <wire from="(720,660)" to="(720,710)"/>
+    <wire from="(570,830)" to="(570,880)"/>
+    <wire from="(660,880)" to="(670,880)"/>
+    <wire from="(370,1010)" to="(1400,1010)"/>
+    <wire from="(1070,620)" to="(1310,620)"/>
+    <wire from="(250,830)" to="(250,900)"/>
+    <wire from="(250,1120)" to="(250,1130)"/>
+    <wire from="(840,750)" to="(940,750)"/>
+    <wire from="(510,1220)" to="(610,1220)"/>
+    <wire from="(520,430)" to="(520,460)"/>
+    <wire from="(570,800)" to="(570,830)"/>
+    <wire from="(340,1210)" to="(440,1210)"/>
+    <wire from="(640,900)" to="(640,980)"/>
+    <wire from="(1450,280)" to="(1450,1060)"/>
+    <wire from="(280,440)" to="(320,440)"/>
+    <wire from="(770,360)" to="(1200,360)"/>
+    <wire from="(1020,1120)" to="(1020,1200)"/>
+    <wire from="(500,180)" to="(540,180)"/>
+    <wire from="(1010,1110)" to="(1010,1220)"/>
+    <wire from="(1170,280)" to="(1170,330)"/>
+    <wire from="(710,650)" to="(710,760)"/>
+    <wire from="(610,1110)" to="(630,1110)"/>
+    <wire from="(280,470)" to="(620,470)"/>
+    <wire from="(310,650)" to="(330,650)"/>
+    <wire from="(820,890)" to="(820,950)"/>
+    <wire from="(460,650)" to="(470,650)"/>
+    <wire from="(770,360)" to="(770,420)"/>
+    <wire from="(1020,890)" to="(1030,890)"/>
+    <wire from="(760,1110)" to="(770,1110)"/>
+    <wire from="(720,430)" to="(730,430)"/>
+    <wire from="(280,500)" to="(920,500)"/>
+    <wire from="(200,790)" to="(260,790)"/>
+    <wire from="(200,1110)" to="(260,1110)"/>
+    <wire from="(1080,1210)" to="(1120,1210)"/>
+    <wire from="(670,580)" to="(670,650)"/>
+    <wire from="(140,260)" to="(190,260)"/>
+    <wire from="(810,530)" to="(910,530)"/>
+    <wire from="(870,600)" to="(1290,600)"/>
+    <wire from="(650,10)" to="(650,290)"/>
+    <wire from="(940,980)" to="(1040,980)"/>
+    <wire from="(280,920)" to="(520,920)"/>
+    <wire from="(640,520)" to="(740,520)"/>
+    <wire from="(440,670)" to="(440,750)"/>
+    <wire from="(570,340)" to="(1180,340)"/>
+    <wire from="(310,990)" to="(410,990)"/>
+    <wire from="(740,1130)" to="(740,1210)"/>
+    <wire from="(1240,280)" to="(1240,550)"/>
+    <wire from="(470,1020)" to="(470,1110)"/>
+    <wire from="(100,780)" to="(100,810)"/>
+    <wire from="(280,950)" to="(820,950)"/>
+    <wire from="(910,420)" to="(930,420)"/>
+    <wire from="(620,660)" to="(620,700)"/>
+    <wire from="(810,880)" to="(810,990)"/>
+    <wire from="(1060,420)" to="(1070,420)"/>
+    <wire from="(510,420)" to="(510,530)"/>
+    <wire from="(410,880)" to="(430,880)"/>
+    <wire from="(320,1120)" to="(330,1120)"/>
+    <wire from="(1480,1140)" to="(1510,1140)"/>
+    <wire from="(230,710)" to="(240,710)"/>
+    <wire from="(470,830)" to="(470,880)"/>
+    <wire from="(820,660)" to="(830,660)"/>
+    <wire from="(560,880)" to="(570,880)"/>
+    <wire from="(1200,280)" to="(1200,360)"/>
+    <wire from="(1070,1080)" to="(1070,1100)"/>
+    <wire from="(1040,980)" to="(1080,980)"/>
+    <wire from="(920,1120)" to="(920,1190)"/>
+    <wire from="(910,760)" to="(1010,760)"/>
+    <wire from="(420,430)" to="(420,450)"/>
+    <wire from="(740,750)" to="(840,750)"/>
+    <wire from="(540,900)" to="(540,980)"/>
+    <wire from="(410,1220)" to="(510,1220)"/>
+    <wire from="(30,10)" to="(260,10)"/>
+    <wire from="(1040,440)" to="(1040,520)"/>
+    <wire from="(910,1110)" to="(910,1220)"/>
+    <wire from="(670,580)" to="(1270,580)"/>
+    <wire from="(1010,650)" to="(1030,650)"/>
+    <wire from="(510,1110)" to="(530,1110)"/>
+    <wire from="(550,830)" to="(570,830)"/>
+    <wire from="(610,650)" to="(610,760)"/>
+    <wire from="(970,840)" to="(1380,840)"/>
+    <wire from="(260,750)" to="(260,790)"/>
+    <wire from="(370,320)" to="(1160,320)"/>
+    <wire from="(360,650)" to="(370,650)"/>
+    <wire from="(920,890)" to="(930,890)"/>
+    <wire from="(720,890)" to="(720,940)"/>
+    <wire from="(660,1110)" to="(670,1110)"/>
+    <wire from="(620,430)" to="(630,430)"/>
+    <wire from="(1270,280)" to="(1270,580)"/>
+    <wire from="(1380,840)" to="(1380,1120)"/>
+    <wire from="(840,980)" to="(940,980)"/>
+    <wire from="(540,520)" to="(640,520)"/>
+    <wire from="(340,670)" to="(340,750)"/>
+    <wire from="(520,660)" to="(520,690)"/>
+    <wire from="(710,530)" to="(810,530)"/>
+    <wire from="(640,1130)" to="(640,1210)"/>
+    <wire from="(1390,850)" to="(1390,1120)"/>
+    <wire from="(1340,280)" to="(1340,800)"/>
+    <wire from="(280,670)" to="(320,670)"/>
+    <wire from="(1070,1080)" to="(1470,1080)"/>
+    <wire from="(810,420)" to="(830,420)"/>
+    <wire from="(1350,810)" to="(1350,1120)"/>
+    <wire from="(710,880)" to="(710,990)"/>
+    <wire from="(280,700)" to="(620,700)"/>
+    <wire from="(410,420)" to="(410,530)"/>
+    <wire from="(310,880)" to="(330,880)"/>
+    <wire from="(820,1120)" to="(820,1180)"/>
+    <wire from="(460,880)" to="(470,880)"/>
+    <wire from="(1410,280)" to="(1410,1020)"/>
+    <wire from="(470,560)" to="(1250,560)"/>
+    <wire from="(370,830)" to="(370,880)"/>
+    <wire from="(770,590)" to="(770,650)"/>
+    <wire from="(1370,830)" to="(1370,1120)"/>
+    <wire from="(960,420)" to="(970,420)"/>
+    <wire from="(1360,820)" to="(1360,1120)"/>
+    <wire from="(1020,1120)" to="(1030,1120)"/>
+    <wire from="(1230,280)" to="(1230,390)"/>
+    <wire from="(720,660)" to="(730,660)"/>
+    <wire from="(770,820)" to="(1360,820)"/>
+    <wire from="(870,370)" to="(870,420)"/>
+    <wire from="(1010,530)" to="(1090,530)"/>
+    <wire from="(1320,780)" to="(1320,1120)"/>
+    <wire from="(280,730)" to="(920,730)"/>
+    <wire from="(190,530)" to="(250,530)"/>
+    <wire from="(200,540)" to="(260,540)"/>
+    <wire from="(1230,390)" to="(1230,1120)"/>
+    <wire from="(670,810)" to="(670,880)"/>
+    <wire from="(250,520)" to="(250,530)"/>
+    <wire from="(320,430)" to="(320,440)"/>
+    <wire from="(810,760)" to="(910,760)"/>
+    <wire from="(940,1210)" to="(1040,1210)"/>
+    <wire from="(280,1150)" to="(520,1150)"/>
+    <wire from="(1340,800)" to="(1340,1120)"/>
+    <wire from="(640,750)" to="(740,750)"/>
+    <wire from="(440,900)" to="(440,980)"/>
+    <wire from="(570,1030)" to="(570,1110)"/>
+    <wire from="(310,1220)" to="(410,1220)"/>
+    <wire from="(1300,280)" to="(1300,610)"/>
+    <wire from="(260,10)" to="(260,290)"/>
+    <wire from="(940,440)" to="(940,520)"/>
+    <wire from="(1330,790)" to="(1330,1120)"/>
+    <wire from="(280,1180)" to="(820,1180)"/>
+    <wire from="(620,890)" to="(620,930)"/>
+    <wire from="(910,650)" to="(930,650)"/>
+    <wire from="(810,1110)" to="(810,1220)"/>
+    <wire from="(510,650)" to="(510,760)"/>
+    <wire from="(1060,650)" to="(1070,650)"/>
+    <wire from="(1200,360)" to="(1200,1120)"/>
+    <wire from="(410,1110)" to="(430,1110)"/>
+    <wire from="(450,830)" to="(470,830)"/>
+    <wire from="(870,1060)" to="(1450,1060)"/>
+    <wire from="(1370,280)" to="(1370,830)"/>
+    <wire from="(230,940)" to="(240,940)"/>
+    <wire from="(1220,380)" to="(1220,1120)"/>
+    <wire from="(570,800)" to="(1340,800)"/>
+    <wire from="(820,890)" to="(830,890)"/>
+    <wire from="(1210,370)" to="(1210,1120)"/>
+    <wire from="(520,430)" to="(530,430)"/>
+    <wire from="(560,1110)" to="(570,1110)"/>
+    <wire from="(1040,670)" to="(1040,750)"/>
+    <wire from="(1170,330)" to="(1170,1120)"/>
+    <wire from="(1040,1210)" to="(1080,1210)"/>
+    <wire from="(1190,350)" to="(1190,1120)"/>
+    <wire from="(910,990)" to="(1010,990)"/>
+    <wire from="(420,660)" to="(420,680)"/>
+    <wire from="(610,530)" to="(710,530)"/>
+    <wire from="(740,980)" to="(840,980)"/>
+    <wire from="(1440,280)" to="(1440,1050)"/>
+    <wire from="(540,1130)" to="(540,1210)"/>
+    <wire from="(440,520)" to="(540,520)"/>
+    <wire from="(1180,340)" to="(1180,1120)"/>
+    <wire from="(370,320)" to="(370,420)"/>
+    <wire from="(1010,880)" to="(1030,880)"/>
+    <wire from="(710,420)" to="(730,420)"/>
+    <wire from="(610,880)" to="(610,990)"/>
+    <wire from="(310,420)" to="(310,530)"/>
+    <wire from="(280,450)" to="(420,450)"/>
+    <wire from="(1160,320)" to="(1160,1120)"/>
+    <wire from="(360,880)" to="(370,880)"/>
+    <wire from="(920,1120)" to="(930,1120)"/>
+    <wire from="(720,1120)" to="(720,1170)"/>
+    <wire from="(1160,280)" to="(1160,320)"/>
+    <wire from="(860,420)" to="(870,420)"/>
+    <wire from="(620,660)" to="(630,660)"/>
+    <wire from="(670,1040)" to="(1430,1040)"/>
+    <wire from="(280,480)" to="(720,480)"/>
+    <wire from="(370,780)" to="(1320,780)"/>
+    <wire from="(260,1110)" to="(260,1130)"/>
+    <wire from="(840,1210)" to="(940,1210)"/>
+    <wire from="(540,750)" to="(640,750)"/>
+    <wire from="(400,760)" to="(510,760)"/>
+    <wire from="(340,900)" to="(340,980)"/>
+    <wire from="(520,890)" to="(520,920)"/>
+    <wire from="(710,760)" to="(810,760)"/>
+    <wire from="(280,510)" to="(1020,510)"/>
+    <wire from="(190,840)" to="(190,1120)"/>
+    <wire from="(840,440)" to="(840,520)"/>
+    <wire from="(280,900)" to="(320,900)"/>
+    <wire from="(810,650)" to="(830,650)"/>
+    <wire from="(710,1110)" to="(710,1220)"/>
+    <wire from="(970,380)" to="(970,420)"/>
+    <wire from="(280,930)" to="(620,930)"/>
+    <wire from="(310,1110)" to="(330,1110)"/>
+    <wire from="(350,830)" to="(370,830)"/>
+    <wire from="(770,820)" to="(770,880)"/>
+    <wire from="(420,430)" to="(430,430)"/>
+    <wire from="(1070,390)" to="(1230,390)"/>
+    <wire from="(460,1110)" to="(470,1110)"/>
+    <wire from="(1470,280)" to="(1470,1080)"/>
+    <wire from="(960,650)" to="(970,650)"/>
+    <wire from="(120,840)" to="(190,840)"/>
+    <wire from="(720,890)" to="(730,890)"/>
+    <wire from="(1010,760)" to="(1090,760)"/>
+    <wire from="(870,600)" to="(870,650)"/>
+    <wire from="(1320,220)" to="(1320,240)"/>
+    <wire from="(280,960)" to="(920,960)"/>
+    <wire from="(670,1040)" to="(670,1110)"/>
+    <wire from="(320,660)" to="(320,670)"/>
+    <wire from="(810,990)" to="(910,990)"/>
+    <wire from="(510,530)" to="(610,530)"/>
+    <wire from="(1190,280)" to="(1190,350)"/>
+    <wire from="(640,980)" to="(740,980)"/>
+    <wire from="(440,1130)" to="(440,1210)"/>
+    <wire from="(30,10)" to="(30,290)"/>
+    <wire from="(470,1020)" to="(1410,1020)"/>
+    <wire from="(940,670)" to="(940,750)"/>
+    <wire from="(1020,430)" to="(1020,510)"/>
+    <wire from="(1010,420)" to="(1010,530)"/>
+    <wire from="(620,1120)" to="(620,1160)"/>
+    <wire from="(870,370)" to="(1210,370)"/>
+    <wire from="(910,880)" to="(930,880)"/>
+    <wire from="(610,420)" to="(630,420)"/>
+    <wire from="(510,880)" to="(510,990)"/>
+    <wire from="(1060,880)" to="(1070,880)"/>
+    <wire from="(260,790)" to="(260,900)"/>
+    <wire from="(1330,280)" to="(1330,790)"/>
+    <wire from="(1260,280)" to="(1260,570)"/>
+    <wire from="(230,1170)" to="(240,1170)"/>
+    <wire from="(120,810)" to="(190,810)"/>
+    <wire from="(820,1120)" to="(830,1120)"/>
+    <wire from="(760,420)" to="(770,420)"/>
+    <wire from="(90,750)" to="(90,810)"/>
+    <wire from="(520,660)" to="(530,660)"/>
+    <wire from="(1040,900)" to="(1040,980)"/>
+    <wire from="(250,750)" to="(250,820)"/>
+    <wire from="(1400,280)" to="(1400,1010)"/>
+    <wire from="(910,1220)" to="(1010,1220)"/>
+    <wire from="(420,890)" to="(420,910)"/>
+    <wire from="(610,760)" to="(710,760)"/>
+    <wire from="(740,1210)" to="(840,1210)"/>
+    <wire from="(740,440)" to="(740,520)"/>
+    <wire from="(440,750)" to="(540,750)"/>
+    <wire from="(470,330)" to="(470,420)"/>
+    <wire from="(370,550)" to="(370,650)"/>
+    <wire from="(1010,1110)" to="(1030,1110)"/>
+    <wire from="(400,650)" to="(430,650)"/>
+    <wire from="(310,80)" to="(340,80)"/>
+    <wire from="(710,650)" to="(730,650)"/>
+    <wire from="(610,1110)" to="(610,1220)"/>
+    <wire from="(310,650)" to="(310,760)"/>
+    <wire from="(280,680)" to="(420,680)"/>
+    <wire from="(670,350)" to="(1190,350)"/>
+    <wire from="(320,430)" to="(330,430)"/>
+    <wire from="(360,1110)" to="(370,1110)"/>
+    <wire from="(1220,280)" to="(1220,380)"/>
+    <wire from="(1080,520)" to="(1080,750)"/>
+    <wire from="(1090,530)" to="(1090,760)"/>
+    <wire from="(970,610)" to="(1300,610)"/>
+    <wire from="(860,650)" to="(870,650)"/>
+    <wire from="(260,290)" to="(650,290)"/>
+    <wire from="(620,890)" to="(630,890)"/>
+    <wire from="(200,790)" to="(200,1110)"/>
+    <wire from="(1360,280)" to="(1360,820)"/>
+    <wire from="(920,430)" to="(920,500)"/>
+    <wire from="(280,710)" to="(720,710)"/>
+    <wire from="(1070,390)" to="(1070,420)"/>
+    <wire from="(1290,280)" to="(1290,600)"/>
+    <wire from="(540,980)" to="(640,980)"/>
+    <wire from="(340,1130)" to="(340,1210)"/>
+    <wire from="(520,1120)" to="(520,1150)"/>
+    <wire from="(710,990)" to="(810,990)"/>
+    <wire from="(280,740)" to="(1020,740)"/>
+    <wire from="(410,530)" to="(510,530)"/>
+    <wire from="(280,1130)" to="(320,1130)"/>
+    <wire from="(840,670)" to="(840,750)"/>
+    <wire from="(810,880)" to="(830,880)"/>
+    <wire from="(310,760)" to="(400,760)"/>
+    <wire from="(910,420)" to="(910,530)"/>
+    <wire from="(970,610)" to="(970,650)"/>
+    <wire from="(410,880)" to="(410,990)"/>
+    <wire from="(280,1160)" to="(620,1160)"/>
+    <wire from="(510,420)" to="(530,420)"/>
+    <wire from="(1430,280)" to="(1430,1040)"/>
+    <wire from="(770,1050)" to="(770,1110)"/>
+    <wire from="(420,660)" to="(430,660)"/>
+    <wire from="(110,710)" to="(110,760)"/>
+    <wire from="(1480,260)" to="(1510,260)"/>
+    <wire from="(960,880)" to="(970,880)"/>
+    <wire from="(660,420)" to="(670,420)"/>
+    <wire from="(120,820)" to="(250,820)"/>
+    <wire from="(720,1120)" to="(730,1120)"/>
+    <wire from="(1010,990)" to="(1090,990)"/>
+    <wire from="(870,830)" to="(870,880)"/>
+    <wire from="(470,330)" to="(1170,330)"/>
+    <wire from="(280,1190)" to="(920,1190)"/>
+    <wire from="(770,590)" to="(1280,590)"/>
+    <wire from="(320,890)" to="(320,900)"/>
+    <wire from="(810,1220)" to="(910,1220)"/>
+    <wire from="(1070,850)" to="(1390,850)"/>
+    <wire from="(510,760)" to="(610,760)"/>
+    <wire from="(640,1210)" to="(740,1210)"/>
+    <wire from="(640,440)" to="(640,520)"/>
+    <wire from="(340,750)" to="(440,750)"/>
+    <wire from="(140,160)" to="(180,160)"/>
+    <wire from="(940,900)" to="(940,980)"/>
+    <wire from="(1020,660)" to="(1020,740)"/>
+    <wire from="(1010,650)" to="(1010,760)"/>
+    <wire from="(910,1110)" to="(930,1110)"/>
+    <wire from="(1460,1070)" to="(1460,1120)"/>
+    <wire from="(610,650)" to="(630,650)"/>
+    <wire from="(510,1110)" to="(510,1220)"/>
+    <wire from="(1060,1110)" to="(1070,1110)"/>
+    <wire from="(310,180)" to="(340,180)"/>
+    <wire from="(1450,1060)" to="(1450,1120)"/>
+    <wire from="(1390,280)" to="(1390,850)"/>
+    <wire from="(820,430)" to="(820,490)"/>
+    <wire from="(1070,1100)" to="(1100,1100)"/>
+    <wire from="(370,780)" to="(370,830)"/>
+    <wire from="(1020,430)" to="(1030,430)"/>
+    <wire from="(200,540)" to="(200,790)"/>
+    <wire from="(760,650)" to="(770,650)"/>
+    <wire from="(520,890)" to="(530,890)"/>
+    <wire from="(1470,1080)" to="(1470,1120)"/>
+    <wire from="(1040,1130)" to="(1040,1210)"/>
+    <wire from="(1460,280)" to="(1460,1070)"/>
+    <wire from="(870,830)" to="(1370,830)"/>
+    <wire from="(1430,1040)" to="(1430,1120)"/>
+    <wire from="(190,1120)" to="(250,1120)"/>
+    <wire from="(570,570)" to="(1260,570)"/>
+    <wire from="(1420,1030)" to="(1420,1120)"/>
+    <wire from="(1440,1050)" to="(1440,1120)"/>
+    <wire from="(940,520)" to="(1040,520)"/>
+    <wire from="(420,1120)" to="(420,1140)"/>
+    <wire from="(280,460)" to="(520,460)"/>
+    <wire from="(610,990)" to="(710,990)"/>
+    <wire from="(570,340)" to="(570,420)"/>
+    <wire from="(310,530)" to="(410,530)"/>
+    <wire from="(740,670)" to="(740,750)"/>
+    <wire from="(440,980)" to="(540,980)"/>
+    <wire from="(190,530)" to="(190,810)"/>
+    <wire from="(470,560)" to="(470,650)"/>
+    <wire from="(280,490)" to="(820,490)"/>
+    <wire from="(1310,620)" to="(1310,1120)"/>
+    <wire from="(810,420)" to="(810,530)"/>
+    <wire from="(710,880)" to="(730,880)"/>
+    <wire from="(400,650)" to="(400,760)"/>
+    <wire from="(410,420)" to="(430,420)"/>
+    <wire from="(310,880)" to="(310,990)"/>
+    <wire from="(1300,610)" to="(1300,1120)"/>
+    <wire from="(1180,280)" to="(1180,340)"/>
+    <wire from="(280,910)" to="(420,910)"/>
+    <wire from="(1410,1020)" to="(1410,1120)"/>
+    <wire from="(320,660)" to="(330,660)"/>
+    <wire from="(1080,750)" to="(1080,980)"/>
+    <wire from="(1090,760)" to="(1090,990)"/>
+    <wire from="(860,880)" to="(870,880)"/>
+    <wire from="(1400,1010)" to="(1400,1120)"/>
+    <wire from="(560,420)" to="(570,420)"/>
+    <wire from="(620,1120)" to="(630,1120)"/>
+    <wire from="(1280,590)" to="(1280,1120)"/>
+    <wire from="(110,780)" to="(110,790)"/>
+    <wire from="(1040,520)" to="(1080,520)"/>
+    <wire from="(920,660)" to="(920,730)"/>
+    <wire from="(1250,280)" to="(1250,560)"/>
+    <wire from="(280,940)" to="(720,940)"/>
+    <wire from="(1070,620)" to="(1070,650)"/>
+    <wire from="(1270,580)" to="(1270,1120)"/>
+    <wire from="(670,810)" to="(1350,810)"/>
+    <wire from="(540,1210)" to="(640,1210)"/>
+    <wire from="(710,1220)" to="(810,1220)"/>
+    <wire from="(540,440)" to="(540,520)"/>
+    <wire from="(970,1070)" to="(1460,1070)"/>
+    <wire from="(280,970)" to="(1020,970)"/>
+    <wire from="(140,100)" to="(180,100)"/>
+    <wire from="(1070,1100)" to="(1070,1110)"/>
+    <wire from="(1290,600)" to="(1290,1120)"/>
+    <wire from="(370,550)" to="(1240,550)"/>
+    <wire from="(840,900)" to="(840,980)"/>
+    <wire from="(910,650)" to="(910,760)"/>
+    <wire from="(1320,280)" to="(1320,780)"/>
+    <wire from="(810,1110)" to="(830,1110)"/>
+    <wire from="(1250,560)" to="(1250,1120)"/>
+    <wire from="(510,650)" to="(530,650)"/>
+    <wire from="(110,790)" to="(200,790)"/>
+    <wire from="(970,840)" to="(970,880)"/>
+    <wire from="(410,1110)" to="(410,1220)"/>
+    <wire from="(1240,550)" to="(1240,1120)"/>
+    <wire from="(420,890)" to="(430,890)"/>
+    <wire from="(1260,570)" to="(1260,1120)"/>
+    <wire from="(920,430)" to="(930,430)"/>
+    <wire from="(720,430)" to="(720,480)"/>
+    <wire from="(960,1110)" to="(970,1110)"/>
+    <wire from="(660,650)" to="(670,650)"/>
+    <wire from="(260,10)" to="(650,10)"/>
+    <wire from="(1010,1220)" to="(1090,1220)"/>
+    <wire from="(870,1060)" to="(870,1110)"/>
+    <comp lib="0" loc="(350,830)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="32"/>
-      <a name="label" val="$28 $gp"/>
+      <a name="label" val="$s0"/>
     </comp>
-    <comp lib="0" loc="(160,220)" name="Tunnel">
+    <comp lib="0" loc="(190,260)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(860,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$5 $a1"/>
+    </comp>
+    <comp lib="0" loc="(190,220)" name="Tunnel">
       <a name="label" val="WE"/>
     </comp>
-    <comp lib="4" loc="(930,650)" name="Register">
+    <comp lib="0" loc="(310,180)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="32"/>
-      <a name="label" val="$14 $t6"/>
+      <a name="label" val="reg2"/>
     </comp>
-    <comp lib="0" loc="(470,190)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(110,710)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="write_reg#"/>
+    </comp>
+    <comp lib="4" loc="(760,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$20 $s4"/>
+    </comp>
+    <comp lib="0" loc="(450,830)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="$s1"/>
+    </comp>
+    <comp lib="0" loc="(140,100)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RW"/>
+    </comp>
+    <comp lib="2" loc="(1320,1160)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="select" val="5"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(70,830)" name="Constant"/>
+    <comp lib="2" loc="(80,830)" name="Demultiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(770,420)" name="Tunnel">
       <a name="width" val="32"/>
       <a name="label" val="$a0"/>
     </comp>
-    <comp lib="4" loc="(530,880)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$18 $s2"/>
-    </comp>
-    <comp lib="4" loc="(330,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$0 $Zero"/>
-    </comp>
-    <comp lib="0" loc="(470,150)" name="Pin">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(340,180)" name="Pin">
+      <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="$a0 Value"/>
-      <a name="labelloc" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(80,760)" name="Splitter">
+    <comp lib="0" loc="(310,80)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="reg1"/>
+    </comp>
+    <comp lib="4" loc="(760,1110)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$28 $gp"/>
+    </comp>
+    <comp lib="0" loc="(140,160)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
+    <comp lib="4" loc="(1060,1110)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$31 $ra"/>
+    </comp>
+    <comp lib="0" loc="(1320,1180)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="label" val="reg2"/>
+    </comp>
+    <comp lib="0" loc="(1090,1280)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="label" val="write_data"/>
+    </comp>
+    <comp lib="4" loc="(560,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$10 $t2"/>
+    </comp>
+    <comp lib="0" loc="(140,220)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="WE"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="4" loc="(960,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$6 $a2"/>
+    </comp>
+    <comp lib="4" loc="(1060,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$7 $a3"/>
+    </comp>
+    <comp lib="0" loc="(230,1170)" name="Constant"/>
+    <comp lib="2" loc="(1320,240)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="select" val="5"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(240,480)" name="Demultiplexer">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(540,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="v0"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(460,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$17 $s1"/>
+    </comp>
+    <comp lib="0" loc="(550,830)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="$s2"/>
+    </comp>
+    <comp lib="6" loc="(449,262)" name="Text">
+      <a name="text" val="Output"/>
+      <a name="font" val="SansSerif plain 24"/>
+    </comp>
+    <comp lib="0" loc="(180,70)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="reg2#"/>
+    </comp>
+    <comp lib="0" loc="(90,750)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="WE"/>
+    </comp>
+    <comp lib="0" loc="(570,420)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="$v0"/>
+    </comp>
+    <comp lib="4" loc="(860,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$13 $t5"/>
+    </comp>
+    <comp lib="4" loc="(1060,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$23 $s7"/>
+    </comp>
+    <comp lib="2" loc="(240,940)" name="Demultiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(140,40)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1#"/>
+    </comp>
+    <comp lib="4" loc="(760,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$4 $a0"/>
+    </comp>
+    <comp lib="4" loc="(860,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$21 $s5"/>
+    </comp>
+    <comp lib="0" loc="(1320,220)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="reg1"/>
+    </comp>
+    <comp lib="0" loc="(1510,260)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="reg1#"/>
+    </comp>
+    <comp lib="0" loc="(140,70)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2#"/>
+    </comp>
+    <comp lib="4" loc="(860,1110)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$29 $sp"/>
+    </comp>
+    <comp lib="4" loc="(960,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$22 $s6"/>
+    </comp>
+    <comp lib="0" loc="(230,940)" name="Constant"/>
+    <comp lib="4" loc="(360,1110)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$24 $t8"/>
+    </comp>
+    <comp lib="0" loc="(230,480)" name="Constant"/>
+    <comp lib="4" loc="(460,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$1 $at"/>
+    </comp>
+    <comp lib="0" loc="(1120,1210)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(180,100)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="write_reg#"/>
+    </comp>
+    <comp lib="0" loc="(500,180)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="$v0"/>
+    </comp>
+    <comp lib="4" loc="(660,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$19 $s3"/>
+    </comp>
+    <comp lib="0" loc="(180,40)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="reg1#"/>
+    </comp>
+    <comp lib="4" loc="(1060,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$15 $t7"/>
+    </comp>
+    <comp lib="2" loc="(240,710)" name="Demultiplexer">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="4" loc="(360,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$16 $s0"/>
+    </comp>
+    <comp lib="4" loc="(360,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$8 $t0"/>
+    </comp>
+    <comp lib="0" loc="(110,760)" name="Splitter">
       <a name="facing" val="south"/>
       <a name="incoming" val="5"/>
       <a name="appear" val="center"/>
@@ -653,351 +895,101 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit3" val="1"/>
       <a name="bit4" val="1"/>
     </comp>
-    <comp lib="4" loc="(1030,1110)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$31 $ra"/>
-    </comp>
-    <comp lib="4" loc="(530,1110)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$26 $k0"/>
-    </comp>
-    <comp lib="0" loc="(150,70)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="reg2#"/>
-    </comp>
-    <comp lib="0" loc="(740,150)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$ra Value"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(630,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$3 $v1"/>
-    </comp>
-    <comp lib="2" loc="(210,940)" name="Demultiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="6" loc="(47,256)" name="Text">
-      <a name="text" val="输入引脚"/>
-      <a name="font" val="SansSerif bold 12"/>
-    </comp>
-    <comp lib="0" loc="(300,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="Reg2"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(1290,1160)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="select" val="5"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(630,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$11 $t3"/>
-    </comp>
-    <comp lib="0" loc="(200,1170)" name="Constant"/>
-    <comp lib="4" loc="(1030,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$15 $t7"/>
-    </comp>
-    <comp lib="0" loc="(150,160)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="write_data"/>
-    </comp>
-    <comp lib="0" loc="(560,190)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$v0"/>
-    </comp>
-    <comp lib="4" loc="(530,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$2 $v0"/>
-    </comp>
-    <comp lib="0" loc="(130,100)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Write Reg#"/>
-    </comp>
-    <comp lib="0" loc="(130,220)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Write Enable"/>
-    </comp>
-    <comp lib="2" loc="(210,480)" name="Demultiplexer">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(200,940)" name="Constant"/>
-    <comp lib="0" loc="(420,830)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$s1"/>
-    </comp>
-    <comp lib="4" loc="(430,880)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$17 $s1"/>
-    </comp>
-    <comp lib="4" loc="(830,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$5 $a1"/>
-    </comp>
-    <comp lib="4" loc="(330,1110)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$24 $t8"/>
-    </comp>
-    <comp lib="0" loc="(320,830)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$s0"/>
-    </comp>
-    <comp lib="0" loc="(130,70)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Reg2"/>
-    </comp>
-    <comp lib="0" loc="(130,160)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
-    </comp>
-    <comp lib="0" loc="(1060,1280)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="write_data"/>
-    </comp>
-    <comp lib="4" loc="(830,1110)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$29 $sp"/>
-    </comp>
-    <comp lib="6" loc="(338,258)" name="Text">
-      <a name="text" val="输出引脚"/>
-      <a name="font" val="SansSerif bold 12"/>
-    </comp>
-    <comp lib="0" loc="(130,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Clock"/>
-    </comp>
-    <comp lib="4" loc="(430,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$9 $t1"/>
-    </comp>
-    <comp lib="6" loc="(606,39)" name="Text">
-      <a name="text" val="Debug引脚，便于观测寄存器值"/>
-      <a name="font" val="SansSerif bold 12"/>
-    </comp>
-    <comp lib="0" loc="(150,40)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="reg1#"/>
-    </comp>
-    <comp lib="6" loc="(606,257)" name="Text">
-      <a name="text" val="请勿修改引脚以及封装，直接使用隧道连接电路"/>
-    </comp>
-    <comp lib="0" loc="(650,150)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$s2 Value"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(740,420)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="$a0"/>
-    </comp>
-    <comp lib="4" loc="(330,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$8 $t0"/>
-    </comp>
-    <comp lib="0" loc="(520,830)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$s2"/>
-    </comp>
-    <comp lib="2" loc="(50,830)" name="Demultiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="4" loc="(430,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$1 $at"/>
-    </comp>
-    <comp lib="0" loc="(1290,1180)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="reg2"/>
-    </comp>
-    <comp lib="4" loc="(730,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$4 $a0"/>
-    </comp>
-    <comp lib="2" loc="(210,710)" name="Demultiplexer">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1090,1210)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1480,260)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="reg1#"/>
-    </comp>
-    <comp lib="0" loc="(80,710)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="write_reg#"/>
-    </comp>
-    <comp lib="0" loc="(60,750)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="WE"/>
-    </comp>
-    <comp lib="0" loc="(280,80)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="reg1"/>
-    </comp>
-    <comp lib="0" loc="(160,250)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(40,830)" name="Constant"/>
-    <comp lib="0" loc="(540,420)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="$v0"/>
-    </comp>
-    <comp lib="4" loc="(930,880)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$22 $s6"/>
-    </comp>
-    <comp lib="4" loc="(1030,880)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$23 $s7"/>
-    </comp>
-    <comp lib="0" loc="(650,190)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$s2"/>
-    </comp>
-    <comp lib="4" loc="(930,1110)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$30 $fp"/>
-    </comp>
-    <comp lib="4" loc="(630,1110)" name="Register">
+    <comp lib="4" loc="(660,1110)" name="Register">
       <a name="width" val="32"/>
       <a name="label" val="$27 $k1"/>
     </comp>
-    <comp lib="4" loc="(730,880)" name="Register">
+    <comp lib="4" loc="(760,650)" name="Register">
       <a name="width" val="32"/>
-      <a name="label" val="$20 $s4"/>
+      <a name="label" val="$12 $t4"/>
     </comp>
-    <comp lib="0" loc="(200,710)" name="Constant"/>
-    <comp lib="0" loc="(280,180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="reg2"/>
-    </comp>
-    <comp lib="0" loc="(150,100)" name="Tunnel">
+    <comp lib="0" loc="(1510,1140)" name="Tunnel">
       <a name="width" val="5"/>
-      <a name="label" val="write_reg#"/>
+      <a name="label" val="reg2#"/>
     </comp>
-    <comp lib="4" loc="(1030,420)" name="Register">
+    <comp lib="4" loc="(560,1110)" name="Register">
       <a name="width" val="32"/>
-      <a name="label" val="$7 $a3"/>
+      <a name="label" val="$26 $k0"/>
     </comp>
-    <comp lib="0" loc="(200,480)" name="Constant"/>
-    <comp lib="0" loc="(130,40)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Reg1#"/>
-    </comp>
-    <comp lib="4" loc="(530,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$10 $t2"/>
-    </comp>
-    <comp lib="4" loc="(630,880)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$19 $s3"/>
-    </comp>
-    <comp lib="0" loc="(560,150)" name="Pin">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(340,80)" name="Pin">
+      <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="$v0 Value"/>
-      <a name="labelloc" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(430,1110)" name="Register">
+    <comp lib="4" loc="(560,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$2 $v0"/>
+    </comp>
+    <comp lib="0" loc="(500,80)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="$a0"/>
+    </comp>
+    <comp lib="0" loc="(1100,1100)" name="Tunnel">
+      <a name="width" val="32"/>
+      <a name="label" val="$ra"/>
+    </comp>
+    <comp lib="4" loc="(460,1110)" name="Register">
       <a name="width" val="32"/>
       <a name="label" val="$25 $t9"/>
     </comp>
-    <comp lib="4" loc="(330,880)" name="Register">
+    <comp lib="0" loc="(180,160)" name="Tunnel">
       <a name="width" val="32"/>
-      <a name="label" val="$16 $s0"/>
+      <a name="label" val="write_data"/>
     </comp>
-    <comp lib="2" loc="(210,1170)" name="Demultiplexer">
+    <comp lib="4" loc="(660,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$11 $t3"/>
+    </comp>
+    <comp lib="4" loc="(960,1110)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$30 $fp"/>
+    </comp>
+    <comp lib="6" loc="(69,248)" name="Text">
+      <a name="text" val="Input"/>
+      <a name="font" val="SansSerif plain 24"/>
+    </comp>
+    <comp lib="4" loc="(960,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$14 $t6"/>
+    </comp>
+    <comp lib="0" loc="(230,710)" name="Constant"/>
+    <comp lib="4" loc="(660,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$3 $v1"/>
+    </comp>
+    <comp lib="4" loc="(360,420)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$0 $Zero"/>
+    </comp>
+    <comp lib="0" loc="(140,260)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="4" loc="(560,880)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$18 $s2"/>
+    </comp>
+    <comp lib="4" loc="(460,650)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="$9 $t1"/>
+    </comp>
+    <comp lib="2" loc="(240,1170)" name="Demultiplexer">
       <a name="selloc" val="tr"/>
       <a name="select" val="3"/>
       <a name="disabled" val="0"/>
     </comp>
-    <comp lib="4" loc="(730,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$12 $t4"/>
-    </comp>
-    <comp lib="2" loc="(1290,240)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="select" val="5"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1290,220)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="reg1"/>
-    </comp>
-    <comp lib="0" loc="(740,190)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="label" val="$ra"/>
-    </comp>
-    <comp lib="4" loc="(830,880)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$21 $s5"/>
-    </comp>
-    <comp lib="0" loc="(1070,1100)" name="Tunnel">
-      <a name="width" val="32"/>
-      <a name="label" val="$ra"/>
-    </comp>
-    <comp lib="0" loc="(1480,1140)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="reg2#"/>
-    </comp>
-    <comp lib="0" loc="(300,80)" name="Pin">
+    <comp lib="0" loc="(540,80)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="label" val="Reg1"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="a0"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(930,420)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$6 $a2"/>
-    </comp>
-    <comp lib="4" loc="(830,650)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="$13 $t5"/>
-    </comp>
-  </circuit>
-  <circuit name="test">
-    <a name="circuit" val="test"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <wire from="(180,220)" to="(180,250)"/>
-    <comp loc="(200,190)" name="main"/>
   </circuit>
 </project>

--- a/src/pipeline_cpu.circ
+++ b/src/pipeline_cpu.circ
@@ -53,7 +53,7 @@
   </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
-      <a name="select" val="3"/>
+      <a name="width" val="32"/>
     </tool>
     <tool name="Demultiplexer">
       <a name="select" val="5"/>
@@ -78,7 +78,7 @@
   </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
-      <a name="width" val="16"/>
+      <a name="width" val="32"/>
     </tool>
     <tool name="ROM">
       <a name="contents">addr/data: 8 8
@@ -96,11 +96,11 @@
     </tool>
   </lib>
   <lib desc="file#common/alu.circ" name="7"/>
-  <lib desc="file#common/regfile.circ" name="8"/>
-  <lib desc="file#common/control.circ" name="9"/>
-  <lib desc="file#common/statistics.circ" name="10"/>
-  <lib desc="file#common/syscall_decoder.circ" name="11"/>
-  <lib desc="file#common/immediate_extender.circ" name="12"/>
+  <lib desc="file#common/control.circ" name="8"/>
+  <lib desc="file#common/statistics.circ" name="9"/>
+  <lib desc="file#common/syscall_decoder.circ" name="10"/>
+  <lib desc="file#common/immediate_extender.circ" name="11"/>
+  <lib desc="file#common/regfile.circ" name="12"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -590,36 +590,307 @@
     <wire from="(730,560)" to="(740,560)"/>
     <wire from="(550,220)" to="(560,220)"/>
     <wire from="(490,1280)" to="(500,1280)"/>
-    <comp lib="0" loc="(1670,1130)" name="Tunnel">
-      <a name="label" val="IsJALEX"/>
+    <comp lib="1" loc="(380,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="6" loc="(1316,692)" name="Text">
-      <a name="text" val="WriteReg#"/>
+    <comp lib="0" loc="(1520,350)" name="Tunnel">
+      <a name="label" val="JumpEX"/>
     </comp>
-    <comp lib="0" loc="(1050,950)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(920,1070)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(420,760)" name="Tunnel">
+    <comp lib="1" loc="(290,690)" name="AND Gate">
       <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(720,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(320,520)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x800"/>
+    </comp>
+    <comp lib="0" loc="(920,520)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="3" loc="(1530,1160)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="5" loc="(600,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(890,1030)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1780,1120)" name="Constant">
+    <comp lib="0" loc="(1190,630)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1040,1060)" name="Tunnel">
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(950,450)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="0" loc="(480,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1280,150)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="6" loc="(859,501)" name="Text">
+      <a name="text" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(2010,750)" name="Tunnel">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="8" loc="(890,150)" name="Control"/>
+    <comp lib="4" loc="(540,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(250,1300)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(1090,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rs"/>
+    </comp>
+    <comp lib="0" loc="(980,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="6" loc="(862,240)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp lib="0" loc="(1140,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(1670,1110)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
+    </comp>
+    <comp lib="6" loc="(1167,1164)" name="Text">
+      <a name="text" val="Jump Addr"/>
+    </comp>
+    <comp lib="6" loc="(2439,1205)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="1" loc="(750,1290)" name="NOT Gate">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(840,250)" name="Splitter">
+    <comp lib="0" loc="(970,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="4" loc="(450,560)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(1940,590)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit0" val="none"/>
       <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(580,860)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(600,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1560,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="1" loc="(1180,490)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="12" loc="(1120,490)" name="Regfile"/>
+    <comp lib="6" loc="(1437,1244)" name="Text">
+      <a name="text" val="ALU Result"/>
+    </comp>
+    <comp lib="0" loc="(350,1350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1670,1130)" name="Tunnel">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(280,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp lib="4" loc="(530,1270)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="4" loc="(2100,590)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="0" loc="(2030,630)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1070,770)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="1"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+      <a name="bit11" val="1"/>
+      <a name="bit12" val="1"/>
+      <a name="bit13" val="1"/>
+      <a name="bit14" val="1"/>
+      <a name="bit15" val="1"/>
+      <a name="bit16" val="1"/>
+      <a name="bit17" val="1"/>
+      <a name="bit18" val="1"/>
+      <a name="bit19" val="1"/>
+      <a name="bit20" val="1"/>
+      <a name="bit21" val="1"/>
+      <a name="bit22" val="1"/>
+      <a name="bit23" val="1"/>
+      <a name="bit24" val="1"/>
+      <a name="bit25" val="1"/>
+      <a name="bit26" val="1"/>
+      <a name="bit27" val="1"/>
+      <a name="bit28" val="2"/>
+      <a name="bit29" val="2"/>
+      <a name="bit30" val="2"/>
+      <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="2" loc="(1500,550)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(1175,1145)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="0" loc="(520,420)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1050,950)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(220,1270)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(360,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1700,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="6" loc="(1656,674)" name="Text">
+      <a name="text" val="WriteDataEX"/>
+    </comp>
+    <comp lib="0" loc="(1490,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="4" loc="(670,650)" name="ROM">
+      <a name="addrWidth" val="9"/>
+      <a name="dataWidth" val="32"/>
+      <a name="contents">addr/data: 9 32
+201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
+401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
+23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
+23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
+1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
+20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
+23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
+8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
+23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
+8fda0000 409a0000 201a0000 409a0800 42000018
+</a>
+    </comp>
+    <comp lib="0" loc="(1480,1170)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(1880,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(230,1330)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(2220,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(840,330)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
       <a name="bit6" val="none"/>
       <a name="bit7" val="none"/>
       <a name="bit8" val="none"/>
@@ -640,118 +911,54 @@
       <a name="bit23" val="none"/>
       <a name="bit24" val="none"/>
       <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(480,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
+    <comp lib="6" loc="(1165,1186)" name="Text">
+      <a name="text" val="Branch Addr"/>
     </comp>
-    <comp lib="1" loc="(1710,340)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="3" loc="(640,850)" name="Adder">
+      <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(680,1290)" name="Probe">
+    <comp loc="(360,1330)" name="Hazard Unit"/>
+    <comp lib="0" loc="(1110,1320)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Load/Use"/>
-      <a name="labelloc" val="north"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
     </comp>
     <comp lib="0" loc="(2010,1050)" name="Tunnel">
       <a name="label" val="IsCOP0MEM"/>
     </comp>
-    <comp lib="0" loc="(1480,1170)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
+    <comp loc="(1770,150)" name="EX/MEM"/>
+    <comp lib="6" loc="(1347,1084)" name="Text">
+      <a name="text" val="IsEret"/>
     </comp>
-    <comp lib="0" loc="(970,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="2" loc="(1000,690)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2220,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="6" loc="(1656,674)" name="Text">
-      <a name="text" val="WriteDataEX"/>
-    </comp>
-    <comp lib="4" loc="(2100,590)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="0" loc="(1030,760)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(580,860)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
-      <a name="facing" val="south"/>
+    <comp lib="2" loc="(260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="4" loc="(670,650)" name="ROM">
-      <a name="addrWidth" val="9"/>
-      <a name="dataWidth" val="32"/>
-      <a name="contents">addr/data: 9 32
-201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
-401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
-23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
-23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
-1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
-20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
-23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
-8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
-23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
-8fda0000 409a0000 201a0000 409a0800 42000018
-</a>
-    </comp>
-    <comp lib="0" loc="(1120,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="1" loc="(1640,1190)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="0" loc="(840,850)" name="Splitter">
+    <comp lib="7" loc="(1670,590)" name="ALU"/>
+    <comp lib="11" loc="(950,830)" name="Immediate Extender"/>
+    <comp lib="0" loc="(840,700)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
       <a name="bit11" val="0"/>
       <a name="bit12" val="0"/>
       <a name="bit13" val="0"/>
@@ -774,61 +981,116 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="6" loc="(1214,627)" name="Text">
-      <a name="text" val="Shamt"/>
+    <comp loc="(1370,140)" name="ID/EX"/>
+    <comp lib="0" loc="(1220,1290)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RsOutput"/>
     </comp>
-    <comp lib="0" loc="(1280,150)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
+    <comp lib="1" loc="(1710,340)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="6" loc="(1165,1186)" name="Text">
-      <a name="text" val="Branch Addr"/>
+    <comp lib="0" loc="(490,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="BranchSuccess"/>
     </comp>
-    <comp lib="2" loc="(2360,570)" name="Multiplexer">
+    <comp lib="0" loc="(550,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="6" loc="(860,688)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="0" loc="(1690,1040)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="9" loc="(680,360)" name="statistics"/>
+    <comp lib="0" loc="(1870,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(2170,1110)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(1080,700)" name="Multiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
+      <a name="width" val="5"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1320,640)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
     </comp>
     <comp lib="2" loc="(1600,630)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(570,280)" name="Splitter">
+    <comp lib="0" loc="(980,920)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(760,130)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1380,1130)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="fanout" val="8"/>
+    </comp>
+    <comp lib="0" loc="(1200,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="1" loc="(440,700)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="1" loc="(1740,280)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2290,510)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(840,770)" name="Splitter">
+      <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit1" val="0"/>
       <a name="bit2" val="0"/>
       <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-      <a name="bit16" val="4"/>
-      <a name="bit17" val="4"/>
-      <a name="bit18" val="4"/>
-      <a name="bit19" val="4"/>
-      <a name="bit20" val="5"/>
-      <a name="bit21" val="5"/>
-      <a name="bit22" val="5"/>
-      <a name="bit23" val="5"/>
-      <a name="bit24" val="6"/>
-      <a name="bit25" val="6"/>
-      <a name="bit26" val="6"/>
-      <a name="bit27" val="6"/>
-      <a name="bit28" val="7"/>
-      <a name="bit29" val="7"/>
-      <a name="bit30" val="7"/>
-      <a name="bit31" val="7"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
     <comp lib="0" loc="(730,560)" name="Splitter">
       <a name="facing" val="north"/>
@@ -868,45 +1130,13 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(550,770)" name="Tunnel">
+    <comp lib="2" loc="(1000,690)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(390,1290)" name="NOT Gate">
       <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
     </comp>
-    <comp loc="(1290,180)" name="RegWrite_Decider"/>
-    <comp lib="0" loc="(920,540)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(930,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(1220,1290)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="3" loc="(1530,1160)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1040,920)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="6" loc="(863,316)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp loc="(1370,140)" name="ID/EX"/>
-    <comp lib="0" loc="(1320,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp loc="(1770,150)" name="EX/MEM"/>
-    <comp loc="(2160,140)" name="MEM/WB"/>
     <comp lib="0" loc="(700,370)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="6"/>
@@ -919,34 +1149,297 @@
       <a name="bit4" val="1"/>
       <a name="bit5" val="0"/>
     </comp>
-    <comp lib="6" loc="(1579,1326)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
+    <comp lib="0" loc="(830,880)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
     </comp>
-    <comp loc="(1120,490)" name="Regfile_Wrapper"/>
-    <comp lib="4" loc="(470,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(1560,160)" name="Tunnel">
+    <comp lib="0" loc="(2250,460)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(890,1030)" name="Tunnel">
-      <a name="facing" val="east"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="6" loc="(1317,872)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
+    <comp lib="0" loc="(840,850)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="2" loc="(360,560)" name="Multiplexer">
+    <comp lib="0" loc="(2190,1110)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(2460,590)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1870,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="0" loc="(840,550)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="12" loc="(950,830)" name="Immediate Extender"/>
+    <comp lib="2" loc="(160,520)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1090,500)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rs"/>
+    </comp>
+    <comp lib="2" loc="(2360,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(980,990)" name="CP0"/>
+    <comp lib="2" loc="(210,530)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1720,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(610,310)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(1980,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(1630,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="0" loc="(1160,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="3" loc="(1590,1150)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="6" loc="(1443,1265)" name="Text">
+      <a name="text" val="Memory Result"/>
+    </comp>
+    <comp lib="0" loc="(930,920)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(1570,1060)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp lib="0" loc="(460,560)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="10" loc="(2230,460)" name="syscall_decoder"/>
+    <comp lib="0" loc="(920,540)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(650,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(840,510)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="2" loc="(310,550)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(340,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="0" loc="(680,1290)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Load/Use"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp loc="(740,140)" name="IF/ID">
+      <a name="labelfont" val="Monaco bold 44"/>
+    </comp>
+    <comp lib="0" loc="(1610,1110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="JumpEX"/>
+    </comp>
+    <comp lib="0" loc="(1040,920)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="5" loc="(590,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
     <comp lib="0" loc="(460,710)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -984,22 +1477,334 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="6" loc="(859,501)" name="Text">
-      <a name="text" val="RS"/>
+    <comp lib="2" loc="(430,650)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(250,1300)" name="Tunnel">
-      <a name="label" val="Halt"/>
+    <comp loc="(1290,180)" name="RegWrite_Decider"/>
+    <comp lib="2" loc="(480,560)" name="Demultiplexer">
+      <a name="width" val="9"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="7" loc="(1670,590)" name="ALU"/>
+    <comp lib="6" loc="(1314,841)" name="Text">
+      <a name="text" val="Immediate"/>
+    </comp>
+    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(570,280)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+      <a name="bit11" val="2"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+      <a name="bit14" val="3"/>
+      <a name="bit15" val="3"/>
+      <a name="bit16" val="4"/>
+      <a name="bit17" val="4"/>
+      <a name="bit18" val="4"/>
+      <a name="bit19" val="4"/>
+      <a name="bit20" val="5"/>
+      <a name="bit21" val="5"/>
+      <a name="bit22" val="5"/>
+      <a name="bit23" val="5"/>
+      <a name="bit24" val="6"/>
+      <a name="bit25" val="6"/>
+      <a name="bit26" val="6"/>
+      <a name="bit27" val="6"/>
+      <a name="bit28" val="7"/>
+      <a name="bit29" val="7"/>
+      <a name="bit30" val="7"/>
+      <a name="bit31" val="7"/>
+    </comp>
+    <comp lib="0" loc="(2100,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="0" loc="(840,250)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1030,710)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="5" loc="(550,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1030,760)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1120,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1110,540)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="5" loc="(710,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(420,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(550,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1640,1090)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="0" loc="(510,1300)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1520,290)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
+    </comp>
+    <comp lib="6" loc="(584,110)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp loc="(2160,140)" name="MEM/WB"/>
+    <comp lib="0" loc="(1760,60)" name="Tunnel">
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="2" loc="(1340,500)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(857,539)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="6" loc="(2010,695)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="6" loc="(2166,1226)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="2" loc="(2410,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1800,1120)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(950,470)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(840,630)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="4" loc="(390,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
+    </comp>
+    <comp lib="6" loc="(1214,627)" name="Text">
+      <a name="text" val="Shamt"/>
+    </comp>
+    <comp lib="2" loc="(1950,770)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1640,1190)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="6" loc="(1579,1326)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="0" loc="(1320,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RsOutput"/>
+    </comp>
+    <comp lib="0" loc="(400,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="6" loc="(1316,692)" name="Text">
+      <a name="text" val="WriteReg#"/>
+    </comp>
+    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(1530,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(1340,590)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(470,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(210,1330)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="6" loc="(863,316)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
     <comp lib="0" loc="(870,1320)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="9" loc="(890,150)" name="Control"/>
-    <comp lib="6" loc="(1175,1145)" name="Text">
-      <a name="text" val="JR Addr"/>
+    <comp lib="0" loc="(620,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
     </comp>
-    <comp loc="(360,1330)" name="Hazard Unit"/>
+    <comp lib="0" loc="(550,1270)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(930,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="2" loc="(220,1280)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(1315,765)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="0" loc="(1490,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
     <comp lib="4" loc="(670,550)" name="ROM">
       <a name="addrWidth" val="9"/>
       <a name="dataWidth" val="32"/>
@@ -1048,322 +1853,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="0" loc="(920,520)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(510,1300)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(980,920)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="6" loc="(1347,1084)" name="Text">
-      <a name="text" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(2030,630)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(840,770)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1140,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="6" loc="(1315,765)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="1" loc="(380,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(1314,841)" name="Text">
-      <a name="text" val="Immediate"/>
-    </comp>
-    <comp lib="0" loc="(760,130)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(2170,1110)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(930,920)" name="Tunnel">
+    <comp lib="0" loc="(920,1070)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="ExpSrc0"/>
+      <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="0" loc="(950,450)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="2" loc="(2410,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(490,1280)" name="Tunnel">
+    <comp lib="0" loc="(330,660)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="BranchSuccess"/>
+      <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="0" loc="(600,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(840,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(220,1280)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(320,520)" name="Constant">
+    <comp lib="5" loc="(650,760)" name="Button">
       <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x800"/>
     </comp>
-    <comp lib="4" loc="(450,560)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="0" loc="(2220,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="4" loc="(610,310)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="6" loc="(857,539)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="1" loc="(390,1290)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="6" loc="(862,240)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="0" loc="(1070,770)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="1"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="1"/>
-      <a name="bit9" val="1"/>
-      <a name="bit10" val="1"/>
-      <a name="bit11" val="1"/>
-      <a name="bit12" val="1"/>
-      <a name="bit13" val="1"/>
-      <a name="bit14" val="1"/>
-      <a name="bit15" val="1"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="2"/>
-      <a name="bit29" val="2"/>
-      <a name="bit30" val="2"/>
-      <a name="bit31" val="2"/>
-    </comp>
-    <comp lib="6" loc="(584,110)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="0" loc="(550,1270)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="2" loc="(2460,590)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(650,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(840,630)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp loc="(740,140)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
-    </comp>
-    <comp lib="2" loc="(1340,500)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(682,877)" name="Text">
-      <a name="text" val="PCPlus4IF"/>
-    </comp>
-    <comp lib="1" loc="(750,1290)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="2" loc="(210,530)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1940,590)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+    <comp lib="6" loc="(1317,872)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
     </comp>
     <comp lib="2" loc="(1960,1070)" name="Multiplexer">
       <a name="facing" val="south"/>
@@ -1371,518 +1873,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="2" loc="(1530,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(2010,695)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(1030,710)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="0" loc="(220,1270)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(620,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(840,510)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="4" loc="(540,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="1" loc="(1740,280)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(550,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(830,880)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="5" loc="(590,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1490,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="2" loc="(1500,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1040,1060)" name="Tunnel">
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(210,1330)" name="Clock">
+    <comp lib="0" loc="(1780,1120)" name="Constant">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(1110,540)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="2" loc="(480,560)" name="Demultiplexer">
-      <a name="width" val="9"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="6" loc="(1437,1244)" name="Text">
-      <a name="text" val="ALU Result"/>
-    </comp>
-    <comp lib="1" loc="(1180,490)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="10" loc="(680,360)" name="statistics"/>
-    <comp lib="0" loc="(1320,640)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-    </comp>
-    <comp loc="(980,990)" name="CP0"/>
-    <comp lib="0" loc="(1640,1090)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="0" loc="(330,660)" name="Tunnel">
+    <comp lib="0" loc="(2220,510)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(1980,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="5" loc="(650,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="3" loc="(1590,1150)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="2" loc="(160,520)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(350,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1630,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="0" loc="(1720,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(230,1330)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1490,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(1090,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="6" loc="(2439,1205)" name="Text">
-      <a name="text" val="WB_DATA"/>
-    </comp>
-    <comp lib="0" loc="(1760,60)" name="Tunnel">
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="0" loc="(2100,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0MEM"/>
-    </comp>
-    <comp lib="0" loc="(1800,1120)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(430,650)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(1340,590)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1167,1164)" name="Text">
-      <a name="text" val="Jump Addr"/>
-    </comp>
-    <comp lib="0" loc="(1700,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="5" loc="(600,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1610,1110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="0" loc="(340,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="4" loc="(530,1270)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="3" loc="(640,850)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(840,330)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(310,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(280,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="0" loc="(1520,290)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
-    </comp>
-    <comp lib="0" loc="(1200,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-    </comp>
-    <comp lib="6" loc="(860,688)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="2" loc="(1950,770)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(2166,1226)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="0" loc="(1160,480)" name="Tunnel">
-      <a name="facing" val="south"/>
       <a name="width" val="32"/>
       <a name="label" val="a0"/>
     </comp>
-    <comp lib="0" loc="(1690,1040)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="0" loc="(950,470)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(1520,350)" name="Tunnel">
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="5" loc="(710,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="4" loc="(390,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="0" loc="(1110,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="0" loc="(400,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1380,1130)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1090,500)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="0" loc="(1670,1110)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
-    </comp>
-    <comp lib="5" loc="(550,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="6" loc="(1443,1265)" name="Text">
-      <a name="text" val="Memory Result"/>
-    </comp>
-    <comp lib="0" loc="(1570,1060)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="2" loc="(720,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1190,630)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="2" loc="(1080,700)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(460,560)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2190,1110)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(2290,510)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(520,420)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(2250,460)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="11" loc="(2230,460)" name="syscall_decoder"/>
-    <comp lib="0" loc="(840,700)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1880,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(2010,750)" name="Tunnel">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(980,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="1" loc="(440,700)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="1" loc="(290,690)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="6" loc="(682,877)" name="Text">
+      <a name="text" val="PCPlus4IF"/>
     </comp>
   </circuit>
   <circuit name="IF/ID">
@@ -1921,6 +1921,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(310,470)" to="(350,470)"/>
     <wire from="(370,520)" to="(570,520)"/>
     <wire from="(370,420)" to="(570,420)"/>
+    <comp lib="0" loc="(340,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
     <comp lib="0" loc="(410,470)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -1929,6 +1935,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlus4IF"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="4" loc="(380,370)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(380,470)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
     <comp lib="0" loc="(410,370)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -1936,23 +1948,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="InstID"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(380,370)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(310,470)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
     </comp>
     <comp lib="0" loc="(160,350)" name="Pin">
       <a name="facing" val="south"/>
@@ -1965,11 +1960,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="InstIF"/>
     </comp>
-    <comp lib="0" loc="(340,590)" name="Pin">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(570,350)" name="Pin">
+      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(310,470)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
     </comp>
   </circuit>
   <circuit name="ID/EX">
@@ -2273,8 +2273,119 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(900,630)" to="(980,630)"/>
     <wire from="(900,390)" to="(980,390)"/>
     <wire from="(1230,410)" to="(1250,410)"/>
+    <comp lib="0" loc="(1240,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(590,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,670)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(1230,530)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,600)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="0" loc="(240,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R2EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1180,710)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#ID"/>
+    </comp>
+    <comp lib="0" loc="(1180,530)" name="Pin">
+      <a name="label" val="IsJRID"/>
+    </comp>
+    <comp lib="0" loc="(1250,590)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(180,830)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(590,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,660)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
+    </comp>
+    <comp lib="4" loc="(910,600)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1230,590)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="0" loc="(1180,410)" name="Pin">
       <a name="label" val="JumpID"/>
+    </comp>
+    <comp lib="0" loc="(930,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,720)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(220,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(520,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ShamtID"/>
+    </comp>
+    <comp lib="0" loc="(1250,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BranchEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(240,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R1EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,540)" name="Pin">
+      <a name="label" val="RegWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1180,590)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="4" loc="(570,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1250,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="JumpEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(590,560)" name="Pin">
       <a name="facing" val="west"/>
@@ -2283,23 +2394,115 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlusEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
+    <comp lib="0" loc="(240,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
+      <a name="label" val="ImmEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
+    <comp lib="4" loc="(1230,470)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,600)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeqEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1240,650)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(570,360)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(860,360)" name="Pin">
       <a name="label" val="IsJALID"/>
     </comp>
+    <comp lib="0" loc="(170,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(930,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,780)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="0" loc="(860,420)" name="Pin">
       <a name="label" val="IsShamtID"/>
+    </comp>
+    <comp lib="0" loc="(520,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="JumpAddr"/>
+    </comp>
+    <comp lib="4" loc="(1230,710)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(170,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ImmID"/>
+    </comp>
+    <comp lib="4" loc="(570,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(220,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(930,780)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1180,470)" name="Pin">
+      <a name="label" val="BranchID"/>
+    </comp>
+    <comp lib="0" loc="(920,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALEX"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(930,480)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="MemtoRegEX"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,720)" name="Pin">
+      <a name="label" val="IsExceptionID"/>
+    </comp>
+    <comp lib="0" loc="(930,660)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrcEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,540)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(910,780)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1230,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,480)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
     </comp>
     <comp lib="0" loc="(1250,780)" name="Pin">
       <a name="facing" val="west"/>
@@ -2312,45 +2515,31 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="PCPlus4ID"/>
     </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
+    <comp lib="0" loc="(1180,780)" name="Pin">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="4" loc="(1230,650)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(1250,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(220,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(1230,350)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
+    <comp lib="4" loc="(910,420)" name="Register">
+      <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(590,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(170,560)" name="Pin">
       <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,670)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(930,660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrcEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
+      <a name="label" val="R2ID"/>
     </comp>
     <comp lib="0" loc="(60,290)" name="Pin">
       <a name="facing" val="south"/>
@@ -2358,41 +2547,40 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="clk"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="4" loc="(910,540)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(240,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ImmEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
-    </comp>
     <comp lib="0" loc="(930,540)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="RegWriteEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
+    <comp lib="0" loc="(1180,350)" name="Pin">
+      <a name="label" val="MemWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1180,650)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
+    </comp>
+    <comp lib="0" loc="(170,670)" name="Pin">
       <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="CP0Dout"/>
     </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
+    <comp lib="4" loc="(910,480)" name="Register">
+      <a name="width" val="1"/>
     </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(100,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
+    <comp lib="0" loc="(1250,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJREX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,660)" name="Register">
       <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(240,670)" name="Pin">
@@ -2402,196 +2590,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="CP0Dout"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(1240,650)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,720)" name="Pin">
-      <a name="label" val="IsExceptionID"/>
-    </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
-    </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
-    </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,470)" name="Pin">
-      <a name="label" val="BranchID"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(240,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R2EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,670)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(180,830)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,590)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,780)" name="Pin">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
-    </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(860,780)" name="Pin">
       <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="0" loc="(240,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R1EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
     </comp>
   </circuit>
   <circuit name="EX/MEM">
@@ -2702,12 +2702,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,160)" to="(860,190)"/>
     <wire from="(850,470)" to="(850,500)"/>
     <wire from="(560,70)" to="(980,70)"/>
-    <wire from="(470,380)" to="(560,380)"/>
-    <wire from="(870,240)" to="(890,240)"/>
-    <wire from="(470,260)" to="(560,260)"/>
     <wire from="(470,500)" to="(560,500)"/>
     <wire from="(980,390)" to="(980,500)"/>
     <wire from="(470,140)" to="(560,140)"/>
+    <wire from="(470,380)" to="(560,380)"/>
+    <wire from="(870,240)" to="(890,240)"/>
+    <wire from="(470,260)" to="(560,260)"/>
     <wire from="(640,290)" to="(850,290)"/>
     <wire from="(300,80)" to="(640,80)"/>
     <wire from="(980,190)" to="(980,290)"/>
@@ -2757,19 +2757,95 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(430,530)" to="(450,530)"/>
     <wire from="(430,410)" to="(450,410)"/>
     <wire from="(830,460)" to="(840,460)"/>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
+    <comp lib="0" loc="(820,340)" name="Pin">
       <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
+      <a name="label" val="JumpAddrEX"/>
+    </comp>
+    <comp lib="0" loc="(500,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(300,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(820,450)" name="Pin">
       <a name="width" val="32"/>
       <a name="label" val="CP0Dout"/>
     </comp>
+    <comp lib="0" loc="(430,350)" name="Pin">
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="0" loc="(890,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,230)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(480,170)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(480,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(440,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(430,170)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
+    </comp>
+    <comp lib="0" loc="(820,140)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="0" loc="(430,410)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(820,240)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataEX"/>
+    </comp>
+    <comp lib="4" loc="(870,240)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(430,110)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(430,290)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
+    </comp>
+    <comp lib="0" loc="(890,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="4" loc="(870,340)" name="Register">
       <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,110)" name="Register">
+      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(350,60)" name="Pin">
       <a name="facing" val="south"/>
@@ -2777,31 +2853,26 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="clr"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
+    <comp lib="4" loc="(870,450)" name="Register">
       <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
     </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
+    <comp lib="4" loc="(480,350)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(500,110)" name="Pin">
+    <comp lib="0" loc="(430,530)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="4" loc="(870,140)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(500,530)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="IsJALMEM"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(500,170)" name="Pin">
       <a name="facing" val="west"/>
@@ -2809,8 +2880,23 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemtoRegMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
+    <comp lib="4" loc="(480,290)" name="Register">
       <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(500,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(500,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallMEM"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(430,470)" name="Pin">
       <a name="label" val="IsSyscallEX"/>
@@ -2822,51 +2908,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="CP0Dout"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(870,450)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="4" loc="(480,530)" name="Register">
       <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,530)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="4" loc="(480,170)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(500,350)" name="Pin">
       <a name="facing" val="west"/>
@@ -2881,53 +2924,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUResultMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(500,230)" name="Pin">
+    <comp lib="0" loc="(500,110)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(890,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(480,530)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(500,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionMEM"/>
+      <a name="label" val="IsJALMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
   </circuit>
@@ -3070,11 +3070,24 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(250,290)" to="(390,290)"/>
     <wire from="(290,200)" to="(490,200)"/>
     <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="0" loc="(720,390)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataMEM"/>
+    </comp>
+    <comp lib="0" loc="(360,440)" name="Pin">
+      <a name="label" val="IsExceptionMEM"/>
+    </comp>
+    <comp lib="4" loc="(770,390)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(360,380)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(790,290)" name="Pin">
       <a name="facing" val="west"/>
@@ -3083,64 +3096,33 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUResultWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(360,260)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
+    <comp lib="4" loc="(410,560)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(360,500)" name="Pin">
+      <a name="label" val="IsSyscallMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="0" loc="(430,260)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="IsJALWB"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(770,290)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="0" loc="(720,390)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
-    </comp>
-    <comp lib="0" loc="(790,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(410,380)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(410,560)" name="Register">
-      <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(370,720)" name="Pin">
       <a name="facing" val="north"/>
@@ -3148,11 +3130,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="En"/>
       <a name="labelloc" val="south"/>
     </comp>
+    <comp lib="4" loc="(410,500)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
     <comp lib="0" loc="(290,180)" name="Pin">
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
       <a name="label" val="clr"/>
       <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(720,610)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(720,290)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+    </comp>
+    <comp lib="4" loc="(770,610)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(720,500)" name="Pin">
       <a name="width" val="32"/>
@@ -3164,49 +3169,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RegWriteWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(250,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(410,380)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(360,560)" name="Pin">
       <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(790,610)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(770,610)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
-      <a name="labelloc" val="east"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
     <comp lib="0" loc="(790,390)" name="Pin">
       <a name="facing" val="west"/>
@@ -3215,120 +3190,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ReadDataWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(720,610)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-  </circuit>
-  <circuit name="Regfile_Wrapper">
-    <a name="circuit" val="Regfile_Wrapper"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#b4ff80" height="120" stroke="none" width="108" x="240" y="160"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="257" y="255">RW</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="258" y="275">Din</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="337" y="215">R1</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="336" y="231">R2</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="258" y="184">R1#</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="259" y="225">R2#</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="300" y="177">clk</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="328" y="175">WE</text>
-      <text font-family="SansSerif" font-size="16" font-weight="bold" text-anchor="middle" x="318" y="272">RegFile</text>
-      <circ-port height="8" pin="240,190" width="8" x="236" y="176"/>
-      <circ-port height="8" pin="240,210" width="8" x="236" y="216"/>
-      <circ-port height="8" pin="240,230" width="8" x="236" y="246"/>
-      <circ-port height="10" pin="400,140" width="10" x="345" y="205"/>
-      <circ-port height="10" pin="400,260" width="10" x="345" y="225"/>
-      <circ-port height="8" pin="300,350" width="8" x="236" y="266"/>
-      <circ-port height="8" pin="320,290" width="8" x="326" y="156"/>
-      <circ-port height="8" pin="350,290" width="8" x="296" y="156"/>
-      <circ-port height="10" pin="300,80" width="10" x="255" y="155"/>
-      <circ-port height="10" pin="400,80" width="10" x="275" y="155"/>
-      <circ-anchor facing="east" height="6" width="6" x="237" y="157"/>
-    </appear>
-    <wire from="(300,80)" to="(300,180)"/>
-    <wire from="(370,220)" to="(390,220)"/>
-    <wire from="(370,200)" to="(390,200)"/>
-    <wire from="(300,240)" to="(300,350)"/>
-    <wire from="(400,80)" to="(400,90)"/>
-    <wire from="(390,220)" to="(390,260)"/>
-    <wire from="(390,260)" to="(400,260)"/>
-    <wire from="(390,140)" to="(400,140)"/>
-    <wire from="(320,90)" to="(400,90)"/>
-    <wire from="(320,240)" to="(320,290)"/>
-    <wire from="(350,240)" to="(350,290)"/>
-    <wire from="(390,140)" to="(390,200)"/>
-    <wire from="(240,210)" to="(280,210)"/>
-    <wire from="(240,190)" to="(280,190)"/>
-    <wire from="(240,230)" to="(280,230)"/>
-    <wire from="(320,90)" to="(320,180)"/>
-    <comp lib="0" loc="(400,140)" name="Pin">
+    <comp lib="0" loc="(790,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1"/>
+      <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(400,260)" name="Pin">
+    <comp lib="4" loc="(410,440)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(770,500)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(770,290)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(410,320)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(410,260)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(790,610)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2"/>
+      <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="8" loc="(370,210)" name="main"/>
-    <comp lib="0" loc="(320,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WE"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(240,190)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1#"/>
-    </comp>
-    <comp lib="0" loc="(400,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="a0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="v0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2#"/>
-    </comp>
-    <comp lib="0" loc="(240,230)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RW"/>
-    </comp>
-    <comp lib="0" loc="(300,350)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
-    </comp>
-    <comp lib="0" loc="(350,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">
@@ -3447,13 +3336,9 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,600)" to="(1000,600)"/>
     <wire from="(900,550)" to="(910,550)"/>
     <wire from="(900,530)" to="(910,530)"/>
-    <comp lib="0" loc="(1390,350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(130,170)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteMEM"/>
+    <comp lib="0" loc="(160,290)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
     </comp>
     <comp lib="0" loc="(1420,450)" name="Pin">
       <a name="facing" val="west"/>
@@ -3465,13 +3350,31 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="facing" val="east"/>
       <a name="label" val="ReadWriteEX"/>
     </comp>
-    <comp lib="0" loc="(900,320)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(130,170)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteMEM"/>
     </comp>
-    <comp loc="(800,370)" name="Hazard_Detector"/>
-    <comp lib="6" loc="(912,490)" name="Text">
-      <a name="text" val="Rt Hazard in MEM"/>
+    <comp lib="0" loc="(900,550)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(570,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(170,50)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1550,150)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(840,220)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadWriteMEM"/>
     </comp>
     <comp lib="0" loc="(1540,510)" name="Pin">
       <a name="facing" val="west"/>
@@ -3480,63 +3383,59 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="BubbleNum"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(980,350)" name="Constant">
+      <a name="width" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1210,410)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="IsLW"/>
+    </comp>
+    <comp lib="6" loc="(909,590)" name="Text">
+      <a name="text" val="Rt Hazard in EX"/>
+    </comp>
+    <comp lib="0" loc="(360,200)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="2" loc="(1020,550)" name="Multiplexer">
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(640,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
     <comp lib="1" loc="(1540,150)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
       <a name="negate0" val="true"/>
     </comp>
-    <comp lib="1" loc="(1550,340)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
+    <comp loc="(800,570)" name="Hazard_Detector"/>
     <comp lib="0" loc="(820,250)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="0" loc="(1350,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(740,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(130,290)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="0" loc="(900,530)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="4" loc="(1480,510)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(1550,150)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(940,330)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="2" loc="(1020,340)" name="Multiplexer">
       <a name="width" val="2"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1570,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushID"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(160,330)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(900,320)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(130,210)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(130,50)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(900,340)" name="Constant">
       <a name="width" val="2"/>
@@ -3545,9 +3444,9 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(1350,180)" name="Pin">
       <a name="label" val="IsToBranchOrJump"/>
     </comp>
-    <comp lib="0" loc="(160,290)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
+    <comp loc="(800,270)" name="Hazard_Detector"/>
+    <comp lib="6" loc="(1204,445)" name="Text">
+      <a name="text" val="hasHazard"/>
     </comp>
     <comp lib="0" loc="(1040,340)" name="Pin">
       <a name="facing" val="west"/>
@@ -3556,45 +3455,39 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RsOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp loc="(800,470)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(1210,410)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="IsLW"/>
-    </comp>
-    <comp lib="0" loc="(980,560)" name="Constant">
-      <a name="width" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1020,340)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(790,460)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(150,210)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(130,50)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="6" loc="(1204,445)" name="Text">
-      <a name="text" val="hasHazard"/>
-    </comp>
-    <comp lib="0" loc="(790,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
     <comp lib="0" loc="(130,330)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="RT"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp loc="(800,270)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(150,170)" name="Tunnel">
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(900,530)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
     <comp lib="0" loc="(150,130)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(790,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(1460,550)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(790,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(130,130)" name="Pin">
+      <a name="tristate" val="false"/>
       <a name="label" val="ReadRs"/>
     </comp>
     <comp lib="0" loc="(530,250)" name="Tunnel">
@@ -3602,67 +3495,40 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="width" val="5"/>
       <a name="label" val="RT"/>
     </comp>
-    <comp lib="6" loc="(909,590)" name="Text">
-      <a name="text" val="Rt Hazard in EX"/>
+    <comp lib="0" loc="(160,250)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp loc="(800,370)" name="Hazard_Detector"/>
+    <comp lib="6" loc="(917,390)" name="Text">
+      <a name="text" val="Rs Hazard in EX"/>
+    </comp>
+    <comp lib="0" loc="(740,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="2" loc="(940,330)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(912,490)" name="Text">
+      <a name="text" val="Rt Hazard in MEM"/>
     </comp>
     <comp lib="0" loc="(360,240)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWriteEX"/>
     </comp>
-    <comp lib="0" loc="(130,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="1" loc="(1160,450)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
     <comp lib="1" loc="(1290,430)" name="AND Gate">
       <a name="inputs" val="2"/>
     </comp>
-    <comp loc="(800,570)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(130,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(380,240)" name="Tunnel">
-      <a name="label" val="ReadWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(980,350)" name="Constant">
-      <a name="width" val="2"/>
-    </comp>
-    <comp lib="0" loc="(380,200)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="2" loc="(1020,550)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(160,250)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(1460,550)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(640,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
+    <comp loc="(800,470)" name="Hazard_Detector"/>
     <comp lib="6" loc="(922,290)" name="Text">
       <a name="text" val="Rs Hazard in MEM"/>
-    </comp>
-    <comp lib="2" loc="(940,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(840,220)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadWriteMEM"/>
     </comp>
     <comp lib="0" loc="(1040,550)" name="Pin">
       <a name="facing" val="west"/>
@@ -3671,32 +3537,13 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RtOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(570,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="RS"/>
+    <comp lib="2" loc="(940,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(790,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(150,170)" name="Tunnel">
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(140,250)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="6" loc="(917,390)" name="Text">
-      <a name="text" val="Rs Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(360,200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(170,50)" name="Tunnel">
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(380,240)" name="Tunnel">
+      <a name="label" val="ReadWriteEX"/>
     </comp>
     <comp lib="0" loc="(1420,410)" name="Pin">
       <a name="facing" val="west"/>
@@ -3704,21 +3551,63 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="StallIF"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="1" loc="(1550,340)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1570,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="0" loc="(790,360)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(1350,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(140,250)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="1" loc="(1160,450)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(980,560)" name="Constant">
+      <a name="width" val="2"/>
+    </comp>
+    <comp lib="0" loc="(380,200)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
     </comp>
     <comp lib="0" loc="(790,540)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ReadWriteEX"/>
     </comp>
-    <comp lib="0" loc="(160,330)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
+    <comp lib="0" loc="(790,460)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
     </comp>
-    <comp lib="0" loc="(900,550)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x2"/>
+    <comp lib="0" loc="(130,290)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="4" loc="(1480,510)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(150,210)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(1390,350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
   </circuit>
   <circuit name="RegisterRead_Detector">
@@ -4721,491 +4610,7 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,2720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,580)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4550)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1290)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,430)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2090)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4830)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(710,1960)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="1" loc="(510,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,4550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,1960)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2540)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,380)" name="Pin">
@@ -5213,42 +4618,124 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct1"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
+    <comp lib="1" loc="(410,550)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,1260)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,950)" name="AND Gate">
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(690,4550)" name="OR Gate">
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,830)" name="OR Gate">
@@ -5261,31 +4748,177 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="1" loc="(320,1140)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
+    <comp lib="1" loc="(410,690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(410,4260)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,580)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,4550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(410,950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2460)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,910)" name="NOT Gate">
       <a name="size" val="20"/>
@@ -5294,16 +4927,171 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(320,3010)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,210)" name="NOT Gate">
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,2910)" name="NOT Gate">
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,530)" name="Pin">
@@ -5311,46 +5099,147 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+    <comp lib="1" loc="(510,2280)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(610,4820)" name="AND Gate">
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2320)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
+      <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(510,2310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,250)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2090)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(410,4140)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4830)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
   </circuit>
   <circuit name="Hazard_Detector">
@@ -5385,43 +5274,43 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,300)" to="(610,300)"/>
     <wire from="(590,290)" to="(600,290)"/>
     <wire from="(600,340)" to="(610,340)"/>
-    <comp lib="1" loc="(530,330)" name="NOT Gate"/>
+    <comp lib="0" loc="(400,380)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Register#"/>
+    </comp>
+    <comp lib="3" loc="(490,370)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
     <comp lib="0" loc="(700,320)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="Hazard"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(400,380)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Register#"/>
-    </comp>
-    <comp lib="0" loc="(400,340)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg"/>
-    </comp>
     <comp lib="0" loc="(590,310)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
     </comp>
     <comp lib="0" loc="(590,290)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="Read"/>
     </comp>
+    <comp lib="3" loc="(490,330)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
     <comp lib="1" loc="(660,320)" name="AND Gate">
       <a name="inputs" val="4"/>
     </comp>
-    <comp lib="3" loc="(490,370)" name="Comparator">
+    <comp lib="0" loc="(430,320)" name="Constant">
       <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="3" loc="(490,330)" name="Comparator">
+    <comp lib="1" loc="(530,330)" name="NOT Gate"/>
+    <comp lib="0" loc="(400,340)" name="Pin">
       <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg"/>
     </comp>
   </circuit>
   <circuit name="CP0">
@@ -5617,237 +5506,32 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(850,680)" to="(850,730)"/>
     <wire from="(590,240)" to="(590,1190)"/>
     <wire from="(180,1050)" to="(180,1110)"/>
-    <comp lib="0" loc="(1180,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCout"/>
-    </comp>
-    <comp lib="0" loc="(210,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="2" loc="(770,650)" name="Demultiplexer">
+    <comp lib="2" loc="(1150,790)" name="Multiplexer">
       <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(110,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc0"/>
-    </comp>
-    <comp lib="0" loc="(260,160)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ExpBlock"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(370,360)" name="NOT Gate"/>
-    <comp lib="4" loc="(1000,1070)" name="Register">
       <a name="width" val="32"/>
-      <a name="label" val="Cause"/>
-    </comp>
-    <comp lib="0" loc="(870,140)" name="Tunnel">
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="1" loc="(770,570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="0" loc="(760,650)" name="Constant"/>
-    <comp lib="1" loc="(890,720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(880,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="2" loc="(210,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(790,1070)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(290,390)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="1" loc="(440,770)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(810,100)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(270,960)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="6" loc="(306,664)" name="Text">
-      <a name="text" val="Exception Signals"/>
-      <a name="font" val="Monaco plain 26"/>
     </comp>
     <comp lib="4" loc="(990,490)" name="Register">
       <a name="width" val="32"/>
       <a name="trigger" val="low"/>
       <a name="label" val="EPC"/>
     </comp>
-    <comp lib="0" loc="(220,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(710,580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="4" loc="(340,850)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-    </comp>
-    <comp lib="0" loc="(810,180)" name="Pin">
-      <a name="tristate" val="false"/>
+    <comp lib="0" loc="(870,180)" name="Tunnel">
       <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(740,1010)" name="Constant">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(110,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="BlockSrc0"/>
+    </comp>
+    <comp lib="0" loc="(1150,160)" name="Tunnel">
+      <a name="label" val="enable"/>
     </comp>
     <comp lib="0" loc="(810,140)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(1180,790)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Dout"/>
-    </comp>
-    <comp lib="6" loc="(327,306)" name="Text">
-      <a name="text" val="Signal Decoding"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="1" loc="(750,460)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(260,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ExRegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(890,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(490,110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(430,920)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(710,780)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
-    </comp>
-    <comp lib="0" loc="(240,410)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Inst"/>
-    </comp>
-    <comp lib="0" loc="(180,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc1"/>
-    </comp>
-    <comp lib="0" loc="(500,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(150,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1170,930)" name="Tunnel">
-      <a name="label" val="BlockSrc0"/>
-    </comp>
-    <comp lib="0" loc="(1130,950)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(400,390)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(1150,110)" name="Tunnel">
-      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(550,110)" name="Pin">
       <a name="facing" val="west"/>
@@ -5855,175 +5539,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsEret"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1170,950)" name="Tunnel">
-      <a name="label" val="BlockSrc1"/>
-    </comp>
-    <comp lib="0" loc="(780,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(740,1010)" name="Constant">
-      <a name="width" val="32"/>
-    </comp>
     <comp lib="2" loc="(770,490)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1150,160)" name="Tunnel">
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(1030,790)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(390,760)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(260,860)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="0" loc="(710,480)" name="Pin">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(810,180)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="PCin"/>
-    </comp>
-    <comp lib="0" loc="(470,770)" name="Tunnel">
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(290,1030)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(260,890)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="0" loc="(870,100)" name="Tunnel">
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="2" loc="(140,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(280,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
       <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="6" loc="(654,60)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="1" loc="(790,1120)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="2" loc="(280,1070)" name="Demultiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(250,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="BlockSrc2"/>
-    </comp>
-    <comp lib="0" loc="(710,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(870,180)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(780,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(300,460)" name="Splitter">
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(970,990)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1090,160)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(140,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(1130,840)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(400,390)" name="Tunnel">
       <a name="width" val="2"/>
       <a name="label" val="Sel"/>
     </comp>
@@ -6031,41 +5556,13 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="4" loc="(990,950)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Block"/>
-    </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(490,900)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(400,360)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(980,1110)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="4" loc="(450,880)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(740,1070)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x3"/>
-    </comp>
     <comp lib="6" loc="(953,342)" name="Text">
       <a name="text" val="Registers"/>
       <a name="font" val="Monaco plain 26"/>
     </comp>
-    <comp lib="4" loc="(990,780)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Status"/>
+    <comp lib="1" loc="(890,610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="1" loc="(390,460)" name="AND Gate">
       <a name="size" val="30"/>
@@ -6075,17 +5572,48 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="negate4" val="true"/>
       <a name="negate5" val="true"/>
     </comp>
-    <comp lib="0" loc="(780,1130)" name="Tunnel">
+    <comp lib="2" loc="(210,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(890,720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(280,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(500,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(970,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(290,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1090,160)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(810,100)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(780,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1170,930)" name="Tunnel">
+      <a name="label" val="BlockSrc0"/>
+    </comp>
+    <comp lib="0" loc="(280,1080)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(410,460)" name="Tunnel">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(790,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
     </comp>
     <comp lib="0" loc="(300,360)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -6124,22 +5652,207 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
+    <comp lib="0" loc="(1130,950)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(210,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1030,790)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="4" loc="(990,950)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Block"/>
+    </comp>
+    <comp lib="0" loc="(470,770)" name="Tunnel">
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(1180,790)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Dout"/>
+    </comp>
+    <comp lib="1" loc="(750,460)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="1" loc="(790,1010)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
     <comp lib="1" loc="(200,960)" name="OR Gate">
       <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
+    <comp lib="1" loc="(260,890)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(780,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(980,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="0" loc="(970,990)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(940,520)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="0" loc="(750,410)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="0" loc="(970,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(290,390)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(740,1120)" name="Constant">
+    <comp lib="0" loc="(780,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(710,480)" name="Pin">
       <a name="width" val="32"/>
-      <a name="value" val="0x7"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCin"/>
+    </comp>
+    <comp lib="0" loc="(870,140)" name="Tunnel">
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(430,920)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="2" loc="(140,1070)" name="Demultiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(410,460)" name="Tunnel">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(220,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1170,970)" name="Tunnel">
+      <a name="label" val="BlockSrc2"/>
+    </comp>
+    <comp lib="0" loc="(710,780)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Din"/>
+    </comp>
+    <comp lib="0" loc="(390,760)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(550,160)" name="Pin">
       <a name="facing" val="west"/>
@@ -6147,36 +5860,212 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="HasExp"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1090,110)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
+    <comp lib="4" loc="(340,850)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+    </comp>
+    <comp lib="0" loc="(180,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="BlockSrc1"/>
+    </comp>
+    <comp lib="1" loc="(440,770)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(230,110)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ExRegWrite"/>
     </comp>
-    <comp lib="1" loc="(790,1010)" name="Controlled Buffer">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(1090,110)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
     </comp>
-    <comp lib="1" loc="(940,520)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(220,160)" name="Tunnel">
+    <comp lib="0" loc="(880,510)" name="Tunnel">
       <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(240,410)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Inst"/>
+    </comp>
+    <comp lib="6" loc="(306,664)" name="Text">
+      <a name="text" val="Exception Signals"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(260,160)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="label" val="ExpBlock"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(740,1120)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x7"/>
+    </comp>
+    <comp lib="0" loc="(1150,110)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(150,1030)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(490,900)" name="NOT Gate">
+      <a name="facing" val="south"/>
     </comp>
     <comp lib="0" loc="(1030,810)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="ExpBlock"/>
     </comp>
-    <comp lib="0" loc="(1170,970)" name="Tunnel">
+    <comp lib="0" loc="(710,580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(1180,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCout"/>
+    </comp>
+    <comp lib="0" loc="(260,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExRegWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(327,306)" name="Text">
+      <a name="text" val="Signal Decoding"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(300,460)" name="Splitter">
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(710,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(1130,840)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="1" loc="(790,1070)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="1" loc="(770,570)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(740,1070)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x3"/>
+    </comp>
+    <comp lib="4" loc="(1000,1070)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Cause"/>
+    </comp>
+    <comp lib="0" loc="(140,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(760,650)" name="Constant"/>
+    <comp lib="0" loc="(400,360)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(490,110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(260,860)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="1" loc="(790,1120)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(250,1110)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="BlockSrc2"/>
     </comp>
-    <comp lib="2" loc="(1150,790)" name="Multiplexer">
+    <comp lib="0" loc="(790,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="0" loc="(870,100)" name="Tunnel">
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(450,880)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(370,360)" name="NOT Gate"/>
+    <comp lib="0" loc="(220,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="2" loc="(770,650)" name="Demultiplexer">
       <a name="select" val="2"/>
-      <a name="width" val="32"/>
+      <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(270,960)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="4" loc="(990,780)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Status"/>
+    </comp>
+    <comp lib="0" loc="(1170,950)" name="Tunnel">
+      <a name="label" val="BlockSrc1"/>
+    </comp>
+    <comp lib="6" loc="(654,60)" name="Text">
+      <a name="text" val="Input &amp; Output"/>
+      <a name="font" val="Monaco plain 26"/>
     </comp>
   </circuit>
   <circuit name="RegWrite_Decider">
@@ -6197,6 +6086,12 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(390,240)" to="(420,240)"/>
     <wire from="(390,260)" to="(420,260)"/>
     <wire from="(430,270)" to="(430,310)"/>
+    <comp lib="0" loc="(460,250)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FinalRegWrite"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="0" loc="(390,260)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ExRegWrite"/>
@@ -6212,12 +6107,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     </comp>
     <comp lib="2" loc="(450,250)" name="Multiplexer">
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(460,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FinalRegWrite"/>
-      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
 </project>

--- a/src/pipeline_cpu_bubbling.circ
+++ b/src/pipeline_cpu_bubbling.circ
@@ -53,7 +53,7 @@
   </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
-      <a name="select" val="3"/>
+      <a name="width" val="32"/>
     </tool>
     <tool name="Demultiplexer">
       <a name="select" val="5"/>
@@ -78,7 +78,7 @@
   </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
-      <a name="width" val="16"/>
+      <a name="width" val="32"/>
     </tool>
     <tool name="ROM">
       <a name="contents">addr/data: 8 8
@@ -96,11 +96,11 @@
     </tool>
   </lib>
   <lib desc="file#common/alu.circ" name="7"/>
-  <lib desc="file#common/regfile.circ" name="8"/>
-  <lib desc="file#common/control.circ" name="9"/>
-  <lib desc="file#common/statistics.circ" name="10"/>
-  <lib desc="file#common/syscall_decoder.circ" name="11"/>
-  <lib desc="file#common/immediate_extender.circ" name="12"/>
+  <lib desc="file#common/control.circ" name="8"/>
+  <lib desc="file#common/statistics.circ" name="9"/>
+  <lib desc="file#common/syscall_decoder.circ" name="10"/>
+  <lib desc="file#common/immediate_extender.circ" name="11"/>
+  <lib desc="file#common/regfile.circ" name="12"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -451,21 +451,23 @@
     <wire from="(530,360)" to="(540,360)"/>
     <wire from="(560,870)" to="(570,870)"/>
     <wire from="(350,410)" to="(420,410)"/>
+    <comp lib="0" loc="(1750,1050)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(590,120)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="9" loc="(510,350)" name="statistics"/>
     <comp lib="6" loc="(512,867)" name="Text">
       <a name="text" val="PCPlus4IF"/>
     </comp>
-    <comp lib="0" loc="(310,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(200,730)" name="Tunnel">
+    <comp lib="0" loc="(1760,630)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(540,550)" name="Splitter">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(670,620)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -475,11 +477,11 @@
       <a name="bit3" val="none"/>
       <a name="bit4" val="none"/>
       <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
       <a name="bit11" val="none"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
@@ -495,12 +497,18 @@
       <a name="bit23" val="none"/>
       <a name="bit24" val="none"/>
       <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(230,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(670,240)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -539,82 +547,183 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="5" loc="(460,170)" name="Hex Digit Display">
+    <comp lib="3" loc="(1360,930)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
+    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="3" loc="(470,620)" name="Adder">
+    <comp lib="6" loc="(1040,682)" name="Text">
+      <a name="text" val="WriteReg#"/>
+    </comp>
+    <comp lib="6" loc="(690,678)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="6" loc="(689,491)" name="Text">
+      <a name="text" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(670,540)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(530,360)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="3" loc="(1440,920)" name="Adder">
       <a name="width" val="32"/>
     </comp>
-    <comp lib="6" loc="(1005,925)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp loc="(1080,130)" name="ID/EX"/>
-    <comp lib="0" loc="(2030,500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="2" loc="(1260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(490,680)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(692,230)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="0" loc="(420,720)" name="Probe">
+    <comp lib="0" loc="(1780,150)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Bubble Number"/>
-      <a name="labelloc" val="north"/>
+      <a name="label" val="RegWriteMEM"/>
     </comp>
-    <comp lib="0" loc="(480,730)" name="Clock">
+    <comp lib="0" loc="(670,500)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="4" loc="(440,300)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(1520,920)" name="Constant">
       <a name="facing" val="north"/>
+    </comp>
+    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1090,910)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(180,1080)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(830,680)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(693,306)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
+    <comp lib="2" loc="(1290,610)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="2" loc="(1350,620)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(490,670)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(310,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="8" loc="(720,140)" name="Control"/>
+    <comp lib="0" loc="(300,580)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="3" loc="(1440,920)" name="Adder">
+    <comp lib="6" loc="(1973,684)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="0" loc="(410,630)" name="Constant">
       <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
     </comp>
-    <comp lib="6" loc="(1044,617)" name="Text">
-      <a name="text" val="Shamt"/>
-    </comp>
-    <comp lib="2" loc="(200,550)" name="Multiplexer">
+    <comp lib="2" loc="(910,690)" name="Multiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
+      <a name="width" val="5"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp loc="(1510,140)" name="EX/MEM"/>
-    <comp lib="0" loc="(990,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
+    <comp lib="6" loc="(1033,862)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
     </comp>
     <comp lib="4" loc="(1830,580)" name="RAM">
       <a name="addrWidth" val="10"/>
       <a name="dataWidth" val="32"/>
       <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(1510,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
     </comp>
     <comp lib="4" loc="(520,550)" name="ROM">
       <a name="addrWidth" val="10"/>
@@ -664,138 +773,57 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="0" loc="(1520,920)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="6" loc="(1953,236)" name="Text">
-      <a name="text" val="Ignored"/>
-    </comp>
-    <comp lib="6" loc="(1840,685)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="5" loc="(420,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1900,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(800,810)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp loc="(1890,130)" name="MEM/WB"/>
-    <comp lib="0" loc="(1760,630)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp loc="(950,480)" name="Regfile_Wrapper"/>
-    <comp lib="0" loc="(670,500)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(1033,862)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="0" loc="(1310,940)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(180,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(500,730)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="4" loc="(300,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="4" loc="(440,300)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="4" loc="(220,700)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(810,750)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(1480,270)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(230,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1540,920)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(2030,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="10" loc="(510,350)" name="statistics"/>
-    <comp lib="0" loc="(2130,500)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
     <comp lib="0" loc="(450,450)" name="Probe">
       <a name="facing" val="north"/>
       <a name="radix" val="10unsigned"/>
       <a name="label" val="I"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(660,870)" name="Splitter">
+    <comp lib="2" loc="(90,530)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="11" loc="(780,820)" name="Immediate Extender"/>
+    <comp lib="1" loc="(1480,270)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(800,810)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(1310,940)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="6" loc="(1044,617)" name="Text">
+      <a name="text" val="Shamt"/>
+    </comp>
+    <comp lib="4" loc="(370,320)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="4" loc="(300,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(200,730)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="5" loc="(420,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(540,550)" name="Splitter">
       <a name="facing" val="north"/>
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -826,172 +854,14 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit23" val="none"/>
       <a name="bit24" val="none"/>
       <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
       <a name="bit28" val="0"/>
       <a name="bit29" val="0"/>
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="4" loc="(220,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="0" loc="(410,630)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(350,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(150,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(670,320)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1780,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="6" loc="(693,306)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(270,700)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(530,360)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(2080,450)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1750,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="11" loc="(2060,450)" name="syscall_decoder"/>
-    <comp lib="0" loc="(670,690)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1920,910)" name="Constant">
+    <comp lib="0" loc="(1540,920)" name="Constant">
       <a name="facing" val="north"/>
       <a name="value" val="0x0"/>
     </comp>
@@ -1031,36 +901,70 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(970,480)" name="Tunnel">
+    <comp lib="0" loc="(2030,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="1" loc="(580,1030)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="5" loc="(460,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1510,1050)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
+      <a name="label" val="RegWriteEX"/>
     </comp>
-    <comp lib="6" loc="(1040,682)" name="Text">
-      <a name="text" val="WriteReg#"/>
+    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="6" loc="(2028,981)" name="Text">
-      <a name="text" val="WB_DATA"/>
+    <comp lib="0" loc="(780,440)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
     </comp>
-    <comp lib="1" loc="(1450,330)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(350,550)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1020,620)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(687,529)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(860,700)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="2" loc="(1290,610)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+    <comp lib="6" loc="(1309,1055)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
     </comp>
     <comp lib="0" loc="(850,760)" name="Splitter">
       <a name="facing" val="west"/>
@@ -1099,140 +1003,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="2"/>
       <a name="bit31" val="2"/>
     </comp>
-    <comp lib="0" loc="(300,580)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(2010,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(590,120)" name="Tunnel">
+    <comp loc="(190,1060)" name="Hazard Unit"/>
+    <comp lib="0" loc="(2080,450)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="9" loc="(720,140)" name="Control"/>
-    <comp lib="4" loc="(320,550)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="7" loc="(1410,580)" name="ALU"/>
-    <comp lib="0" loc="(670,840)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
+    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="3" loc="(1360,930)" name="Shifter">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="label" val="Halt"/>
     </comp>
-    <comp lib="6" loc="(1973,684)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="0" loc="(810,710)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="6" loc="(1035,833)" name="Text">
-      <a name="text" val="Immediate"/>
-    </comp>
-    <comp lib="4" loc="(370,320)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="6" loc="(1035,755)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp loc="(190,1060)" name="Hazard Unit"/>
-    <comp lib="1" loc="(580,1030)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(780,440)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="0" loc="(1670,580)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp loc="(570,130)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
-    </comp>
-    <comp lib="6" loc="(995,966)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="2" loc="(910,690)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(780,460)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
     </comp>
     <comp lib="0" loc="(400,270)" name="Splitter">
       <a name="facing" val="north"/>
@@ -1271,79 +1056,28 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="7"/>
       <a name="bit31" val="7"/>
     </comp>
+    <comp lib="6" loc="(1005,925)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="4" loc="(220,700)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="7" loc="(1410,580)" name="ALU"/>
+    <comp lib="0" loc="(2030,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="6" loc="(1454,655)" name="Text">
+      <a name="text" val="WriteDataEX"/>
+    </comp>
     <comp lib="0" loc="(350,420)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(780,460)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="12" loc="(780,820)" name="Immediate Extender"/>
-    <comp lib="2" loc="(830,680)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1410,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="6" loc="(997,944)" name="Text">
-      <a name="text" val="Jump Addr"/>
-    </comp>
-    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="1" loc="(1370,410)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1090,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="2" loc="(2060,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1010,470)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="6" loc="(689,491)" name="Text">
-      <a name="text" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(380,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="2" loc="(90,530)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(300,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="6" loc="(414,100)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(670,540)" name="Splitter">
+    <comp loc="(1510,140)" name="EX/MEM"/>
+    <comp lib="0" loc="(670,690)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -1358,16 +1092,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit8" val="none"/>
       <a name="bit9" val="none"/>
       <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
       <a name="bit21" val="none"/>
       <a name="bit22" val="none"/>
       <a name="bit23" val="none"/>
@@ -1380,21 +1114,218 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(670,620)" name="Splitter">
+    <comp lib="0" loc="(860,700)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="0" loc="(490,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="10" loc="(2060,450)" name="syscall_decoder"/>
+    <comp lib="6" loc="(1035,755)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="4" loc="(220,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
+    </comp>
+    <comp lib="6" loc="(1035,833)" name="Text">
+      <a name="text" val="Immediate"/>
+    </comp>
+    <comp lib="12" loc="(950,480)" name="Regfile"/>
+    <comp lib="0" loc="(1020,620)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1900,910)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(970,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="2" loc="(200,550)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1450,330)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(480,730)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1670,580)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit0" val="none"/>
       <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
       <a name="bit6" val="0"/>
       <a name="bit7" val="0"/>
       <a name="bit8" val="0"/>
       <a name="bit9" val="0"/>
       <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(414,100)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp lib="6" loc="(1840,685)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="0" loc="(500,730)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(420,720)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Bubble Number"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(320,550)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(270,700)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2130,500)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="2" loc="(1260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(670,840)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="2" loc="(2060,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(687,529)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(990,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="6" loc="(2028,981)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp loc="(570,130)" name="IF/ID">
+      <a name="labelfont" val="Monaco bold 44"/>
+    </comp>
+    <comp lib="0" loc="(810,750)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp loc="(1080,130)" name="ID/EX"/>
+    <comp lib="2" loc="(150,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(810,710)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="1" loc="(1370,410)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="0" loc="(1920,910)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(692,230)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp loc="(1890,130)" name="MEM/WB"/>
+    <comp lib="0" loc="(670,320)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
       <a name="bit11" val="none"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
@@ -1417,14 +1348,83 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="6" loc="(690,678)" name="Text">
-      <a name="text" val="RD"/>
+    <comp lib="5" loc="(300,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="6" loc="(1454,655)" name="Text">
-      <a name="text" val="WriteDataEX"/>
+    <comp lib="6" loc="(995,966)" name="Text">
+      <a name="text" val="Branch Addr"/>
     </comp>
-    <comp lib="6" loc="(1309,1055)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
+    <comp lib="2" loc="(490,680)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1010,470)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="2" loc="(2010,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1410,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(380,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="6" loc="(1953,236)" name="Text">
+      <a name="text" val="Ignored"/>
+    </comp>
+    <comp lib="3" loc="(470,620)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(660,870)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="6" loc="(997,944)" name="Text">
+      <a name="text" val="Jump Addr"/>
     </comp>
   </circuit>
   <circuit name="IF/ID">
@@ -1463,14 +1463,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(310,470)" to="(350,470)"/>
     <wire from="(370,520)" to="(570,520)"/>
     <wire from="(370,420)" to="(570,420)"/>
-    <comp lib="0" loc="(160,350)" name="Pin">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(340,590)" name="Pin">
+      <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(380,370)" name="Register">
-      <a name="width" val="32"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(570,350)" name="Pin">
       <a name="facing" val="south"/>
@@ -1486,10 +1483,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="InstID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(310,370)" name="Pin">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(160,350)" name="Pin">
+      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="InstIF"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(410,470)" name="Pin">
       <a name="facing" val="west"/>
@@ -1499,19 +1497,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlus4IF"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="4" loc="(380,470)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(380,370)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(310,370)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="InstIF"/>
+    </comp>
     <comp lib="0" loc="(310,470)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="0" loc="(340,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
-      <a name="width" val="32"/>
     </comp>
   </circuit>
   <circuit name="ID/EX">
@@ -1793,104 +1793,22 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(900,630)" to="(980,630)"/>
     <wire from="(900,390)" to="(980,390)"/>
     <wire from="(1230,410)" to="(1250,410)"/>
-    <comp lib="0" loc="(590,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(860,780)" name="Pin">
+      <a name="label" val="MemReadID"/>
     </comp>
-    <comp lib="0" loc="(520,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
+    <comp lib="0" loc="(860,540)" name="Pin">
+      <a name="label" val="RegWriteID"/>
     </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,470)" name="Pin">
-      <a name="label" val="BranchID"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
+    <comp lib="0" loc="(170,360)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
+      <a name="label" val="ImmID"/>
     </comp>
     <comp lib="0" loc="(930,780)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="MemReadEX"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(930,660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrcEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
-      <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(1240,650)" name="Pin">
       <a name="facing" val="west"/>
@@ -1899,24 +1817,103 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUopEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
+    <comp lib="0" loc="(860,720)" name="Pin">
+      <a name="label" val="IsExceptionID"/>
     </comp>
-    <comp lib="0" loc="(930,480)" name="Pin">
+    <comp lib="0" loc="(1250,470)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="MemtoRegEX"/>
+      <a name="label" val="BranchEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
+    <comp lib="4" loc="(1230,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1230,590)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,350)" name="Pin">
+      <a name="label" val="MemWriteID"/>
     </comp>
     <comp lib="0" loc="(590,360)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
       <a name="label" val="ShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJREX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,360)" name="Pin">
+      <a name="label" val="IsJALID"/>
+    </comp>
+    <comp lib="0" loc="(170,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2ID"/>
+    </comp>
+    <comp lib="0" loc="(930,660)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrcEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1250,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(100,290)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(520,560)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="4" loc="(570,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(910,720)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(860,600)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="4" loc="(1230,650)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(930,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(930,600)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeqEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(920,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1240,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
       <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(590,560)" name="Pin">
@@ -1926,6 +1923,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="PCPlusEX"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(170,460)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(1180,590)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="4" loc="(910,480)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(570,560)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(910,600)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,710)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#ID"/>
+    </comp>
+    <comp lib="4" loc="(220,460)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(1230,710)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
     <comp lib="0" loc="(240,360)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -1933,69 +1958,21 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ImmEX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
+    <comp lib="4" loc="(910,780)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(930,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(860,660)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
     </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
+    <comp lib="0" loc="(1180,410)" name="Pin">
+      <a name="label" val="JumpID"/>
     </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,720)" name="Pin">
-      <a name="label" val="IsExceptionID"/>
-    </comp>
-    <comp lib="4" loc="(910,540)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,590)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
+    <comp lib="0" loc="(520,360)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
+      <a name="label" val="ShamtID"/>
     </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
+    <comp lib="4" loc="(1230,530)" name="Register">
       <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(520,460)" name="Pin">
@@ -2003,7 +1980,60 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="JumpAddr"/>
     </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
+    <comp lib="0" loc="(930,540)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(860,420)" name="Pin">
+      <a name="label" val="IsShamtID"/>
+    </comp>
+    <comp lib="4" loc="(910,660)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(930,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(570,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(930,480)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(910,420)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,650)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
+    </comp>
+    <comp lib="0" loc="(1250,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="JumpEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(590,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1230,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(220,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(1230,470)" name="Register">
       <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(240,460)" name="Pin">
@@ -2013,28 +2043,35 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R1EX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(60,290)" name="Pin">
+      <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(860,420)" name="Pin">
-      <a name="label" val="IsShamtID"/>
-    </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
+    <comp lib="4" loc="(910,540)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
+    <comp lib="4" loc="(220,560)" name="Register">
+      <a name="width" val="32"/>
     </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(860,480)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
+    </comp>
+    <comp lib="0" loc="(180,640)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="4" loc="(910,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1180,470)" name="Pin">
+      <a name="label" val="BranchID"/>
+    </comp>
+    <comp lib="0" loc="(1180,530)" name="Pin">
+      <a name="label" val="IsJRID"/>
     </comp>
     <comp lib="0" loc="(240,560)" name="Pin">
       <a name="facing" val="west"/>
@@ -2043,47 +2080,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="R2EX"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
     <comp lib="0" loc="(1250,590)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="0" loc="(180,640)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(930,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
       <a name="labelloc" val="east"/>
     </comp>
   </circuit>
@@ -2186,11 +2186,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,360)" to="(860,390)"/>
     <wire from="(860,160)" to="(860,190)"/>
     <wire from="(560,70)" to="(980,70)"/>
+    <wire from="(470,500)" to="(560,500)"/>
+    <wire from="(470,140)" to="(560,140)"/>
     <wire from="(870,240)" to="(890,240)"/>
     <wire from="(470,260)" to="(560,260)"/>
     <wire from="(470,380)" to="(560,380)"/>
-    <wire from="(470,140)" to="(560,140)"/>
-    <wire from="(470,500)" to="(560,500)"/>
     <wire from="(640,290)" to="(850,290)"/>
     <wire from="(300,80)" to="(640,80)"/>
     <wire from="(980,190)" to="(980,290)"/>
@@ -2213,10 +2213,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(300,320)" to="(300,380)"/>
     <wire from="(300,200)" to="(300,260)"/>
     <wire from="(300,80)" to="(300,140)"/>
+    <wire from="(440,420)" to="(440,480)"/>
     <wire from="(830,250)" to="(840,250)"/>
     <wire from="(440,180)" to="(440,240)"/>
     <wire from="(440,300)" to="(440,360)"/>
-    <wire from="(440,420)" to="(440,480)"/>
     <wire from="(440,580)" to="(830,580)"/>
     <wire from="(860,390)" to="(980,390)"/>
     <wire from="(860,190)" to="(980,190)"/>
@@ -2238,117 +2238,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(430,530)" to="(450,530)"/>
     <wire from="(430,410)" to="(450,410)"/>
     <wire from="(830,350)" to="(830,580)"/>
-    <comp lib="4" loc="(870,340)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="0" loc="(890,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(350,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="0" loc="(500,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="0" loc="(500,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
-    </comp>
     <comp lib="0" loc="(500,410)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="MemWriteMEM"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(500,110)" name="Pin">
       <a name="facing" val="west"/>
@@ -2356,32 +2250,8 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsJALMEM"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="4" loc="(480,530)" name="Register">
       <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(500,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,170)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
     </comp>
     <comp lib="0" loc="(500,230)" name="Pin">
       <a name="facing" val="west"/>
@@ -2392,10 +2262,140 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(430,350)" name="Pin">
       <a name="label" val="MemReadEX"/>
     </comp>
+    <comp lib="0" loc="(890,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(870,240)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(820,240)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataEX"/>
+    </comp>
+    <comp lib="0" loc="(440,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="4" loc="(480,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(870,140)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(480,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(300,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(820,340)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrEX"/>
+    </comp>
+    <comp lib="0" loc="(430,470)" name="Pin">
+      <a name="label" val="IsSyscallEX"/>
+    </comp>
+    <comp lib="0" loc="(890,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(820,140)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="4" loc="(480,170)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
     <comp lib="0" loc="(430,530)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(430,290)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
+    </comp>
+    <comp lib="0" loc="(500,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,170)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
+    </comp>
+    <comp lib="4" loc="(480,110)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(870,340)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(500,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(350,60)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(430,110)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(430,230)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(890,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(430,410)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(500,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(480,290)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(500,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionMEM"/>
+      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="MEM/WB">
@@ -2532,53 +2532,14 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ALUResultWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(360,380)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(360,260)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
     <comp lib="4" loc="(410,560)" name="Register">
       <a name="width" val="5"/>
-    </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(290,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(370,620)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(720,390)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
     </comp>
     <comp lib="0" loc="(430,320)" name="Pin">
       <a name="facing" val="west"/>
@@ -2586,15 +2547,11 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="MemtoRegWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="4" loc="(770,390)" name="Register">
       <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
-      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
+    <comp lib="4" loc="(770,290)" name="Register">
+      <a name="width" val="32"/>
     </comp>
     <comp lib="0" loc="(790,500)" name="Pin">
       <a name="facing" val="west"/>
@@ -2603,20 +2560,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="JumpAddrWB"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
-    </comp>
     <comp lib="4" loc="(410,260)" name="Register">
       <a name="width" val="1"/>
     </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
+    <comp lib="0" loc="(430,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(410,320)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(250,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(720,390)" name="Pin">
       <a name="width" val="32"/>
+      <a name="label" val="ReadDataMEM"/>
     </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
+    <comp lib="0" loc="(370,620)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="0" loc="(430,260)" name="Pin">
       <a name="facing" val="west"/>
@@ -2624,31 +2595,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="IsJALWB"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(360,500)" name="Pin">
+      <a name="label" val="IsSyscallMEM"/>
+    </comp>
     <comp lib="4" loc="(410,380)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,380)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(770,290)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
       <a name="width" val="1"/>
     </comp>
     <comp lib="0" loc="(360,560)" name="Pin">
@@ -2656,119 +2606,58 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="WriteReg#MEM"/>
     </comp>
+    <comp lib="0" loc="(720,500)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(430,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(410,440)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(290,180)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(410,500)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(430,380)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,440)" name="Pin">
+      <a name="label" val="IsExceptionMEM"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
     <comp lib="0" loc="(720,290)" name="Pin">
       <a name="width" val="32"/>
       <a name="label" val="ALUResultMEM"/>
     </comp>
-  </circuit>
-  <circuit name="Regfile_Wrapper">
-    <a name="circuit" val="Regfile_Wrapper"/>
-    <a name="clabel" val=""/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="SansSerif plain 12"/>
-    <appear>
-      <rect fill="#b4ff80" height="120" stroke="none" width="108" x="240" y="160"/>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="257" y="255">RW</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="258" y="275">Din</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="337" y="215">R1</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="336" y="231">R2</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="258" y="184">R1#</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="259" y="225">R2#</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="300" y="177">clk</text>
-      <text font-family="SansSerif" font-size="12" text-anchor="middle" x="328" y="175">WE</text>
-      <text font-family="SansSerif" font-size="16" font-weight="bold" text-anchor="middle" x="318" y="272">RegFile</text>
-      <circ-port height="8" pin="240,190" width="8" x="236" y="176"/>
-      <circ-port height="8" pin="240,210" width="8" x="236" y="216"/>
-      <circ-port height="8" pin="240,230" width="8" x="236" y="246"/>
-      <circ-port height="10" pin="400,140" width="10" x="345" y="205"/>
-      <circ-port height="10" pin="400,260" width="10" x="345" y="225"/>
-      <circ-port height="8" pin="300,350" width="8" x="236" y="266"/>
-      <circ-port height="8" pin="320,290" width="8" x="326" y="156"/>
-      <circ-port height="8" pin="350,290" width="8" x="296" y="156"/>
-      <circ-port height="10" pin="300,80" width="10" x="255" y="155"/>
-      <circ-port height="10" pin="400,80" width="10" x="275" y="155"/>
-      <circ-anchor facing="east" height="6" width="6" x="237" y="157"/>
-    </appear>
-    <wire from="(300,80)" to="(300,180)"/>
-    <wire from="(370,220)" to="(390,220)"/>
-    <wire from="(370,200)" to="(390,200)"/>
-    <wire from="(300,240)" to="(300,350)"/>
-    <wire from="(400,80)" to="(400,90)"/>
-    <wire from="(390,220)" to="(390,260)"/>
-    <wire from="(390,260)" to="(400,260)"/>
-    <wire from="(390,140)" to="(400,140)"/>
-    <wire from="(320,90)" to="(400,90)"/>
-    <wire from="(320,240)" to="(320,290)"/>
-    <wire from="(350,240)" to="(350,290)"/>
-    <wire from="(390,140)" to="(390,200)"/>
-    <wire from="(240,210)" to="(280,210)"/>
-    <wire from="(240,190)" to="(280,190)"/>
-    <wire from="(240,230)" to="(280,230)"/>
-    <wire from="(320,90)" to="(320,180)"/>
-    <comp lib="0" loc="(300,350)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Din"/>
+    <comp lib="0" loc="(430,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallWB"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(400,260)" name="Pin">
+    <comp lib="4" loc="(770,500)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(790,390)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(350,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(400,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="a0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,80)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="v0"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,210)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2#"/>
-    </comp>
-    <comp lib="0" loc="(240,230)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RW"/>
-    </comp>
-    <comp lib="8" loc="(370,210)" name="main"/>
-    <comp lib="0" loc="(320,290)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WE"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(240,190)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1#"/>
-    </comp>
-    <comp lib="0" loc="(400,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1"/>
+      <a name="label" val="ReadDataWB"/>
       <a name="labelloc" val="east"/>
     </comp>
   </circuit>
@@ -2892,55 +2781,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,390)" to="(610,390)"/>
     <wire from="(600,470)" to="(610,470)"/>
     <wire from="(600,510)" to="(610,510)"/>
-    <comp lib="0" loc="(540,270)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="3" loc="(470,430)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(510,270)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(600,350)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(930,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,400)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="BubbleNum"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(660,370)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(600,390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(660,490)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(820,390)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="north"/>
-    </comp>
     <comp lib="1" loc="(760,330)" name="AND Gate">
       <a name="inputs" val="2"/>
     </comp>
@@ -2949,14 +2789,108 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="tristate" val="false"/>
       <a name="label" val="WriteReg#EX"/>
     </comp>
-    <comp lib="3" loc="(470,310)" name="Comparator">
+    <comp lib="0" loc="(140,300)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RS"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(980,320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(600,470)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(730,150)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="3" loc="(470,350)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="0" loc="(380,130)" name="Tunnel">
+    <comp lib="0" loc="(340,130)" name="Pin">
+      <a name="tristate" val="false"/>
       <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(320,340)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="1" loc="(660,370)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(920,120)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate0" val="true"/>
+    </comp>
+    <comp lib="0" loc="(1210,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(870,400)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(600,350)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(600,390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(870,320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(600,510)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1030,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="3" loc="(470,510)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="3" loc="(470,390)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(410,420)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
     </comp>
     <comp lib="0" loc="(1100,440)" name="Tunnel">
       <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
+    <comp lib="3" loc="(470,470)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(820,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(1120,400)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(380,130)" name="Tunnel">
       <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(1060,340)" name="Pin">
@@ -2965,23 +2899,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="StallID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="3" loc="(470,350)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="1" loc="(600,470)" name="AND Gate">
+    <comp lib="1" loc="(1190,230)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(920,120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate0" val="true"/>
-    </comp>
-    <comp lib="3" loc="(470,470)" name="Comparator">
+    <comp lib="3" loc="(470,310)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="0" loc="(730,150)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
+    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
+    <comp lib="3" loc="(470,430)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="1" loc="(660,490)" name="OR Gate">
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(50,300)" name="Pin">
       <a name="facing" val="south"/>
@@ -2990,81 +2920,31 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RT"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(730,130)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
-    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(820,310)" name="Pin">
+    <comp lib="0" loc="(540,270)" name="Pin">
+      <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteMEM"/>
+      <a name="label" val="ReadRt"/>
       <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="3" loc="(470,390)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(140,300)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RS"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
-    <comp lib="0" loc="(340,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(1120,400)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(1030,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(410,300)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
     </comp>
     <comp lib="1" loc="(740,450)" name="AND Gate">
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(870,320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(510,270)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(410,420)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="3" loc="(470,510)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="1" loc="(1190,230)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(870,400)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(980,320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(600,510)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1210,240)" name="Pin">
+    <comp lib="0" loc="(1180,400)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="FlushID"/>
+      <a name="width" val="32"/>
+      <a name="label" val="BubbleNum"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(820,390)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteEX"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="0" loc="(1060,300)" name="Pin">
       <a name="facing" val="west"/>
@@ -3072,10 +2952,19 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="StallIF"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(320,340)" name="Pin">
+    <comp lib="0" loc="(730,130)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(930,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(410,300)" name="Constant">
       <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
+      <a name="value" val="0x0"/>
     </comp>
   </circuit>
   <circuit name="Hazard_Detector">
@@ -4051,455 +3940,76 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(100,2410)" to="(490,2410)"/>
     <wire from="(160,2470)" to="(550,2470)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,4470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,4260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2560)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
+    <comp lib="0" loc="(40,530)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
+      <a name="label" val="Funct4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(730,1960)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4470)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2410)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,830)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="9"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,2260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(710,1960)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,3320)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,2910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2130)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
-    </comp>
-    <comp lib="0" loc="(40,530)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="0" loc="(40,80)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -4508,78 +4018,91 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct5"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,250)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,1140)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2140)" name="NOT Gate">
+    <comp lib="1" loc="(510,2560)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+    <comp lib="1" loc="(510,2290)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3640)" name="AND Gate">
+    <comp lib="1" loc="(410,410)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,230)" name="Pin">
@@ -4587,29 +4110,182 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,910)" name="NOT Gate">
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,1650)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
     <comp lib="1" loc="(520,4480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,430)" name="Pin">
@@ -4617,64 +4293,277 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct2"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(690,4470)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
     </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
+    <comp lib="1" loc="(600,2420)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,1290)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2380)" name="NOT Gate">
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,250)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,4470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
     <comp lib="1" loc="(320,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,80)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2130)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
   </circuit>

--- a/src/single_cycle_cpu.circ
+++ b/src/single_cycle_cpu.circ
@@ -53,7 +53,7 @@
   </lib>
   <lib desc="#Plexers" name="2">
     <tool name="Multiplexer">
-      <a name="select" val="3"/>
+      <a name="width" val="32"/>
     </tool>
     <tool name="Demultiplexer">
       <a name="select" val="5"/>
@@ -78,7 +78,7 @@
   </lib>
   <lib desc="#Memory" name="4">
     <tool name="Register">
-      <a name="width" val="16"/>
+      <a name="width" val="32"/>
     </tool>
     <tool name="ROM">
       <a name="contents">addr/data: 8 8
@@ -96,12 +96,12 @@
     </tool>
   </lib>
   <lib desc="file#common/alu.circ" name="7"/>
-  <lib desc="file#common/regfile.circ" name="8"/>
-  <lib desc="file#common/control.circ" name="9"/>
-  <lib desc="file#common/statistics.circ" name="10"/>
-  <lib desc="file#common/syscall_decoder.circ" name="11"/>
-  <lib desc="file#common/immediate_extender.circ" name="12"/>
-  <lib desc="file#common/statistics.circ" name="13"/>
+  <lib desc="file#common/control.circ" name="8"/>
+  <lib desc="file#common/statistics.circ" name="9"/>
+  <lib desc="file#common/syscall_decoder.circ" name="10"/>
+  <lib desc="file#common/immediate_extender.circ" name="11"/>
+  <lib desc="file#common/statistics.circ" name="12"/>
+  <lib desc="file#common/regfile.circ" name="13"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -141,6 +141,7 @@
     <a name="clabelup" val="east"/>
     <a name="clabelfont" val="SansSerif plain 12"/>
     <wire from="(1390,430)" to="(1390,450)"/>
+    <wire from="(760,920)" to="(760,930)"/>
     <wire from="(1130,580)" to="(1130,790)"/>
     <wire from="(1150,510)" to="(1150,530)"/>
     <wire from="(1230,110)" to="(1230,130)"/>
@@ -150,13 +151,11 @@
     <wire from="(950,370)" to="(950,500)"/>
     <wire from="(1330,380)" to="(1370,380)"/>
     <wire from="(540,570)" to="(540,660)"/>
-    <wire from="(820,910)" to="(860,910)"/>
-    <wire from="(680,520)" to="(780,520)"/>
     <wire from="(140,550)" to="(180,550)"/>
-    <wire from="(810,920)" to="(810,1000)"/>
     <wire from="(900,140)" to="(1140,140)"/>
     <wire from="(280,140)" to="(280,550)"/>
     <wire from="(630,950)" to="(630,970)"/>
+    <wire from="(570,490)" to="(570,530)"/>
     <wire from="(1370,370)" to="(1380,370)"/>
     <wire from="(80,740)" to="(110,740)"/>
     <wire from="(1450,330)" to="(1450,380)"/>
@@ -164,6 +163,7 @@
     <wire from="(1410,390)" to="(1490,390)"/>
     <wire from="(1180,230)" to="(1320,230)"/>
     <wire from="(340,610)" to="(360,610)"/>
+    <wire from="(740,520)" to="(770,520)"/>
     <wire from="(1590,150)" to="(1590,200)"/>
     <wire from="(280,550)" to="(280,660)"/>
     <wire from="(500,610)" to="(520,610)"/>
@@ -171,25 +171,32 @@
     <wire from="(1610,130)" to="(1620,130)"/>
     <wire from="(1290,330)" to="(1290,390)"/>
     <wire from="(1320,550)" to="(1320,660)"/>
+    <wire from="(840,400)" to="(850,400)"/>
+    <wire from="(790,910)" to="(800,910)"/>
     <wire from="(1520,510)" to="(1540,510)"/>
     <wire from="(1370,330)" to="(1370,370)"/>
     <wire from="(520,560)" to="(530,560)"/>
+    <wire from="(590,550)" to="(600,550)"/>
     <wire from="(1100,340)" to="(1210,340)"/>
     <wire from="(630,840)" to="(630,850)"/>
-    <wire from="(790,920)" to="(790,930)"/>
+    <wire from="(730,540)" to="(780,540)"/>
     <wire from="(820,1030)" to="(820,1040)"/>
     <wire from="(120,570)" to="(120,580)"/>
     <wire from="(1370,380)" to="(1370,410)"/>
     <wire from="(380,270)" to="(380,280)"/>
     <wire from="(560,220)" to="(600,220)"/>
     <wire from="(1530,330)" to="(1530,400)"/>
+    <wire from="(840,340)" to="(880,340)"/>
     <wire from="(90,1020)" to="(90,1040)"/>
     <wire from="(70,680)" to="(70,700)"/>
+    <wire from="(680,570)" to="(780,570)"/>
     <wire from="(1060,310)" to="(1060,320)"/>
     <wire from="(710,880)" to="(950,880)"/>
+    <wire from="(610,580)" to="(610,600)"/>
     <wire from="(1350,760)" to="(1350,770)"/>
     <wire from="(950,550)" to="(950,660)"/>
     <wire from="(1570,140)" to="(1580,140)"/>
+    <wire from="(830,910)" to="(850,910)"/>
     <wire from="(280,660)" to="(280,890)"/>
     <wire from="(670,990)" to="(690,990)"/>
     <wire from="(1130,580)" to="(1140,580)"/>
@@ -199,12 +206,12 @@
     <wire from="(1230,110)" to="(1300,110)"/>
     <wire from="(650,160)" to="(680,160)"/>
     <wire from="(650,240)" to="(680,240)"/>
+    <wire from="(780,930)" to="(810,930)"/>
     <wire from="(470,160)" to="(480,160)"/>
-    <wire from="(840,610)" to="(850,610)"/>
     <wire from="(1120,560)" to="(1140,560)"/>
     <wire from="(1120,240)" to="(1140,240)"/>
     <wire from="(1120,160)" to="(1140,160)"/>
-    <wire from="(810,620)" to="(810,670)"/>
+    <wire from="(590,490)" to="(730,490)"/>
     <wire from="(950,660)" to="(1320,660)"/>
     <wire from="(660,840)" to="(660,850)"/>
     <wire from="(690,950)" to="(690,960)"/>
@@ -212,30 +219,31 @@
     <wire from="(1150,530)" to="(1150,550)"/>
     <wire from="(80,980)" to="(80,990)"/>
     <wire from="(1400,380)" to="(1400,410)"/>
-    <wire from="(800,570)" to="(800,890)"/>
     <wire from="(1320,550)" to="(1360,550)"/>
-    <wire from="(630,580)" to="(670,580)"/>
+    <wire from="(710,560)" to="(770,560)"/>
     <wire from="(950,660)" to="(950,880)"/>
     <wire from="(1180,150)" to="(1240,150)"/>
+    <wire from="(840,460)" to="(840,480)"/>
     <wire from="(1400,380)" to="(1450,380)"/>
     <wire from="(450,180)" to="(450,270)"/>
     <wire from="(600,220)" to="(600,240)"/>
     <wire from="(1300,120)" to="(1350,120)"/>
+    <wire from="(590,530)" to="(590,550)"/>
     <wire from="(930,260)" to="(930,340)"/>
     <wire from="(1300,760)" to="(1300,770)"/>
+    <wire from="(570,570)" to="(570,720)"/>
     <wire from="(90,510)" to="(90,540)"/>
     <wire from="(1420,400)" to="(1420,410)"/>
-    <wire from="(850,580)" to="(870,580)"/>
     <wire from="(900,140)" to="(900,570)"/>
     <wire from="(320,120)" to="(350,120)"/>
     <wire from="(480,160)" to="(480,320)"/>
+    <wire from="(770,590)" to="(770,890)"/>
     <wire from="(690,90)" to="(720,90)"/>
     <wire from="(740,80)" to="(1410,80)"/>
     <wire from="(1060,790)" to="(1130,790)"/>
     <wire from="(40,570)" to="(60,570)"/>
     <wire from="(90,540)" to="(110,540)"/>
     <wire from="(410,910)" to="(410,950)"/>
-    <wire from="(700,590)" to="(770,590)"/>
     <wire from="(430,170)" to="(440,170)"/>
     <wire from="(1290,210)" to="(1320,210)"/>
     <wire from="(180,680)" to="(180,730)"/>
@@ -243,8 +251,10 @@
     <wire from="(700,720)" to="(900,720)"/>
     <wire from="(120,660)" to="(130,660)"/>
     <wire from="(1390,370)" to="(1390,410)"/>
-    <wire from="(590,570)" to="(600,570)"/>
+    <wire from="(770,590)" to="(780,590)"/>
     <wire from="(380,270)" to="(450,270)"/>
+    <wire from="(880,340)" to="(880,390)"/>
+    <wire from="(590,570)" to="(600,570)"/>
     <wire from="(690,840)" to="(690,850)"/>
     <wire from="(1360,390)" to="(1360,410)"/>
     <wire from="(930,340)" to="(930,480)"/>
@@ -252,7 +262,7 @@
     <wire from="(800,1030)" to="(800,1040)"/>
     <wire from="(280,890)" to="(280,1030)"/>
     <wire from="(110,740)" to="(110,750)"/>
-    <wire from="(870,530)" to="(930,530)"/>
+    <wire from="(890,550)" to="(950,550)"/>
     <wire from="(950,500)" to="(1140,500)"/>
     <wire from="(280,890)" to="(400,890)"/>
     <wire from="(290,200)" to="(290,220)"/>
@@ -261,13 +271,11 @@
     <wire from="(1330,480)" to="(1520,480)"/>
     <wire from="(180,730)" to="(180,750)"/>
     <wire from="(1270,530)" to="(1330,530)"/>
-    <wire from="(820,570)" to="(820,590)"/>
     <wire from="(1250,760)" to="(1250,770)"/>
+    <wire from="(860,370)" to="(860,390)"/>
     <wire from="(1210,450)" to="(1390,450)"/>
-    <wire from="(610,600)" to="(610,640)"/>
-    <wire from="(890,910)" to="(910,910)"/>
+    <wire from="(770,520)" to="(770,560)"/>
     <wire from="(1080,310)" to="(1090,310)"/>
-    <wire from="(760,540)" to="(780,540)"/>
     <wire from="(650,340)" to="(680,340)"/>
     <wire from="(650,420)" to="(680,420)"/>
     <wire from="(650,180)" to="(680,180)"/>
@@ -279,14 +287,12 @@
     <wire from="(210,550)" to="(280,550)"/>
     <wire from="(1390,370)" to="(1410,370)"/>
     <wire from="(950,550)" to="(1090,550)"/>
-    <wire from="(770,560)" to="(780,560)"/>
     <wire from="(750,1020)" to="(760,1020)"/>
+    <wire from="(720,510)" to="(730,510)"/>
     <wire from="(280,140)" to="(350,140)"/>
-    <wire from="(850,570)" to="(850,580)"/>
     <wire from="(40,920)" to="(610,920)"/>
     <wire from="(430,1040)" to="(800,1040)"/>
     <wire from="(200,720)" to="(200,730)"/>
-    <wire from="(570,590)" to="(570,720)"/>
     <wire from="(570,720)" to="(570,790)"/>
     <wire from="(570,860)" to="(610,860)"/>
     <wire from="(570,940)" to="(610,940)"/>
@@ -296,8 +302,8 @@
     <wire from="(1230,470)" to="(1230,480)"/>
     <wire from="(1100,580)" to="(1100,590)"/>
     <wire from="(590,790)" to="(1020,790)"/>
+    <wire from="(770,440)" to="(770,520)"/>
     <wire from="(570,530)" to="(570,550)"/>
-    <wire from="(590,550)" to="(590,570)"/>
     <wire from="(690,90)" to="(690,110)"/>
     <wire from="(1460,120)" to="(1580,120)"/>
     <wire from="(930,480)" to="(1140,480)"/>
@@ -310,13 +316,11 @@
     <wire from="(90,560)" to="(110,560)"/>
     <wire from="(180,730)" to="(200,730)"/>
     <wire from="(520,480)" to="(520,540)"/>
-    <wire from="(830,670)" to="(840,670)"/>
     <wire from="(520,560)" to="(520,610)"/>
-    <wire from="(710,930)" to="(790,930)"/>
     <wire from="(1410,330)" to="(1410,370)"/>
-    <wire from="(590,590)" to="(600,590)"/>
-    <wire from="(680,610)" to="(680,620)"/>
     <wire from="(680,690)" to="(680,700)"/>
+    <wire from="(660,590)" to="(660,600)"/>
+    <wire from="(810,930)" to="(810,1000)"/>
     <wire from="(430,890)" to="(610,890)"/>
     <wire from="(80,730)" to="(80,740)"/>
     <wire from="(40,40)" to="(1620,40)"/>
@@ -326,8 +330,7 @@
     <wire from="(180,200)" to="(220,200)"/>
     <wire from="(900,570)" to="(900,720)"/>
     <wire from="(1350,400)" to="(1350,410)"/>
-    <wire from="(790,670)" to="(810,670)"/>
-    <wire from="(630,510)" to="(650,510)"/>
+    <wire from="(570,320)" to="(570,490)"/>
     <wire from="(600,240)" to="(620,240)"/>
     <wire from="(650,360)" to="(680,360)"/>
     <wire from="(650,440)" to="(680,440)"/>
@@ -340,25 +343,25 @@
     <wire from="(690,130)" to="(1230,130)"/>
     <wire from="(360,210)" to="(510,210)"/>
     <wire from="(330,540)" to="(340,540)"/>
-    <wire from="(690,500)" to="(700,500)"/>
-    <wire from="(720,530)" to="(730,530)"/>
     <wire from="(310,270)" to="(380,270)"/>
     <wire from="(580,790)" to="(590,790)"/>
     <wire from="(1250,490)" to="(1270,490)"/>
     <wire from="(1570,520)" to="(1610,520)"/>
     <wire from="(1440,140)" to="(1440,160)"/>
     <wire from="(70,680)" to="(130,680)"/>
+    <wire from="(710,930)" to="(760,930)"/>
+    <wire from="(780,920)" to="(780,930)"/>
     <wire from="(1390,570)" to="(1390,600)"/>
     <wire from="(1500,530)" to="(1540,530)"/>
     <wire from="(160,220)" to="(160,240)"/>
     <wire from="(430,170)" to="(430,200)"/>
-    <wire from="(570,320)" to="(570,530)"/>
     <wire from="(930,340)" to="(1040,340)"/>
+    <wire from="(570,550)" to="(570,570)"/>
     <wire from="(40,570)" to="(40,920)"/>
-    <wire from="(740,560)" to="(740,580)"/>
     <wire from="(320,570)" to="(320,660)"/>
-    <wire from="(570,550)" to="(570,590)"/>
+    <wire from="(840,370)" to="(860,370)"/>
     <wire from="(1230,130)" to="(1240,130)"/>
+    <wire from="(630,560)" to="(650,560)"/>
     <wire from="(700,70)" to="(720,70)"/>
     <wire from="(1150,530)" to="(1160,530)"/>
     <wire from="(1570,140)" to="(1570,260)"/>
@@ -368,12 +371,11 @@
     <wire from="(340,560)" to="(340,610)"/>
     <wire from="(310,210)" to="(310,270)"/>
     <wire from="(340,480)" to="(340,540)"/>
-    <wire from="(660,600)" to="(670,600)"/>
     <wire from="(1210,340)" to="(1210,450)"/>
-    <wire from="(870,550)" to="(950,550)"/>
+    <wire from="(690,550)" to="(700,550)"/>
     <wire from="(700,880)" to="(710,880)"/>
     <wire from="(520,540)" to="(530,540)"/>
-    <wire from="(740,610)" to="(740,620)"/>
+    <wire from="(640,580)" to="(650,580)"/>
     <wire from="(380,200)" to="(380,270)"/>
     <wire from="(340,190)" to="(340,320)"/>
     <wire from="(1420,400)" to="(1530,400)"/>
@@ -382,7 +384,6 @@
     <wire from="(410,180)" to="(410,320)"/>
     <wire from="(1230,470)" to="(1270,470)"/>
     <wire from="(1410,80)" to="(1410,110)"/>
-    <wire from="(590,530)" to="(650,530)"/>
     <wire from="(930,260)" to="(1570,260)"/>
     <wire from="(900,570)" to="(1090,570)"/>
     <wire from="(570,790)" to="(570,860)"/>
@@ -390,10 +391,11 @@
     <wire from="(1610,520)" to="(1610,1040)"/>
     <wire from="(390,130)" to="(690,130)"/>
     <wire from="(190,570)" to="(190,650)"/>
-    <wire from="(770,560)" to="(770,590)"/>
     <wire from="(60,730)" to="(60,750)"/>
+    <wire from="(890,530)" to="(930,530)"/>
     <wire from="(1380,130)" to="(1430,130)"/>
     <wire from="(1080,310)" to="(1080,320)"/>
+    <wire from="(590,530)" to="(700,530)"/>
     <wire from="(120,630)" to="(120,660)"/>
     <wire from="(1550,540)" to="(1550,550)"/>
     <wire from="(1440,190)" to="(1440,200)"/>
@@ -401,6 +403,7 @@
     <wire from="(1350,220)" to="(1360,220)"/>
     <wire from="(1100,370)" to="(1110,370)"/>
     <wire from="(1330,480)" to="(1330,530)"/>
+    <wire from="(760,500)" to="(780,500)"/>
     <wire from="(650,380)" to="(680,380)"/>
     <wire from="(650,460)" to="(680,460)"/>
     <wire from="(1280,140)" to="(1350,140)"/>
@@ -411,6 +414,7 @@
     <wire from="(650,220)" to="(680,220)"/>
     <wire from="(500,480)" to="(520,480)"/>
     <wire from="(600,970)" to="(630,970)"/>
+    <wire from="(870,420)" to="(870,480)"/>
     <wire from="(290,200)" to="(300,200)"/>
     <wire from="(360,190)" to="(370,190)"/>
     <wire from="(330,560)" to="(340,560)"/>
@@ -419,42 +423,39 @@
     <wire from="(220,200)" to="(220,320)"/>
     <wire from="(930,480)" to="(930,530)"/>
     <wire from="(950,500)" to="(950,550)"/>
-    <wire from="(590,550)" to="(730,550)"/>
     <wire from="(1120,220)" to="(1140,220)"/>
     <wire from="(700,930)" to="(710,930)"/>
     <wire from="(710,860)" to="(720,860)"/>
     <wire from="(1380,370)" to="(1380,410)"/>
     <wire from="(570,240)" to="(580,240)"/>
-    <wire from="(830,620)" to="(830,670)"/>
     <wire from="(40,40)" to="(40,550)"/>
     <wire from="(560,550)" to="(570,550)"/>
-    <comp lib="0" loc="(370,1050)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="5" loc="(1410,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1290,210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="2" loc="(1170,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="2" loc="(140,550)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="2" loc="(800,890)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
+    <comp lib="0" loc="(660,840)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="2" loc="(1610,130)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(80,980)" name="Tunnel">
+    <comp lib="2" loc="(1570,520)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(210,550)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(1060,310)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(720,860)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
     </comp>
     <comp lib="0" loc="(1390,430)" name="Splitter">
       <a name="facing" val="north"/>
@@ -493,21 +494,257 @@
       <a name="bit30" val="7"/>
       <a name="bit31" val="7"/>
     </comp>
-    <comp lib="5" loc="(1290,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(1350,760)" name="Button">
+    <comp lib="5" loc="(1250,760)" name="Button">
       <a name="facing" val="south"/>
     </comp>
-    <comp lib="1" loc="(1350,220)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(850,910)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(570,530)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="8" loc="(620,140)" name="Control"/>
+    <comp lib="0" loc="(570,790)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
     <comp lib="0" loc="(1350,770)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="3" loc="(1180,150)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(280,660)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="2" loc="(680,570)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1300,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="2" loc="(1170,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(680,200)" name="Tunnel">
+      <a name="label" val="MemtoReg"/>
+    </comp>
+    <comp lib="0" loc="(680,180)" name="Tunnel">
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="0" loc="(720,960)" name="Tunnel">
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="4" loc="(1500,530)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="0" loc="(1270,470)" name="Tunnel">
+      <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="0" loc="(680,240)" name="Tunnel">
+      <a name="label" val="MemWrite"/>
+    </comp>
+    <comp lib="0" loc="(90,1040)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(650,1010)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(680,300)" name="Tunnel">
+      <a name="label" val="Branch"/>
+    </comp>
+    <comp lib="2" loc="(90,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(840,460)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(410,950)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(840,340)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(840,400)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="1" loc="(160,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(680,340)" name="Tunnel">
+      <a name="label" val="Jump"/>
+    </comp>
+    <comp lib="0" loc="(560,220)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(570,940)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(720,510)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="2" loc="(810,1000)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(160,240)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="4" loc="(330,190)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="3" loc="(1280,140)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="5" loc="(1250,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="5" loc="(1330,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(840,370)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="RegWrite"/>
+    </comp>
+    <comp lib="0" loc="(700,70)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(680,420)" name="Tunnel">
+      <a name="label" val="IsSyscall"/>
     </comp>
     <comp lib="4" loc="(500,480)" name="ROM">
       <a name="addrWidth" val="9"/>
@@ -594,26 +831,52 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="2"/>
       <a name="bit31" val="2"/>
     </comp>
-    <comp lib="0" loc="(1340,530)" name="Splitter">
+    <comp loc="(610,870)" name="CP0"/>
+    <comp lib="1" loc="(200,690)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1430,570)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1090,310)" name="Tunnel">
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="4" loc="(500,610)" name="ROM">
+      <a name="addrWidth" val="9"/>
+      <a name="dataWidth" val="32"/>
+      <a name="contents">addr/data: 9 32
+201a0001 409a0800 201c0040 39df020 401a0000 afda0000 23de0004 23bd0004
+afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
+23de0004 afd60000 23bd0004 23de0004 afc40000 23bd0004 23de0004 afc20000
+23bd0004 23de0004 40161000 22d60001 201a0000 409a0800 20140005 20150001
+168020 102020 20020022 c 108100 1600fffb 295a022 1680fff8
+201a0001 409a0800 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc 8fc40000
+23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc 23bdfffc
+8fd40000 23defffc 23bdfffc 8fd00000 23defffc 23bdfffc 8fda0000 409a0000
+201a0000 409a0800 42000018
+</a>
+    </comp>
+    <comp lib="0" loc="(570,570)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit0" val="none"/>
       <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
       <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
       <a name="bit16" val="none"/>
       <a name="bit17" val="none"/>
       <a name="bit18" val="none"/>
@@ -631,78 +894,27 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="2" loc="(810,1000)" name="Multiplexer">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(110,1010)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(680,400)" name="Tunnel">
+      <a name="label" val="IsShamt"/>
+    </comp>
+    <comp lib="2" loc="(1380,130)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp loc="(610,870)" name="CP0"/>
-    <comp lib="2" loc="(1460,120)" name="Multiplexer">
+    <comp lib="0" loc="(680,320)" name="Tunnel">
+      <a name="label" val="BneOrBeq"/>
+    </comp>
+    <comp lib="4" loc="(180,200)" name="Counter">
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,440)" name="Tunnel">
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="0" loc="(870,580)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(660,500)" name="NOT Gate">
-      <a name="facing" val="west"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
     </comp>
     <comp lib="0" loc="(180,750)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(570,530)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(700,590)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,160)" name="Tunnel">
-      <a name="label" val="IsJAL"/>
-    </comp>
-    <comp lib="13" loc="(540,210)" name="statistics"/>
-    <comp lib="0" loc="(90,510)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x800"/>
     </comp>
     <comp lib="0" loc="(580,240)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -741,401 +953,27 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(1120,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="3" loc="(1280,140)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(680,420)" name="Tunnel">
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(840,670)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(700,500)" name="Tunnel">
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="2" loc="(1610,130)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(600,970)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(380,280)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(680,260)" name="Tunnel">
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="0" loc="(570,590)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(340,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="2" loc="(680,520)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,460)" name="Tunnel">
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(570,720)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1100,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(610,640)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="RegDst"/>
-    </comp>
-    <comp lib="1" loc="(740,580)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(720,860)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="2" loc="(90,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,280)" name="Tunnel">
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="2" loc="(760,540)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,340)" name="Tunnel">
-      <a name="label" val="Jump"/>
-    </comp>
-    <comp lib="1" loc="(120,580)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(110,750)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="8" loc="(870,540)" name="main"/>
-    <comp lib="0" loc="(320,120)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="2" loc="(820,590)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(680,380)" name="Tunnel">
-      <a name="label" val="ALUSrc"/>
-    </comp>
-    <comp lib="0" loc="(680,400)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
-    </comp>
-    <comp lib="4" loc="(210,550)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="0" loc="(410,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="9" loc="(620,140)" name="Control"/>
-    <comp lib="0" loc="(280,550)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1120,160)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="1" loc="(70,700)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1090,310)" name="Tunnel">
-      <a name="label" val="IsSyscall"/>
-    </comp>
-    <comp lib="0" loc="(160,240)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(60,750)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(690,990)" name="Tunnel">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="2" loc="(630,580)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(850,610)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="2" loc="(190,650)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1110,370)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="5" loc="(1250,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1060,310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="11" loc="(1040,320)" name="syscall_decoder"/>
-    <comp lib="1" loc="(200,690)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1450,600)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemRead"/>
-    </comp>
-    <comp lib="5" loc="(1490,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(110,1010)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="5" loc="(1450,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="1" loc="(790,1020)" name="NOT Gate"/>
-    <comp lib="0" loc="(70,1040)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(220,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(680,200)" name="Tunnel">
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="0" loc="(910,910)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
     <comp lib="4" loc="(470,160)" name="Counter">
       <a name="width" val="32"/>
       <a name="max" val="0xffffffff"/>
     </comp>
-    <comp lib="0" loc="(1440,200)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="Jump"/>
+    <comp lib="0" loc="(690,840)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(680,320)" name="Tunnel">
-      <a name="label" val="BneOrBeq"/>
-    </comp>
-    <comp lib="7" loc="(1240,530)" name="ALU"/>
-    <comp lib="0" loc="(480,320)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1300,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(570,940)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1550,550)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemtoReg"/>
-    </comp>
-    <comp lib="5" loc="(1300,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(560,220)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1270,470)" name="Tunnel">
-      <a name="label" val="Equal"/>
-    </comp>
-    <comp lib="0" loc="(1250,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="2" loc="(140,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(700,70)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(130,630)" name="Tunnel">
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="2" loc="(1170,490)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1440,160)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="1" loc="(1180,230)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(660,840)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(1270,490)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-    </comp>
-    <comp lib="0" loc="(570,790)" name="Splitter">
+    <comp lib="0" loc="(570,320)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
       <a name="bit11" val="none"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
@@ -1158,169 +996,22 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="5" loc="(1330,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="4" loc="(180,200)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="1" loc="(860,910)" name="NOT Gate">
-      <a name="facing" val="west"/>
-    </comp>
     <comp lib="0" loc="(680,220)" name="Tunnel">
       <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="2" loc="(1570,520)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(630,840)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(570,80)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(680,180)" name="Tunnel">
-      <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="3" loc="(430,1040)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(680,360)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUop"/>
-    </comp>
-    <comp lib="0" loc="(650,1010)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="2" loc="(560,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(160,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(280,660)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(690,840)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="2" loc="(300,550)" name="Demultiplexer">
-      <a name="width" val="9"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(1380,130)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="3" loc="(1180,150)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(90,1040)" name="Constant">
-      <a name="facing" val="north"/>
     </comp>
     <comp lib="0" loc="(1060,790)" name="Bit Extender">
       <a name="in_width" val="5"/>
       <a name="out_width" val="32"/>
     </comp>
-    <comp lib="4" loc="(400,180)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(680,300)" name="Tunnel">
-      <a name="label" val="Branch"/>
-    </comp>
-    <comp lib="4" loc="(330,190)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(680,690)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtend"/>
-    </comp>
-    <comp lib="0" loc="(740,620)" name="Tunnel">
+    <comp lib="0" loc="(1440,200)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="IsSyscall"/>
+      <a name="label" val="Jump"/>
     </comp>
-    <comp lib="0" loc="(720,530)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x4"/>
+    <comp lib="0" loc="(60,750)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsEret"/>
     </comp>
+    <comp lib="12" loc="(540,210)" name="statistics"/>
     <comp lib="0" loc="(690,130)" name="Splitter">
       <a name="facing" val="north"/>
       <a name="fanout" val="1"/>
@@ -1359,55 +1050,98 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="2" loc="(80,990)" name="Multiplexer">
+    <comp lib="0" loc="(690,990)" name="Tunnel">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(1120,160)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="5" loc="(1450,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(680,460)" name="Tunnel">
+      <a name="label" val="ZeroExtend"/>
+    </comp>
+    <comp lib="0" loc="(750,1020)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="0" loc="(1290,210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Branch"/>
+    </comp>
+    <comp lib="0" loc="(80,980)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(480,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(130,630)" name="Tunnel">
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="11" loc="(660,700)" name="Immediate Extender"/>
+    <comp lib="0" loc="(680,160)" name="Tunnel">
+      <a name="label" val="IsJAL"/>
+    </comp>
+    <comp lib="1" loc="(1440,160)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(770,890)" name="Multiplexer">
       <a name="facing" val="north"/>
       <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="4" loc="(500,610)" name="ROM">
-      <a name="addrWidth" val="9"/>
-      <a name="dataWidth" val="32"/>
-      <a name="contents">addr/data: 9 32
-201a0001 409a0800 201c0040 39df020 401a0000 afda0000 23de0004 23bd0004
-afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
-23de0004 afd60000 23bd0004 23de0004 afc40000 23bd0004 23de0004 afc20000
-23bd0004 23de0004 40161000 22d60001 201a0000 409a0800 20140005 20150001
-168020 102020 20020022 c 108100 1600fffb 295a022 1680fff8
-201a0001 409a0800 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc 8fc40000
-23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc 23bdfffc
-8fd40000 23defffc 23bdfffc 8fd00000 23defffc 23bdfffc 8fda0000 409a0000
-201a0000 409a0800 42000018
-</a>
+    <comp lib="1" loc="(120,580)" name="NOT Gate">
+      <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(660,600)" name="Constant">
+    <comp lib="0" loc="(70,1040)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(760,500)" name="Multiplexer">
       <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(570,550)" name="Splitter">
+    <comp lib="0" loc="(680,280)" name="Tunnel">
+      <a name="label" val="IsJR"/>
+    </comp>
+    <comp lib="1" loc="(790,1020)" name="NOT Gate"/>
+    <comp lib="0" loc="(630,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="13" loc="(780,480)" name="Regfile"/>
+    <comp lib="0" loc="(570,720)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
       <a name="bit21" val="none"/>
       <a name="bit22" val="none"/>
       <a name="bit23" val="none"/>
@@ -1420,31 +1154,27 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1390,600)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="MemWrite"/>
+    <comp lib="0" loc="(690,550)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x4"/>
     </comp>
-    <comp lib="0" loc="(720,960)" name="Tunnel">
-      <a name="label" val="ExpBlock"/>
+    <comp lib="4" loc="(400,180)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
-    <comp lib="5" loc="(1250,330)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
+    <comp lib="0" loc="(680,690)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtend"/>
     </comp>
-    <comp lib="0" loc="(1120,220)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Equal"/>
+    <comp lib="0" loc="(640,580)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
     </comp>
-    <comp lib="0" loc="(1430,570)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(370,1050)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
     </comp>
-    <comp lib="0" loc="(1590,200)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsJR"/>
-    </comp>
-    <comp lib="5" loc="(1530,330)" name="Hex Digit Display">
+    <comp lib="5" loc="(1410,330)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
@@ -1454,32 +1184,179 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="3" loc="(390,130)" name="Adder">
-      <a name="width" val="32"/>
+    <comp lib="1" loc="(800,910)" name="NOT Gate">
+      <a name="facing" val="west"/>
     </comp>
-    <comp lib="4" loc="(1500,530)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
+    <comp lib="0" loc="(680,440)" name="Tunnel">
+      <a name="label" val="RegDst"/>
+    </comp>
+    <comp lib="0" loc="(1590,200)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsJR"/>
+    </comp>
+    <comp lib="0" loc="(1160,530)" name="Tunnel">
+      <a name="label" val="IsShamt"/>
+    </comp>
+    <comp lib="2" loc="(730,540)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(90,510)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x800"/>
+    </comp>
+    <comp lib="0" loc="(1120,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="BneOrBeq"/>
+    </comp>
+    <comp lib="1" loc="(70,700)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1110,370)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(110,750)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(340,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
     </comp>
     <comp lib="4" loc="(430,890)" name="Register">
       <a name="width" val="32"/>
       <a name="label" val="PC Buffer"/>
     </comp>
-    <comp lib="0" loc="(570,320)" name="Splitter">
+    <comp lib="10" loc="(1040,320)" name="syscall_decoder"/>
+    <comp lib="2" loc="(1120,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1270,490)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUop"/>
+    </comp>
+    <comp lib="0" loc="(1250,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="0" loc="(1390,600)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemWrite"/>
+    </comp>
+    <comp lib="0" loc="(1100,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ALUSrc"/>
+    </comp>
+    <comp lib="0" loc="(1120,220)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Equal"/>
+    </comp>
+    <comp lib="0" loc="(770,440)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsSyscall"/>
+    </comp>
+    <comp lib="2" loc="(190,650)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(220,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="2" loc="(80,990)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(870,420)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(320,120)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(610,600)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDst"/>
+    </comp>
+    <comp lib="0" loc="(680,260)" name="Tunnel">
+      <a name="label" val="MemRead"/>
+    </comp>
+    <comp lib="2" loc="(560,550)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="5" loc="(1530,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(630,560)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(300,550)" name="Demultiplexer">
+      <a name="width" val="9"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(1460,120)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(380,280)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="3" loc="(390,130)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="3" loc="(430,1040)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1550,550)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="MemtoReg"/>
+    </comp>
+    <comp lib="1" loc="(1180,230)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="5" loc="(1300,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(600,970)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="5" loc="(1290,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(280,550)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
       <a name="bit2" val="0"/>
       <a name="bit3" val="0"/>
       <a name="bit4" val="0"/>
       <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
       <a name="bit11" val="none"/>
       <a name="bit12" val="none"/>
       <a name="bit13" val="none"/>
@@ -1502,39 +1379,156 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1160,530)" name="Tunnel">
-      <a name="label" val="IsShamt"/>
+    <comp lib="0" loc="(680,360)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUop"/>
     </comp>
-    <comp lib="0" loc="(680,620)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsJAL"/>
+    <comp lib="0" loc="(680,380)" name="Tunnel">
+      <a name="label" val="ALUSrc"/>
     </comp>
     <comp lib="6" loc="(1384,252)" name="Text">
       <a name="text" val="Screen"/>
     </comp>
-    <comp lib="0" loc="(680,240)" name="Tunnel">
-      <a name="label" val="MemWrite"/>
+    <comp lib="0" loc="(570,80)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(750,1020)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsJAL"/>
+    <comp lib="0" loc="(1340,530)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(410,950)" name="Tunnel">
+    <comp lib="0" loc="(1450,600)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
+      <a name="label" val="MemRead"/>
     </comp>
-    <comp lib="2" loc="(1120,560)" name="Multiplexer">
+    <comp lib="1" loc="(1350,220)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="7" loc="(1240,530)" name="ALU"/>
+    <comp lib="5" loc="(1490,330)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(1170,490)" name="Multiplexer">
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(630,510)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
+    <comp lib="5" loc="(1350,760)" name="Button">
+      <a name="facing" val="south"/>
     </comp>
-    <comp lib="12" loc="(660,700)" name="Immediate Extender"/>
-    <comp lib="0" loc="(790,670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="RegWrite"/>
+    <comp lib="0" loc="(570,490)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(410,320)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(660,600)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsJAL"/>
     </comp>
   </circuit>
   <circuit name="CP0">
@@ -1698,158 +1692,17 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
     <wire from="(730,720)" to="(740,720)"/>
     <wire from="(1000,850)" to="(1080,850)"/>
     <wire from="(870,1020)" to="(870,1070)"/>
-    <comp lib="0" loc="(1100,910)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(520,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsEret"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(840,250)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(380,530)" name="Tunnel">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="0" loc="(940,1060)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpClick"/>
-    </comp>
-    <comp lib="6" loc="(297,376)" name="Text">
-      <a name="text" val="Signal Decoding"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(250,970)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(730,960)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="4" loc="(960,1020)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Cause"/>
-    </comp>
-    <comp lib="0" loc="(780,250)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
     <comp lib="6" loc="(294,718)" name="Text">
       <a name="text" val="Exception Signals"/>
       <a name="font" val="Monaco plain 26"/>
     </comp>
-    <comp lib="0" loc="(410,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="1" loc="(860,680)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1150,860)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(1060,230)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="Dout"/>
-    </comp>
-    <comp lib="0" loc="(730,1020)" name="Constant">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="1" loc="(180,970)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(200,180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="0" loc="(470,230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(770,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
+      <a name="label" val="enable"/>
     </comp>
     <comp lib="0" loc="(370,770)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(320,860)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-    </comp>
-    <comp lib="0" loc="(720,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="0" loc="(1120,180)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(210,480)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="Inst"/>
-    </comp>
-    <comp lib="1" loc="(720,530)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="1" loc="(860,740)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(780,960)" name="Controlled Buffer">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="1" loc="(420,780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(960,850)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="Status"/>
-    </comp>
-    <comp lib="0" loc="(760,790)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
-    </comp>
-    <comp lib="0" loc="(250,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="1" loc="(890,710)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="0" loc="(1150,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCout"/>
-    </comp>
-    <comp lib="0" loc="(1000,880)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(780,210)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(460,180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsEret"/>
     </comp>
     <comp lib="0" loc="(1000,860)" name="Splitter">
       <a name="facing" val="south"/>
@@ -1888,44 +1741,21 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1060,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="enable"/>
-    </comp>
-    <comp lib="0" loc="(770,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(230,180)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ExRegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(110,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="2" loc="(740,560)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="4" loc="(960,850)" name="Register">
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+      <a name="label" val="Status"/>
     </comp>
-    <comp lib="0" loc="(520,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="HasExp"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(190,230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ExpBlock"/>
     </comp>
-    <comp lib="1" loc="(910,590)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(730,1070)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x2"/>
     </comp>
-    <comp lib="4" loc="(430,890)" name="Counter">
-      <a name="width" val="1"/>
-      <a name="max" val="0x1"/>
-      <a name="ongoal" val="stay"/>
-      <a name="trigger" val="falling"/>
+    <comp lib="0" loc="(370,460)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
     </comp>
     <comp lib="0" loc="(270,430)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1964,62 +1794,70 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(240,870)" name="Tunnel">
+    <comp lib="0" loc="(840,250)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="1" loc="(470,910)" name="NOT Gate">
       <a name="facing" val="south"/>
-      <a name="label" val="ExpClick"/>
     </comp>
-    <comp lib="1" loc="(340,430)" name="NOT Gate"/>
-    <comp lib="0" loc="(180,1020)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
+    <comp lib="0" loc="(780,250)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(850,580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
-    </comp>
-    <comp lib="2" loc="(740,720)" name="Demultiplexer">
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(840,170)" name="Tunnel">
-      <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(770,970)" name="Tunnel">
+    <comp lib="0" loc="(110,1020)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="ExpSrc0"/>
     </comp>
-    <comp lib="0" loc="(840,210)" name="Tunnel">
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="1" loc="(240,900)" name="AND Gate">
+    <comp lib="1" loc="(180,970)" name="OR Gate">
       <a name="facing" val="north"/>
       <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate1" val="true"/>
-    </comp>
-    <comp lib="0" loc="(940,890)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(780,1020)" name="Controlled Buffer">
-      <a name="width" val="32"/>
+      <a name="inputs" val="3"/>
     </comp>
     <comp lib="0" loc="(1120,230)" name="Tunnel">
       <a name="label" val="enable"/>
     </comp>
-    <comp lib="0" loc="(940,720)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
+    <comp lib="0" loc="(780,170)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc0"/>
     </comp>
-    <comp lib="0" loc="(730,720)" name="Constant"/>
-    <comp lib="0" loc="(230,230)" name="Pin">
+    <comp lib="0" loc="(1060,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(410,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="1" loc="(780,960)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="1" loc="(890,710)" name="AND Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="0" loc="(520,230)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="label" val="ExpBlock"/>
+      <a name="label" val="HasExp"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(190,230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ExpBlock"/>
+    <comp lib="1" loc="(340,430)" name="NOT Gate"/>
+    <comp lib="6" loc="(923,412)" name="Text">
+      <a name="text" val="Registers"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(720,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="0" loc="(780,210)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="1" loc="(720,530)" name="NOT Gate">
+      <a name="facing" val="south"/>
     </comp>
     <comp lib="1" loc="(360,530)" name="AND Gate">
       <a name="size" val="30"/>
@@ -2029,70 +1867,70 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="negate4" val="true"/>
       <a name="negate5" val="true"/>
     </comp>
-    <comp lib="0" loc="(780,170)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ExpSrc0"/>
+    <comp lib="0" loc="(760,770)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
     </comp>
-    <comp lib="0" loc="(1080,970)" name="Constant">
-      <a name="facing" val="west"/>
-      <a name="width" val="32"/>
-      <a name="value" val="0x0"/>
+    <comp lib="1" loc="(860,680)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(780,1070)" name="Controlled Buffer">
-      <a name="width" val="32"/>
+    <comp lib="0" loc="(850,580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
     </comp>
     <comp lib="4" loc="(960,560)" name="Register">
       <a name="width" val="32"/>
       <a name="trigger" val="high"/>
       <a name="label" val="EPC"/>
     </comp>
-    <comp lib="6" loc="(624,130)" name="Text">
-      <a name="text" val="Input &amp; Output"/>
-      <a name="font" val="Monaco plain 26"/>
+    <comp lib="0" loc="(770,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
     </comp>
-    <comp lib="0" loc="(730,1070)" name="Constant">
+    <comp lib="1" loc="(240,900)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate1" val="true"/>
+    </comp>
+    <comp lib="1" loc="(860,740)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(230,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExpBlock"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(780,1070)" name="Controlled Buffer">
       <a name="width" val="32"/>
-      <a name="value" val="0x2"/>
     </comp>
-    <comp lib="0" loc="(940,700)" name="Tunnel">
-      <a name="label" val="enable"/>
+    <comp lib="0" loc="(230,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ExRegWrite"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(260,460)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+    <comp lib="0" loc="(760,790)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="1" loc="(910,590)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(840,170)" name="Tunnel">
+      <a name="label" val="ExpSrc0"/>
+    </comp>
+    <comp lib="2" loc="(740,560)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(270,530)" name="Splitter">
       <a name="fanout" val="6"/>
@@ -2131,51 +1969,207 @@ afd00000 23bd0004 23de0004 afd40000 23bd0004 23de0004 afd50000 23bd0004
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="2" loc="(1120,860)" name="Multiplexer">
-      <a name="select" val="2"/>
+    <comp lib="0" loc="(680,550)" name="Pin">
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCin"/>
+    </comp>
+    <comp lib="0" loc="(770,970)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
     </comp>
     <comp lib="0" loc="(680,850)" name="Pin">
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
       <a name="label" val="Din"/>
     </comp>
-    <comp lib="0" loc="(370,430)" name="Tunnel">
+    <comp lib="0" loc="(180,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(250,1020)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="0" loc="(840,210)" name="Tunnel">
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="2" loc="(1120,860)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(200,180)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="ExRegWrite"/>
     </comp>
     <comp lib="0" loc="(450,780)" name="Tunnel">
       <a name="label" val="HasExp"/>
     </comp>
-    <comp lib="0" loc="(370,460)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="Sel"/>
+    <comp lib="0" loc="(460,180)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="2" loc="(740,720)" name="Demultiplexer">
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1080,970)" name="Constant">
+      <a name="facing" val="west"/>
+      <a name="width" val="32"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(370,430)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(940,700)" name="Tunnel">
+      <a name="label" val="enable"/>
+    </comp>
+    <comp lib="0" loc="(940,720)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
     </comp>
     <comp lib="0" loc="(940,600)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="0" loc="(1060,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(470,910)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(760,770)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-    </comp>
-    <comp lib="6" loc="(923,412)" name="Text">
-      <a name="text" val="Registers"/>
-      <a name="font" val="Monaco plain 26"/>
-    </comp>
-    <comp lib="0" loc="(680,550)" name="Pin">
+    <comp lib="0" loc="(1150,860)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="32"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="PCin"/>
+      <a name="label" val="Dout"/>
+    </comp>
+    <comp lib="0" loc="(240,870)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="1" loc="(780,1020)" name="Controlled Buffer">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(380,530)" name="Tunnel">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(520,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(320,860)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+    </comp>
+    <comp lib="4" loc="(960,1020)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="Cause"/>
+    </comp>
+    <comp lib="0" loc="(250,970)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="1" loc="(420,780)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(430,890)" name="Counter">
+      <a name="width" val="1"/>
+      <a name="max" val="0x1"/>
+      <a name="ongoal" val="stay"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(940,890)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(624,130)" name="Text">
+      <a name="text" val="Input &amp; Output"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(730,960)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(297,376)" name="Text">
+      <a name="text" val="Signal Decoding"/>
+      <a name="font" val="Monaco plain 26"/>
+    </comp>
+    <comp lib="0" loc="(770,1030)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="0" loc="(1100,910)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="Sel"/>
+    </comp>
+    <comp lib="0" loc="(1150,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCout"/>
+    </comp>
+    <comp lib="0" loc="(210,480)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Inst"/>
+    </comp>
+    <comp lib="0" loc="(730,720)" name="Constant"/>
+    <comp lib="0" loc="(730,1020)" name="Constant">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1120,180)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(260,460)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1000,880)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="0" loc="(940,1060)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpClick"/>
+    </comp>
+    <comp lib="0" loc="(470,230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
     </comp>
   </circuit>
 </project>


### PR DESCRIPTION
Similar to #41, the appearance of regfile could not be changed due to course requirement. A regfile wrapper was created to work around that restriction for cleaner wiring. However, since this is obviously not an issue anymore, this PR removes the regfile wrapper and make the regfile a common component among all MIPS-CPUs. Specifically, this PR has fixed the wiring on single cycle CPU due to the updated appearance.

Old:
<img width="296" alt="Screenshot 2022-07-16 at 10 22 41 PM" src="https://user-images.githubusercontent.com/10323518/179381364-348b9bb4-1e72-4958-964e-f20b1848bf74.png">

New:
<img width="300" alt="Screenshot 2022-07-16 at 10 20 52 PM" src="https://user-images.githubusercontent.com/10323518/179381366-b389d14d-d34e-4f22-a482-8f05bc2596f2.png">

The comments in regfile are also translated to English. An unused and redundant test circuit is removed.

