### PR TITLE
Move pipeline-related buffer set components to a separate library.

### DIFF
--- a/src/common/pipeline.circ
+++ b/src/common/pipeline.circ
@@ -1,0 +1,1466 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project source="2.7.1" version="1.0">
+  This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
+
+  <lib desc="#Wiring" name="0">
+    <tool name="Splitter">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Pin">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+    </tool>
+    <tool name="Tunnel">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="Pull Resistor">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Clock">
+      <a name="facing" val="north"/>
+    </tool>
+    <tool name="Constant">
+      <a name="value" val="0x0"/>
+    </tool>
+    <tool name="Bit Extender">
+      <a name="type" val="sign"/>
+    </tool>
+  </lib>
+  <lib desc="#Gates" name="1">
+    <tool name="Buffer">
+      <a name="width" val="3"/>
+    </tool>
+    <tool name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="OR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="NOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="XOR Gate">
+      <a name="inputs" val="2"/>
+    </tool>
+    <tool name="Odd Parity">
+      <a name="facing" val="south"/>
+      <a name="inputs" val="3"/>
+    </tool>
+  </lib>
+  <lib desc="#Plexers" name="2">
+    <tool name="Multiplexer">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="Demultiplexer">
+      <a name="select" val="5"/>
+    </tool>
+  </lib>
+  <lib desc="#Arithmetic" name="3">
+    <tool name="Subtractor">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Multiplier">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Divider">
+      <a name="width" val="16"/>
+    </tool>
+    <tool name="Negator">
+      <a name="width" val="1"/>
+    </tool>
+    <tool name="Comparator">
+      <a name="width" val="32"/>
+    </tool>
+  </lib>
+  <lib desc="#Memory" name="4">
+    <tool name="Register">
+      <a name="width" val="32"/>
+    </tool>
+    <tool name="ROM">
+      <a name="contents">addr/data: 8 8
+0
+</a>
+    </tool>
+  </lib>
+  <lib desc="#I/O" name="5"/>
+  <lib desc="#Base" name="6">
+    <tool name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+  </lib>
+  <main name="IF/ID"/>
+  <options>
+    <a name="gateUndefined" val="ignore"/>
+    <a name="simlimit" val="1000"/>
+    <a name="simrand" val="0"/>
+  </options>
+  <mappings>
+    <tool lib="6" map="Button2" name="Menu Tool"/>
+    <tool lib="6" map="Button3" name="Menu Tool"/>
+    <tool lib="6" map="Ctrl Button1" name="Menu Tool"/>
+  </mappings>
+  <toolbar>
+    <tool lib="6" name="Poke Tool"/>
+    <tool lib="6" name="Edit Tool"/>
+    <tool lib="6" name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+    <sep/>
+    <tool lib="0" name="Pin">
+      <a name="tristate" val="false"/>
+    </tool>
+    <tool lib="0" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="labelloc" val="east"/>
+    </tool>
+    <tool lib="1" name="NOT Gate"/>
+    <tool lib="1" name="AND Gate"/>
+    <tool lib="1" name="OR Gate"/>
+  </toolbar>
+  <circuit name="IF/ID">
+    <a name="circuit" val="IF/ID"/>
+    <a name="clabel" val="IF/ID"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="Dialog plain 32"/>
+    <appear>
+      <rect fill="#83f9ff" height="963" stroke="none" width="43" x="220" y="0"/>
+      <circ-port height="8" pin="180,70" width="8" x="216" y="416"/>
+      <circ-port height="10" pin="280,70" width="10" x="255" y="415"/>
+      <circ-port height="8" pin="30,50" width="8" x="236" y="-4"/>
+      <circ-port height="8" pin="210,290" width="8" x="226" y="956"/>
+      <circ-port height="8" pin="440,50" width="8" x="246" y="956"/>
+      <circ-port height="8" pin="180,170" width="8" x="216" y="736"/>
+      <circ-port height="10" pin="280,170" width="10" x="255" y="735"/>
+      <circ-anchor facing="east" height="6" width="6" x="217" y="-3"/>
+    </appear>
+    <wire from="(440,50)" to="(440,120)"/>
+    <wire from="(250,70)" to="(280,70)"/>
+    <wire from="(250,170)" to="(280,170)"/>
+    <wire from="(440,120)" to="(440,220)"/>
+    <wire from="(30,120)" to="(30,220)"/>
+    <wire from="(30,50)" to="(30,120)"/>
+    <wire from="(210,80)" to="(210,180)"/>
+    <wire from="(210,180)" to="(210,290)"/>
+    <wire from="(210,80)" to="(220,80)"/>
+    <wire from="(210,180)" to="(220,180)"/>
+    <wire from="(30,120)" to="(230,120)"/>
+    <wire from="(30,220)" to="(230,220)"/>
+    <wire from="(180,70)" to="(220,70)"/>
+    <wire from="(180,170)" to="(220,170)"/>
+    <wire from="(240,120)" to="(440,120)"/>
+    <wire from="(240,220)" to="(440,220)"/>
+    <wire from="(230,190)" to="(230,220)"/>
+    <wire from="(240,90)" to="(240,120)"/>
+    <wire from="(240,190)" to="(240,220)"/>
+    <wire from="(230,90)" to="(230,120)"/>
+    <comp lib="4" loc="(250,70)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(250,170)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(280,70)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="InstID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(180,170)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="0" loc="(210,290)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(280,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4IF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(440,50)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(180,70)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="InstIF"/>
+    </comp>
+    <comp lib="0" loc="(30,50)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+  </circuit>
+  <circuit name="ID/EX">
+    <a name="circuit" val="ID/EX"/>
+    <a name="clabel" val="ID/EX"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="Dialog plain 32"/>
+    <appear>
+      <rect fill="#ffe05d" height="980" stroke="none" width="42" x="110" y="31"/>
+      <circ-port height="8" pin="30,40" width="8" x="126" y="26"/>
+      <circ-port height="8" pin="830,110" width="8" x="106" y="56"/>
+      <circ-port height="8" pin="830,530" width="8" x="106" y="156"/>
+      <circ-port height="8" pin="830,170" width="8" x="106" y="296"/>
+      <circ-port height="8" pin="1150,100" width="8" x="106" y="136"/>
+      <circ-port height="8" pin="830,230" width="8" x="106" y="96"/>
+      <circ-port height="8" pin="1150,160" width="8" x="106" y="236"/>
+      <circ-port height="8" pin="830,290" width="8" x="106" y="76"/>
+      <circ-port height="8" pin="1150,220" width="8" x="106" y="196"/>
+      <circ-port height="8" pin="830,350" width="8" x="106" y="216"/>
+      <circ-port height="8" pin="830,410" width="8" x="106" y="276"/>
+      <circ-port height="8" pin="1150,280" width="8" x="106" y="176"/>
+      <circ-port height="8" pin="830,470" width="8" x="106" y="116"/>
+      <circ-port height="10" pin="890,110" width="10" x="145" y="55"/>
+      <circ-port height="10" pin="900,530" width="10" x="145" y="155"/>
+      <circ-port height="10" pin="900,170" width="10" x="145" y="295"/>
+      <circ-port height="10" pin="1220,100" width="10" x="145" y="135"/>
+      <circ-port height="10" pin="900,230" width="10" x="145" y="95"/>
+      <circ-port height="10" pin="1220,160" width="10" x="145" y="235"/>
+      <circ-port height="10" pin="900,290" width="10" x="145" y="75"/>
+      <circ-port height="10" pin="1220,220" width="10" x="145" y="195"/>
+      <circ-port height="10" pin="900,350" width="10" x="145" y="215"/>
+      <circ-port height="10" pin="900,410" width="10" x="145" y="275"/>
+      <circ-port height="10" pin="1220,280" width="10" x="145" y="175"/>
+      <circ-port height="10" pin="900,470" width="10" x="145" y="115"/>
+      <circ-port height="8" pin="1150,400" width="8" x="106" y="256"/>
+      <circ-port height="10" pin="1210,400" width="10" x="145" y="255"/>
+      <circ-port height="8" pin="1150,460" width="8" x="106" y="586"/>
+      <circ-port height="10" pin="1210,460" width="10" x="145" y="585"/>
+      <circ-port height="8" pin="140,110" width="8" x="106" y="736"/>
+      <circ-port height="10" pin="210,110" width="10" x="145" y="735"/>
+      <circ-port height="8" pin="140,210" width="8" x="106" y="426"/>
+      <circ-port height="10" pin="210,210" width="10" x="145" y="425"/>
+      <circ-port height="8" pin="140,310" width="8" x="106" y="446"/>
+      <circ-port height="10" pin="210,310" width="10" x="145" y="445"/>
+      <circ-port height="8" pin="490,310" width="8" x="106" y="766"/>
+      <circ-port height="10" pin="560,310" width="10" x="145" y="765"/>
+      <circ-port height="8" pin="490,110" width="8" x="106" y="516"/>
+      <circ-port height="10" pin="560,110" width="10" x="145" y="515"/>
+      <circ-port height="8" pin="490,210" width="8" x="106" y="656"/>
+      <circ-port height="10" pin="560,210" width="10" x="145" y="655"/>
+      <circ-port height="8" pin="1150,340" width="8" x="106" y="316"/>
+      <circ-port height="10" pin="1220,340" width="10" x="145" y="315"/>
+      <circ-port height="8" pin="70,40" width="8" x="136" y="1006"/>
+      <circ-port height="8" pin="150,580" width="8" x="116" y="1006"/>
+      <circ-port height="8" pin="140,420" width="8" x="106" y="906"/>
+      <circ-port height="10" pin="210,420" width="10" x="145" y="905"/>
+      <circ-port height="8" pin="1150,530" width="8" x="106" y="976"/>
+      <circ-port height="10" pin="1220,530" width="10" x="145" y="975"/>
+      <circ-anchor facing="east" height="6" width="6" x="107" y="27"/>
+    </appear>
+    <wire from="(870,550)" to="(870,560)"/>
+    <wire from="(870,310)" to="(870,320)"/>
+    <wire from="(530,130)" to="(530,160)"/>
+    <wire from="(1160,470)" to="(1160,540)"/>
+    <wire from="(1180,300)" to="(1180,310)"/>
+    <wire from="(1190,550)" to="(1190,560)"/>
+    <wire from="(170,330)" to="(170,360)"/>
+    <wire from="(310,260)" to="(310,360)"/>
+    <wire from="(880,350)" to="(900,350)"/>
+    <wire from="(1190,490)" to="(1270,490)"/>
+    <wire from="(1190,250)" to="(1270,250)"/>
+    <wire from="(660,50)" to="(660,160)"/>
+    <wire from="(1040,490)" to="(1180,490)"/>
+    <wire from="(30,60)" to="(30,160)"/>
+    <wire from="(1270,310)" to="(1270,370)"/>
+    <wire from="(840,120)" to="(840,180)"/>
+    <wire from="(840,360)" to="(840,420)"/>
+    <wire from="(500,220)" to="(510,220)"/>
+    <wire from="(30,360)" to="(170,360)"/>
+    <wire from="(150,430)" to="(160,430)"/>
+    <wire from="(840,240)" to="(850,240)"/>
+    <wire from="(840,480)" to="(850,480)"/>
+    <wire from="(1040,250)" to="(1180,250)"/>
+    <wire from="(180,360)" to="(310,360)"/>
+    <wire from="(1150,220)" to="(1170,220)"/>
+    <wire from="(1150,460)" to="(1170,460)"/>
+    <wire from="(340,60)" to="(730,60)"/>
+    <wire from="(860,430)" to="(860,440)"/>
+    <wire from="(860,190)" to="(860,200)"/>
+    <wire from="(340,360)" to="(520,360)"/>
+    <wire from="(70,40)" to="(70,50)"/>
+    <wire from="(950,50)" to="(1270,50)"/>
+    <wire from="(520,330)" to="(520,360)"/>
+    <wire from="(1190,120)" to="(1190,130)"/>
+    <wire from="(1190,360)" to="(1190,370)"/>
+    <wire from="(180,230)" to="(180,260)"/>
+    <wire from="(830,350)" to="(850,350)"/>
+    <wire from="(830,110)" to="(850,110)"/>
+    <wire from="(340,260)" to="(340,360)"/>
+    <wire from="(1160,290)" to="(1170,290)"/>
+    <wire from="(1160,410)" to="(1160,470)"/>
+    <wire from="(1160,170)" to="(1160,230)"/>
+    <wire from="(660,260)" to="(660,360)"/>
+    <wire from="(190,110)" to="(210,110)"/>
+    <wire from="(950,200)" to="(950,260)"/>
+    <wire from="(950,440)" to="(950,500)"/>
+    <wire from="(1040,130)" to="(1040,190)"/>
+    <wire from="(1040,370)" to="(1040,430)"/>
+    <wire from="(150,320)" to="(160,320)"/>
+    <wire from="(730,560)" to="(860,560)"/>
+    <wire from="(730,320)" to="(860,320)"/>
+    <wire from="(530,360)" to="(660,360)"/>
+    <wire from="(730,140)" to="(730,200)"/>
+    <wire from="(730,380)" to="(730,440)"/>
+    <wire from="(500,320)" to="(500,570)"/>
+    <wire from="(870,140)" to="(950,140)"/>
+    <wire from="(870,380)" to="(950,380)"/>
+    <wire from="(1200,160)" to="(1220,160)"/>
+    <wire from="(870,490)" to="(870,500)"/>
+    <wire from="(870,250)" to="(870,260)"/>
+    <wire from="(150,570)" to="(150,580)"/>
+    <wire from="(1160,540)" to="(1160,570)"/>
+    <wire from="(70,50)" to="(310,50)"/>
+    <wire from="(840,540)" to="(840,570)"/>
+    <wire from="(530,230)" to="(530,260)"/>
+    <wire from="(1180,480)" to="(1180,490)"/>
+    <wire from="(1180,240)" to="(1180,250)"/>
+    <wire from="(730,60)" to="(730,140)"/>
+    <wire from="(180,440)" to="(180,470)"/>
+    <wire from="(880,290)" to="(900,290)"/>
+    <wire from="(880,530)" to="(900,530)"/>
+    <wire from="(1190,190)" to="(1270,190)"/>
+    <wire from="(1190,430)" to="(1270,430)"/>
+    <wire from="(1040,430)" to="(1180,430)"/>
+    <wire from="(540,110)" to="(560,110)"/>
+    <wire from="(1200,460)" to="(1210,460)"/>
+    <wire from="(30,160)" to="(30,260)"/>
+    <wire from="(150,120)" to="(150,220)"/>
+    <wire from="(310,360)" to="(310,470)"/>
+    <wire from="(140,110)" to="(160,110)"/>
+    <wire from="(1270,250)" to="(1270,310)"/>
+    <wire from="(840,300)" to="(840,360)"/>
+    <wire from="(500,320)" to="(510,320)"/>
+    <wire from="(840,420)" to="(850,420)"/>
+    <wire from="(840,180)" to="(850,180)"/>
+    <wire from="(1040,190)" to="(1180,190)"/>
+    <wire from="(1150,400)" to="(1170,400)"/>
+    <wire from="(1150,160)" to="(1170,160)"/>
+    <wire from="(1200,530)" to="(1220,530)"/>
+    <wire from="(860,130)" to="(860,140)"/>
+    <wire from="(860,370)" to="(860,380)"/>
+    <wire from="(660,50)" to="(950,50)"/>
+    <wire from="(1270,490)" to="(1270,560)"/>
+    <wire from="(1190,300)" to="(1190,310)"/>
+    <wire from="(180,330)" to="(180,360)"/>
+    <wire from="(830,530)" to="(850,530)"/>
+    <wire from="(830,290)" to="(850,290)"/>
+    <wire from="(150,570)" to="(500,570)"/>
+    <wire from="(1190,560)" to="(1270,560)"/>
+    <wire from="(500,120)" to="(500,220)"/>
+    <wire from="(1040,560)" to="(1180,560)"/>
+    <wire from="(1160,230)" to="(1170,230)"/>
+    <wire from="(1160,470)" to="(1170,470)"/>
+    <wire from="(490,110)" to="(510,110)"/>
+    <wire from="(1160,110)" to="(1160,170)"/>
+    <wire from="(1160,350)" to="(1160,410)"/>
+    <wire from="(190,210)" to="(210,210)"/>
+    <wire from="(950,380)" to="(950,440)"/>
+    <wire from="(950,140)" to="(950,200)"/>
+    <wire from="(1040,310)" to="(1040,370)"/>
+    <wire from="(730,260)" to="(860,260)"/>
+    <wire from="(730,500)" to="(860,500)"/>
+    <wire from="(730,320)" to="(730,380)"/>
+    <wire from="(880,110)" to="(890,110)"/>
+    <wire from="(870,320)" to="(950,320)"/>
+    <wire from="(1150,530)" to="(1170,530)"/>
+    <wire from="(870,560)" to="(950,560)"/>
+    <wire from="(1200,100)" to="(1220,100)"/>
+    <wire from="(1200,340)" to="(1220,340)"/>
+    <wire from="(870,430)" to="(870,440)"/>
+    <wire from="(870,190)" to="(870,200)"/>
+    <wire from="(840,570)" to="(1160,570)"/>
+    <wire from="(530,330)" to="(530,360)"/>
+    <wire from="(1180,420)" to="(1180,430)"/>
+    <wire from="(1180,180)" to="(1180,190)"/>
+    <wire from="(170,130)" to="(170,160)"/>
+    <wire from="(880,230)" to="(900,230)"/>
+    <wire from="(880,470)" to="(900,470)"/>
+    <wire from="(1190,130)" to="(1270,130)"/>
+    <wire from="(1190,370)" to="(1270,370)"/>
+    <wire from="(540,210)" to="(560,210)"/>
+    <wire from="(1200,400)" to="(1210,400)"/>
+    <wire from="(30,260)" to="(30,360)"/>
+    <wire from="(150,220)" to="(150,320)"/>
+    <wire from="(140,210)" to="(160,210)"/>
+    <wire from="(1270,430)" to="(1270,490)"/>
+    <wire from="(1270,190)" to="(1270,250)"/>
+    <wire from="(190,420)" to="(210,420)"/>
+    <wire from="(840,240)" to="(840,300)"/>
+    <wire from="(840,480)" to="(840,540)"/>
+    <wire from="(30,160)" to="(170,160)"/>
+    <wire from="(840,360)" to="(850,360)"/>
+    <wire from="(840,120)" to="(850,120)"/>
+    <wire from="(1040,370)" to="(1180,370)"/>
+    <wire from="(1040,130)" to="(1180,130)"/>
+    <wire from="(180,160)" to="(310,160)"/>
+    <wire from="(1150,340)" to="(1170,340)"/>
+    <wire from="(1150,100)" to="(1170,100)"/>
+    <wire from="(860,550)" to="(860,560)"/>
+    <wire from="(860,310)" to="(860,320)"/>
+    <wire from="(340,160)" to="(520,160)"/>
+    <wire from="(30,60)" to="(340,60)"/>
+    <wire from="(30,40)" to="(30,60)"/>
+    <wire from="(1190,240)" to="(1190,250)"/>
+    <wire from="(1180,550)" to="(1180,560)"/>
+    <wire from="(1190,480)" to="(1190,490)"/>
+    <wire from="(520,130)" to="(520,160)"/>
+    <wire from="(830,470)" to="(850,470)"/>
+    <wire from="(830,230)" to="(850,230)"/>
+    <wire from="(340,60)" to="(340,160)"/>
+    <wire from="(500,220)" to="(500,320)"/>
+    <wire from="(1160,170)" to="(1170,170)"/>
+    <wire from="(1160,410)" to="(1170,410)"/>
+    <wire from="(490,210)" to="(510,210)"/>
+    <wire from="(1160,290)" to="(1160,350)"/>
+    <wire from="(140,420)" to="(160,420)"/>
+    <wire from="(190,310)" to="(210,310)"/>
+    <wire from="(950,320)" to="(950,380)"/>
+    <wire from="(1040,250)" to="(1040,310)"/>
+    <wire from="(150,120)" to="(160,120)"/>
+    <wire from="(730,200)" to="(860,200)"/>
+    <wire from="(730,440)" to="(860,440)"/>
+    <wire from="(530,160)" to="(660,160)"/>
+    <wire from="(730,260)" to="(730,320)"/>
+    <wire from="(730,500)" to="(730,560)"/>
+    <wire from="(870,260)" to="(950,260)"/>
+    <wire from="(870,500)" to="(950,500)"/>
+    <wire from="(1200,280)" to="(1220,280)"/>
+    <wire from="(870,370)" to="(870,380)"/>
+    <wire from="(870,130)" to="(870,140)"/>
+    <wire from="(1040,490)" to="(1040,560)"/>
+    <wire from="(150,430)" to="(150,570)"/>
+    <wire from="(1180,360)" to="(1180,370)"/>
+    <wire from="(1180,120)" to="(1180,130)"/>
+    <wire from="(170,230)" to="(170,260)"/>
+    <wire from="(310,160)" to="(310,260)"/>
+    <wire from="(880,170)" to="(900,170)"/>
+    <wire from="(880,410)" to="(900,410)"/>
+    <wire from="(1190,310)" to="(1270,310)"/>
+    <wire from="(540,310)" to="(560,310)"/>
+    <wire from="(1160,540)" to="(1170,540)"/>
+    <wire from="(150,320)" to="(150,430)"/>
+    <wire from="(140,310)" to="(160,310)"/>
+    <wire from="(30,360)" to="(30,470)"/>
+    <wire from="(1270,130)" to="(1270,190)"/>
+    <wire from="(1270,370)" to="(1270,430)"/>
+    <wire from="(840,180)" to="(840,240)"/>
+    <wire from="(840,420)" to="(840,480)"/>
+    <wire from="(500,120)" to="(510,120)"/>
+    <wire from="(30,260)" to="(170,260)"/>
+    <wire from="(840,300)" to="(850,300)"/>
+    <wire from="(840,540)" to="(850,540)"/>
+    <wire from="(1040,310)" to="(1180,310)"/>
+    <wire from="(180,260)" to="(310,260)"/>
+    <wire from="(1150,280)" to="(1170,280)"/>
+    <wire from="(730,60)" to="(1040,60)"/>
+    <wire from="(1270,50)" to="(1270,130)"/>
+    <wire from="(860,490)" to="(860,500)"/>
+    <wire from="(860,250)" to="(860,260)"/>
+    <wire from="(340,260)" to="(520,260)"/>
+    <wire from="(1040,60)" to="(1040,130)"/>
+    <wire from="(950,50)" to="(950,140)"/>
+    <wire from="(1190,180)" to="(1190,190)"/>
+    <wire from="(1190,420)" to="(1190,430)"/>
+    <wire from="(520,230)" to="(520,260)"/>
+    <wire from="(180,130)" to="(180,160)"/>
+    <wire from="(170,440)" to="(170,470)"/>
+    <wire from="(830,410)" to="(850,410)"/>
+    <wire from="(830,170)" to="(850,170)"/>
+    <wire from="(340,160)" to="(340,260)"/>
+    <wire from="(500,570)" to="(840,570)"/>
+    <wire from="(310,50)" to="(660,50)"/>
+    <wire from="(1160,110)" to="(1170,110)"/>
+    <wire from="(1160,350)" to="(1170,350)"/>
+    <wire from="(310,50)" to="(310,160)"/>
+    <wire from="(490,310)" to="(510,310)"/>
+    <wire from="(1160,230)" to="(1160,290)"/>
+    <wire from="(660,160)" to="(660,260)"/>
+    <wire from="(950,260)" to="(950,320)"/>
+    <wire from="(950,500)" to="(950,560)"/>
+    <wire from="(1040,190)" to="(1040,250)"/>
+    <wire from="(1040,430)" to="(1040,490)"/>
+    <wire from="(150,220)" to="(160,220)"/>
+    <wire from="(30,470)" to="(170,470)"/>
+    <wire from="(730,140)" to="(860,140)"/>
+    <wire from="(730,380)" to="(860,380)"/>
+    <wire from="(530,260)" to="(660,260)"/>
+    <wire from="(730,200)" to="(730,260)"/>
+    <wire from="(730,440)" to="(730,500)"/>
+    <wire from="(870,200)" to="(950,200)"/>
+    <wire from="(870,440)" to="(950,440)"/>
+    <wire from="(180,470)" to="(310,470)"/>
+    <wire from="(1200,220)" to="(1220,220)"/>
+    <comp lib="0" loc="(1220,220)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BranchEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(900,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(540,210)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(560,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1150,220)" name="Pin">
+      <a name="label" val="BranchID"/>
+    </comp>
+    <comp lib="0" loc="(830,110)" name="Pin">
+      <a name="label" val="IsJALID"/>
+    </comp>
+    <comp lib="0" loc="(1220,160)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="JumpEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(890,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1200,400)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(900,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsShamtEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(560,210)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1200,280)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(150,580)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(900,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ALUSrcEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(900,230)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(880,530)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(1200,460)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(560,310)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="PCPlusEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(830,230)" name="Pin">
+      <a name="label" val="MemtoRegID"/>
+    </comp>
+    <comp lib="0" loc="(490,310)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="0" loc="(210,310)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R2EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1200,100)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(190,310)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1150,100)" name="Pin">
+      <a name="label" val="MemWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1150,460)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#ID"/>
+    </comp>
+    <comp lib="0" loc="(30,40)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(880,170)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(880,470)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1210,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(900,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1200,340)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(140,110)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ImmID"/>
+    </comp>
+    <comp lib="0" loc="(490,110)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ShamtID"/>
+    </comp>
+    <comp lib="4" loc="(1200,220)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(210,110)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ImmEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(140,420)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="CP0Dout"/>
+    </comp>
+    <comp lib="4" loc="(880,350)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(880,230)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(830,170)" name="Pin">
+      <a name="label" val="IsShamtID"/>
+    </comp>
+    <comp lib="0" loc="(140,310)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R2ID"/>
+    </comp>
+    <comp lib="4" loc="(880,410)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1150,160)" name="Pin">
+      <a name="label" val="JumpID"/>
+    </comp>
+    <comp lib="0" loc="(210,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(190,420)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1220,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1220,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsEret"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(830,530)" name="Pin">
+      <a name="label" val="MemReadID"/>
+    </comp>
+    <comp lib="0" loc="(1150,280)" name="Pin">
+      <a name="label" val="IsJRID"/>
+    </comp>
+    <comp lib="0" loc="(830,290)" name="Pin">
+      <a name="label" val="RegWriteID"/>
+    </comp>
+    <comp lib="0" loc="(1150,340)" name="Pin">
+      <a name="label" val="IsSyscallID"/>
+    </comp>
+    <comp lib="4" loc="(540,310)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1150,530)" name="Pin">
+      <a name="label" val="IsEret"/>
+    </comp>
+    <comp lib="0" loc="(830,410)" name="Pin">
+      <a name="label" val="ALUSrcID"/>
+    </comp>
+    <comp lib="0" loc="(900,350)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BneOrBeqEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1200,530)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(880,290)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(830,350)" name="Pin">
+      <a name="label" val="BneOrBeqID"/>
+    </comp>
+    <comp lib="4" loc="(540,110)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(830,470)" name="Pin">
+      <a name="label" val="IsExceptionID"/>
+    </comp>
+    <comp lib="0" loc="(140,210)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="R1ID"/>
+    </comp>
+    <comp lib="0" loc="(1220,100)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(210,210)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="R1EX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(1200,160)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(1150,400)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopID"/>
+    </comp>
+    <comp lib="0" loc="(900,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(490,210)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="JumpAddr"/>
+    </comp>
+    <comp lib="4" loc="(190,210)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(190,110)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(880,110)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(70,40)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1210,400)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ALUopEX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1220,280)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJREX"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+  </circuit>
+  <circuit name="EX/MEM">
+    <a name="circuit" val="EX/MEM"/>
+    <a name="clabel" val="EX/MEM"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="Dialog plain 32"/>
+    <appear>
+      <rect fill="#ff8045" height="961" stroke="none" width="37" x="52" y="50"/>
+      <circ-port height="8" pin="160,330" width="8" x="46" y="166"/>
+      <circ-port height="10" pin="230,330" width="10" x="85" y="165"/>
+      <circ-port height="8" pin="160,390" width="8" x="46" y="146"/>
+      <circ-port height="10" pin="230,390" width="10" x="85" y="145"/>
+      <circ-port height="8" pin="160,270" width="8" x="46" y="126"/>
+      <circ-port height="10" pin="230,270" width="10" x="85" y="125"/>
+      <circ-port height="8" pin="160,90" width="8" x="46" y="66"/>
+      <circ-port height="10" pin="230,90" width="10" x="85" y="65"/>
+      <circ-port height="8" pin="160,210" width="8" x="46" y="86"/>
+      <circ-port height="10" pin="230,210" width="10" x="85" y="85"/>
+      <circ-port height="8" pin="160,150" width="8" x="46" y="106"/>
+      <circ-port height="10" pin="230,150" width="10" x="85" y="105"/>
+      <circ-port height="8" pin="30,40" width="8" x="66" y="46"/>
+      <circ-port height="8" pin="160,450" width="8" x="46" y="326"/>
+      <circ-port height="10" pin="230,450" width="10" x="85" y="325"/>
+      <circ-port height="8" pin="550,120" width="8" x="46" y="486"/>
+      <circ-port height="10" pin="620,120" width="10" x="85" y="485"/>
+      <circ-port height="8" pin="550,220" width="8" x="46" y="576"/>
+      <circ-port height="10" pin="620,220" width="10" x="85" y="575"/>
+      <circ-port height="8" pin="550,320" width="8" x="46" y="776"/>
+      <circ-port height="10" pin="620,320" width="10" x="85" y="775"/>
+      <circ-port height="8" pin="160,510" width="8" x="46" y="596"/>
+      <circ-port height="10" pin="230,510" width="10" x="85" y="595"/>
+      <circ-port height="8" pin="80,40" width="8" x="76" y="1006"/>
+      <circ-port height="8" pin="170,570" width="8" x="56" y="1006"/>
+      <circ-port height="8" pin="550,430" width="8" x="46" y="916"/>
+      <circ-port height="10" pin="620,430" width="10" x="85" y="915"/>
+      <circ-anchor facing="east" height="6" width="6" x="47" y="47"/>
+    </appear>
+    <wire from="(590,170)" to="(710,170)"/>
+    <wire from="(590,370)" to="(710,370)"/>
+    <wire from="(190,230)" to="(190,240)"/>
+    <wire from="(190,110)" to="(190,120)"/>
+    <wire from="(190,350)" to="(190,360)"/>
+    <wire from="(190,470)" to="(190,480)"/>
+    <wire from="(80,40)" to="(80,50)"/>
+    <wire from="(580,140)" to="(580,170)"/>
+    <wire from="(580,340)" to="(580,370)"/>
+    <wire from="(30,420)" to="(190,420)"/>
+    <wire from="(30,300)" to="(190,300)"/>
+    <wire from="(30,180)" to="(190,180)"/>
+    <wire from="(30,540)" to="(190,540)"/>
+    <wire from="(550,220)" to="(570,220)"/>
+    <wire from="(600,430)" to="(620,430)"/>
+    <wire from="(370,480)" to="(580,480)"/>
+    <wire from="(560,230)" to="(560,330)"/>
+    <wire from="(160,270)" to="(180,270)"/>
+    <wire from="(160,150)" to="(180,150)"/>
+    <wire from="(160,510)" to="(180,510)"/>
+    <wire from="(160,390)" to="(180,390)"/>
+    <wire from="(560,440)" to="(570,440)"/>
+    <wire from="(290,50)" to="(290,120)"/>
+    <wire from="(200,290)" to="(200,300)"/>
+    <wire from="(200,170)" to="(200,180)"/>
+    <wire from="(200,530)" to="(200,540)"/>
+    <wire from="(200,410)" to="(200,420)"/>
+    <wire from="(30,40)" to="(30,60)"/>
+    <wire from="(590,240)" to="(590,270)"/>
+    <wire from="(370,170)" to="(370,270)"/>
+    <wire from="(550,430)" to="(570,430)"/>
+    <wire from="(600,320)" to="(620,320)"/>
+    <wire from="(200,300)" to="(290,300)"/>
+    <wire from="(200,180)" to="(290,180)"/>
+    <wire from="(200,540)" to="(290,540)"/>
+    <wire from="(200,420)" to="(290,420)"/>
+    <wire from="(600,120)" to="(620,120)"/>
+    <wire from="(370,170)" to="(580,170)"/>
+    <wire from="(370,370)" to="(370,480)"/>
+    <wire from="(370,370)" to="(580,370)"/>
+    <wire from="(710,270)" to="(710,370)"/>
+    <wire from="(210,90)" to="(230,90)"/>
+    <wire from="(210,450)" to="(230,450)"/>
+    <wire from="(210,330)" to="(230,330)"/>
+    <wire from="(210,210)" to="(230,210)"/>
+    <wire from="(560,440)" to="(560,560)"/>
+    <wire from="(170,220)" to="(180,220)"/>
+    <wire from="(170,100)" to="(180,100)"/>
+    <wire from="(170,460)" to="(180,460)"/>
+    <wire from="(170,340)" to="(180,340)"/>
+    <wire from="(290,420)" to="(290,480)"/>
+    <wire from="(290,300)" to="(290,360)"/>
+    <wire from="(290,180)" to="(290,240)"/>
+    <wire from="(30,120)" to="(30,180)"/>
+    <wire from="(30,480)" to="(30,540)"/>
+    <wire from="(30,360)" to="(30,420)"/>
+    <wire from="(30,240)" to="(30,300)"/>
+    <wire from="(560,130)" to="(570,130)"/>
+    <wire from="(170,100)" to="(170,160)"/>
+    <wire from="(170,460)" to="(170,520)"/>
+    <wire from="(560,330)" to="(570,330)"/>
+    <wire from="(170,340)" to="(170,400)"/>
+    <wire from="(170,220)" to="(170,280)"/>
+    <wire from="(590,270)" to="(710,270)"/>
+    <wire from="(190,170)" to="(190,180)"/>
+    <wire from="(190,410)" to="(190,420)"/>
+    <wire from="(190,290)" to="(190,300)"/>
+    <wire from="(190,530)" to="(190,540)"/>
+    <wire from="(580,240)" to="(580,270)"/>
+    <wire from="(590,450)" to="(590,480)"/>
+    <wire from="(30,480)" to="(190,480)"/>
+    <wire from="(30,360)" to="(190,360)"/>
+    <wire from="(30,240)" to="(190,240)"/>
+    <wire from="(30,120)" to="(190,120)"/>
+    <wire from="(550,120)" to="(570,120)"/>
+    <wire from="(550,320)" to="(570,320)"/>
+    <wire from="(560,330)" to="(560,440)"/>
+    <wire from="(370,60)" to="(370,170)"/>
+    <wire from="(560,130)" to="(560,230)"/>
+    <wire from="(160,330)" to="(180,330)"/>
+    <wire from="(160,210)" to="(180,210)"/>
+    <wire from="(160,90)" to="(180,90)"/>
+    <wire from="(160,450)" to="(180,450)"/>
+    <wire from="(80,50)" to="(290,50)"/>
+    <wire from="(590,480)" to="(710,480)"/>
+    <wire from="(170,560)" to="(170,570)"/>
+    <wire from="(200,230)" to="(200,240)"/>
+    <wire from="(200,110)" to="(200,120)"/>
+    <wire from="(200,470)" to="(200,480)"/>
+    <wire from="(200,350)" to="(200,360)"/>
+    <wire from="(590,140)" to="(590,170)"/>
+    <wire from="(580,450)" to="(580,480)"/>
+    <wire from="(590,340)" to="(590,370)"/>
+    <wire from="(290,50)" to="(710,50)"/>
+    <wire from="(370,270)" to="(370,370)"/>
+    <wire from="(710,370)" to="(710,480)"/>
+    <wire from="(200,240)" to="(290,240)"/>
+    <wire from="(200,120)" to="(290,120)"/>
+    <wire from="(200,480)" to="(290,480)"/>
+    <wire from="(200,360)" to="(290,360)"/>
+    <wire from="(600,220)" to="(620,220)"/>
+    <wire from="(170,520)" to="(170,560)"/>
+    <wire from="(370,270)" to="(580,270)"/>
+    <wire from="(30,60)" to="(370,60)"/>
+    <wire from="(710,170)" to="(710,270)"/>
+    <wire from="(210,510)" to="(230,510)"/>
+    <wire from="(210,390)" to="(230,390)"/>
+    <wire from="(210,270)" to="(230,270)"/>
+    <wire from="(210,150)" to="(230,150)"/>
+    <wire from="(710,50)" to="(710,170)"/>
+    <wire from="(170,160)" to="(180,160)"/>
+    <wire from="(170,520)" to="(180,520)"/>
+    <wire from="(170,400)" to="(180,400)"/>
+    <wire from="(170,280)" to="(180,280)"/>
+    <wire from="(290,480)" to="(290,540)"/>
+    <wire from="(290,360)" to="(290,420)"/>
+    <wire from="(290,240)" to="(290,300)"/>
+    <wire from="(290,120)" to="(290,180)"/>
+    <wire from="(170,560)" to="(560,560)"/>
+    <wire from="(30,60)" to="(30,120)"/>
+    <wire from="(30,420)" to="(30,480)"/>
+    <wire from="(30,300)" to="(30,360)"/>
+    <wire from="(30,180)" to="(30,240)"/>
+    <wire from="(560,230)" to="(570,230)"/>
+    <wire from="(170,400)" to="(170,460)"/>
+    <wire from="(170,280)" to="(170,340)"/>
+    <wire from="(170,160)" to="(170,220)"/>
+    <comp lib="0" loc="(80,40)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(210,210)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(170,570)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(230,390)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(160,150)" name="Pin">
+      <a name="label" val="MemtoRegEX"/>
+    </comp>
+    <comp lib="4" loc="(600,430)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(550,430)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+    </comp>
+    <comp lib="4" loc="(210,270)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(550,320)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrEX"/>
+    </comp>
+    <comp lib="0" loc="(620,430)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="CP0Dout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(230,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(160,330)" name="Pin">
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="0" loc="(230,330)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemReadMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(620,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(600,320)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(210,90)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(230,450)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(230,270)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(160,390)" name="Pin">
+      <a name="label" val="MemWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(210,390)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(230,150)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(620,220)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(230,210)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(600,220)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="4" loc="(600,120)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(160,90)" name="Pin">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="0" loc="(550,120)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultEX"/>
+    </comp>
+    <comp lib="4" loc="(210,330)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(550,220)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="WriteDataEX"/>
+    </comp>
+    <comp lib="0" loc="(160,210)" name="Pin">
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="4" loc="(210,450)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(160,510)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(160,270)" name="Pin">
+      <a name="label" val="IsExceptionEX"/>
+    </comp>
+    <comp lib="4" loc="(210,510)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(230,90)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(620,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(210,150)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(30,40)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(160,450)" name="Pin">
+      <a name="label" val="IsSyscallEX"/>
+    </comp>
+  </circuit>
+  <circuit name="MEM/WB">
+    <a name="circuit" val="MEM/WB"/>
+    <a name="clabel" val="MEM/WBN"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="Dialog plain 32"/>
+    <appear>
+      <rect fill="#d075ff" height="959" stroke="none" width="41" x="160" y="61"/>
+      <circ-port height="8" pin="140,120" width="8" x="156" y="86"/>
+      <circ-port height="8" pin="30,40" width="8" x="176" y="56"/>
+      <circ-port height="8" pin="140,180" width="8" x="156" y="126"/>
+      <circ-port height="8" pin="140,240" width="8" x="156" y="106"/>
+      <circ-port height="8" pin="140,300" width="8" x="156" y="146"/>
+      <circ-port height="10" pin="210,120" width="10" x="195" y="85"/>
+      <circ-port height="10" pin="210,180" width="10" x="195" y="125"/>
+      <circ-port height="10" pin="210,240" width="10" x="195" y="105"/>
+      <circ-port height="10" pin="210,300" width="10" x="195" y="145"/>
+      <circ-port height="8" pin="500,150" width="8" x="156" y="446"/>
+      <circ-port height="10" pin="570,150" width="10" x="195" y="445"/>
+      <circ-port height="8" pin="500,360" width="8" x="156" y="506"/>
+      <circ-port height="10" pin="570,360" width="10" x="195" y="505"/>
+      <circ-port height="8" pin="500,250" width="8" x="156" y="796"/>
+      <circ-port height="10" pin="570,250" width="10" x="195" y="795"/>
+      <circ-port height="8" pin="140,420" width="8" x="156" y="616"/>
+      <circ-port height="10" pin="210,420" width="10" x="195" y="615"/>
+      <circ-port height="8" pin="140,360" width="8" x="156" y="346"/>
+      <circ-port height="10" pin="210,360" width="10" x="195" y="345"/>
+      <circ-port height="8" pin="70,40" width="8" x="186" y="1016"/>
+      <circ-port height="8" pin="150,580" width="8" x="166" y="1016"/>
+      <circ-port height="8" pin="500,470" width="8" x="156" y="936"/>
+      <circ-port height="10" pin="570,470" width="10" x="195" y="935"/>
+      <circ-anchor facing="east" height="6" width="6" x="157" y="57"/>
+    </appear>
+    <wire from="(180,260)" to="(180,270)"/>
+    <wire from="(180,140)" to="(180,150)"/>
+    <wire from="(180,380)" to="(180,390)"/>
+    <wire from="(530,170)" to="(530,200)"/>
+    <wire from="(530,490)" to="(530,520)"/>
+    <wire from="(540,380)" to="(540,410)"/>
+    <wire from="(150,570)" to="(510,570)"/>
+    <wire from="(30,70)" to="(320,70)"/>
+    <wire from="(270,60)" to="(270,150)"/>
+    <wire from="(320,310)" to="(320,410)"/>
+    <wire from="(180,270)" to="(270,270)"/>
+    <wire from="(180,150)" to="(270,150)"/>
+    <wire from="(180,390)" to="(270,390)"/>
+    <wire from="(690,200)" to="(690,310)"/>
+    <wire from="(510,260)" to="(510,370)"/>
+    <wire from="(320,310)" to="(530,310)"/>
+    <wire from="(500,250)" to="(520,250)"/>
+    <wire from="(190,180)" to="(210,180)"/>
+    <wire from="(190,420)" to="(210,420)"/>
+    <wire from="(190,300)" to="(210,300)"/>
+    <wire from="(150,190)" to="(160,190)"/>
+    <wire from="(150,430)" to="(160,430)"/>
+    <wire from="(150,310)" to="(160,310)"/>
+    <wire from="(270,390)" to="(270,450)"/>
+    <wire from="(270,270)" to="(270,330)"/>
+    <wire from="(270,150)" to="(270,210)"/>
+    <wire from="(30,390)" to="(30,450)"/>
+    <wire from="(30,270)" to="(30,330)"/>
+    <wire from="(30,150)" to="(30,210)"/>
+    <wire from="(150,310)" to="(150,370)"/>
+    <wire from="(150,190)" to="(150,250)"/>
+    <wire from="(320,70)" to="(320,200)"/>
+    <wire from="(170,380)" to="(170,390)"/>
+    <wire from="(170,260)" to="(170,270)"/>
+    <wire from="(170,140)" to="(170,150)"/>
+    <wire from="(30,70)" to="(30,150)"/>
+    <wire from="(70,40)" to="(70,60)"/>
+    <wire from="(530,380)" to="(530,410)"/>
+    <wire from="(30,40)" to="(30,70)"/>
+    <wire from="(540,270)" to="(540,310)"/>
+    <wire from="(540,310)" to="(690,310)"/>
+    <wire from="(690,410)" to="(690,520)"/>
+    <wire from="(550,150)" to="(570,150)"/>
+    <wire from="(550,470)" to="(570,470)"/>
+    <wire from="(320,200)" to="(320,310)"/>
+    <wire from="(320,200)" to="(530,200)"/>
+    <wire from="(320,520)" to="(530,520)"/>
+    <wire from="(140,300)" to="(160,300)"/>
+    <wire from="(140,180)" to="(160,180)"/>
+    <wire from="(140,420)" to="(160,420)"/>
+    <wire from="(510,160)" to="(520,160)"/>
+    <wire from="(510,480)" to="(520,480)"/>
+    <wire from="(30,330)" to="(170,330)"/>
+    <wire from="(30,210)" to="(170,210)"/>
+    <wire from="(30,450)" to="(170,450)"/>
+    <wire from="(180,200)" to="(180,210)"/>
+    <wire from="(180,440)" to="(180,450)"/>
+    <wire from="(180,320)" to="(180,330)"/>
+    <wire from="(150,570)" to="(150,580)"/>
+    <wire from="(150,430)" to="(150,570)"/>
+    <wire from="(270,60)" to="(690,60)"/>
+    <wire from="(510,480)" to="(510,570)"/>
+    <wire from="(530,270)" to="(530,310)"/>
+    <wire from="(540,200)" to="(690,200)"/>
+    <wire from="(540,520)" to="(690,520)"/>
+    <wire from="(510,160)" to="(510,260)"/>
+    <wire from="(180,210)" to="(270,210)"/>
+    <wire from="(180,450)" to="(270,450)"/>
+    <wire from="(180,330)" to="(270,330)"/>
+    <wire from="(550,360)" to="(570,360)"/>
+    <wire from="(320,410)" to="(320,520)"/>
+    <wire from="(320,410)" to="(530,410)"/>
+    <wire from="(500,150)" to="(520,150)"/>
+    <wire from="(500,470)" to="(520,470)"/>
+    <wire from="(190,120)" to="(210,120)"/>
+    <wire from="(190,360)" to="(210,360)"/>
+    <wire from="(190,240)" to="(210,240)"/>
+    <wire from="(510,370)" to="(520,370)"/>
+    <wire from="(150,130)" to="(160,130)"/>
+    <wire from="(150,370)" to="(160,370)"/>
+    <wire from="(150,250)" to="(160,250)"/>
+    <wire from="(270,330)" to="(270,390)"/>
+    <wire from="(270,210)" to="(270,270)"/>
+    <wire from="(30,330)" to="(30,390)"/>
+    <wire from="(30,210)" to="(30,270)"/>
+    <wire from="(150,370)" to="(150,430)"/>
+    <wire from="(150,250)" to="(150,310)"/>
+    <wire from="(150,130)" to="(150,190)"/>
+    <wire from="(690,60)" to="(690,200)"/>
+    <wire from="(170,320)" to="(170,330)"/>
+    <wire from="(170,200)" to="(170,210)"/>
+    <wire from="(170,440)" to="(170,450)"/>
+    <wire from="(540,170)" to="(540,200)"/>
+    <wire from="(540,490)" to="(540,520)"/>
+    <wire from="(540,410)" to="(690,410)"/>
+    <wire from="(550,250)" to="(570,250)"/>
+    <wire from="(510,370)" to="(510,480)"/>
+    <wire from="(500,360)" to="(520,360)"/>
+    <wire from="(140,240)" to="(160,240)"/>
+    <wire from="(140,120)" to="(160,120)"/>
+    <wire from="(690,310)" to="(690,410)"/>
+    <wire from="(140,360)" to="(160,360)"/>
+    <wire from="(510,260)" to="(520,260)"/>
+    <wire from="(30,270)" to="(170,270)"/>
+    <wire from="(30,390)" to="(170,390)"/>
+    <wire from="(30,150)" to="(170,150)"/>
+    <wire from="(70,60)" to="(270,60)"/>
+    <comp lib="0" loc="(570,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,360)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="4" loc="(190,360)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(210,420)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#WB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(550,360)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(140,240)" name="Pin">
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(500,150)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultMEM"/>
+    </comp>
+    <comp lib="0" loc="(210,300)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsExceptionWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(190,300)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(550,250)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(150,580)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="En"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(140,180)" name="Pin">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(500,250)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataMEM"/>
+    </comp>
+    <comp lib="0" loc="(140,120)" name="Pin">
+      <a name="label" val="IsJALMEM"/>
+    </comp>
+    <comp lib="0" loc="(210,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsJALWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(140,420)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="0" loc="(570,470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,470)" name="Pin">
+      <a name="width" val="32"/>
+      <a name="label" val="JumpAddrMEM"/>
+    </comp>
+    <comp lib="0" loc="(70,40)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(570,250)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ReadDataWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(550,470)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(210,180)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MemtoRegWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(190,240)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="4" loc="(550,150)" name="Register">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(140,360)" name="Pin">
+      <a name="label" val="IsSyscallMEM"/>
+    </comp>
+    <comp lib="0" loc="(210,360)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IsSyscallWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(210,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="RegWriteWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(190,420)" name="Register">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(140,300)" name="Pin">
+      <a name="label" val="IsExceptionMEM"/>
+    </comp>
+    <comp lib="4" loc="(190,180)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+    <comp lib="0" loc="(570,150)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="ALUResultWB"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(30,40)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(190,120)" name="Register">
+      <a name="width" val="1"/>
+    </comp>
+  </circuit>
+</project>

--- a/src/pipeline_cpu.circ
+++ b/src/pipeline_cpu.circ
@@ -102,6 +102,7 @@
   <lib desc="file#common/immediate_extender.circ" name="11"/>
   <lib desc="file#common/regfile.circ" name="12"/>
   <lib desc="file#common/cp0.circ" name="13"/>
+  <lib desc="file#common/pipeline.circ" name="14"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -591,19 +592,84 @@
     <wire from="(730,560)" to="(740,560)"/>
     <wire from="(550,220)" to="(560,220)"/>
     <wire from="(490,1280)" to="(500,1280)"/>
-    <comp lib="1" loc="(380,670)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1520,350)" name="Tunnel">
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="1" loc="(290,690)" name="AND Gate">
+    <comp lib="0" loc="(520,420)" name="Tunnel">
       <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(2360,570)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(1656,674)" name="Text">
+      <a name="text" val="WriteDataEX"/>
+    </comp>
+    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(1340,500)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1710,340)" name="XOR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="2" loc="(720,560)" name="Multiplexer">
+    <comp lib="0" loc="(1040,1060)" name="Tunnel">
+      <a name="label" val="ExpBlock"/>
+    </comp>
+    <comp lib="6" loc="(2010,695)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
+    </comp>
+    <comp lib="5" loc="(590,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(890,1030)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(1950,770)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(540,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(760,130)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(2010,1050)" name="Tunnel">
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="0" loc="(2220,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(1800,1120)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="9" loc="(680,360)" name="statistics"/>
+    <comp lib="6" loc="(1315,765)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="0" loc="(1320,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RsOutput"/>
+    </comp>
+    <comp lib="2" loc="(210,530)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
@@ -612,92 +678,64 @@
       <a name="width" val="32"/>
       <a name="value" val="0x800"/>
     </comp>
-    <comp lib="0" loc="(920,520)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="3" loc="(1530,1160)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="5" loc="(600,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(890,1030)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1190,630)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1040,1060)" name="Tunnel">
-      <a name="label" val="ExpBlock"/>
-    </comp>
-    <comp lib="0" loc="(950,450)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="0" loc="(480,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1280,150)" name="Tunnel">
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="6" loc="(859,501)" name="Text">
-      <a name="text" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(2010,750)" name="Tunnel">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="8" loc="(890,150)" name="Control"/>
-    <comp lib="4" loc="(540,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(250,1300)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(1090,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="0" loc="(980,720)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="0" loc="(970,820)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(950,470)" name="Tunnel">
       <a name="label" val="ZeroExtendID"/>
     </comp>
-    <comp lib="6" loc="(862,240)" name="Text">
-      <a name="text" val="OP"/>
+    <comp lib="0" loc="(550,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc0"/>
     </comp>
-    <comp lib="0" loc="(1140,480)" name="Tunnel">
+    <comp lib="2" loc="(1960,1070)" name="Multiplexer">
       <a name="facing" val="south"/>
+      <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
-      <a name="label" val="v0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1670,1110)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
+    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="1" loc="(390,1290)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(680,1290)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Load/Use"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="6" loc="(1317,872)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="0" loc="(1200,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="5" loc="(650,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
     </comp>
     <comp lib="6" loc="(1167,1164)" name="Text">
       <a name="text" val="Jump Addr"/>
     </comp>
-    <comp lib="6" loc="(2439,1205)" name="Text">
-      <a name="text" val="WB_DATA"/>
+    <comp lib="0" loc="(1050,950)" name="Tunnel">
+      <a name="label" val="IsCOP0"/>
     </comp>
-    <comp lib="1" loc="(750,1290)" name="NOT Gate">
+    <comp lib="1" loc="(290,690)" name="AND Gate">
       <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(970,1110)" name="Tunnel">
+    <comp loc="(360,1330)" name="Hazard Unit"/>
+    <comp lib="0" loc="(510,1300)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="ExRegWrite"/>
-    </comp>
-    <comp lib="4" loc="(450,560)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(1940,590)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -736,362 +774,27 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(580,860)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(600,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(1560,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="1" loc="(1180,490)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="12" loc="(1120,490)" name="Regfile"/>
-    <comp lib="6" loc="(1437,1244)" name="Text">
-      <a name="text" val="ALU Result"/>
-    </comp>
-    <comp lib="0" loc="(350,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1670,1130)" name="Tunnel">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(280,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="4" loc="(530,1270)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="4" loc="(2100,590)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp lib="0" loc="(2030,630)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1070,770)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="1"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="1"/>
-      <a name="bit9" val="1"/>
-      <a name="bit10" val="1"/>
-      <a name="bit11" val="1"/>
-      <a name="bit12" val="1"/>
-      <a name="bit13" val="1"/>
-      <a name="bit14" val="1"/>
-      <a name="bit15" val="1"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="2"/>
-      <a name="bit29" val="2"/>
-      <a name="bit30" val="2"/>
-      <a name="bit31" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1500,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1175,1145)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp lib="0" loc="(520,420)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1050,950)" name="Tunnel">
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="0" loc="(220,1270)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(360,560)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1700,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="6" loc="(1656,674)" name="Text">
-      <a name="text" val="WriteDataEX"/>
-    </comp>
-    <comp lib="0" loc="(1490,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="4" loc="(670,650)" name="ROM">
-      <a name="addrWidth" val="9"/>
-      <a name="dataWidth" val="32"/>
-      <a name="contents">addr/data: 9 32
-201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
-401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
-23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
-23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
-1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
-20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
-23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
-8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
-23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
-8fda0000 409a0000 201a0000 409a0800 42000018
-</a>
-    </comp>
-    <comp lib="0" loc="(1480,1170)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(1880,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(230,1330)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(2220,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="0" loc="(840,330)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(1165,1186)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="3" loc="(640,850)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp loc="(360,1330)" name="Hazard Unit"/>
-    <comp lib="0" loc="(1110,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="0" loc="(2010,1050)" name="Tunnel">
-      <a name="label" val="IsCOP0MEM"/>
-    </comp>
-    <comp loc="(1770,150)" name="EX/MEM"/>
-    <comp lib="6" loc="(1347,1084)" name="Text">
-      <a name="text" val="IsEret"/>
-    </comp>
-    <comp lib="2" loc="(260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="7" loc="(1670,590)" name="ALU"/>
-    <comp lib="11" loc="(950,830)" name="Immediate Extender"/>
-    <comp lib="0" loc="(840,700)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp loc="(1370,140)" name="ID/EX"/>
     <comp lib="0" loc="(1220,1290)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="width" val="2"/>
       <a name="label" val="RsOutput"/>
     </comp>
-    <comp lib="1" loc="(1710,340)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="6" loc="(1443,1265)" name="Text">
+      <a name="text" val="Memory Result"/>
     </comp>
-    <comp lib="0" loc="(490,1280)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="BranchSuccess"/>
+    <comp lib="4" loc="(530,1270)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
-    <comp lib="0" loc="(550,770)" name="Tunnel">
+    <comp lib="0" loc="(970,1110)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc0"/>
+      <a name="label" val="ExRegWrite"/>
     </comp>
-    <comp lib="6" loc="(860,688)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="0" loc="(1690,1040)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="9" loc="(680,360)" name="statistics"/>
-    <comp lib="0" loc="(1870,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(2170,1110)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="2" loc="(1080,700)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1320,640)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-    </comp>
-    <comp lib="2" loc="(1600,630)" name="Multiplexer">
+    <comp lib="10" loc="(2230,460)" name="syscall_decoder"/>
+    <comp lib="2" loc="(260,540)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(980,920)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ExpSrc1"/>
-    </comp>
-    <comp lib="0" loc="(760,130)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1380,1130)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1200,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RtOutput"/>
-    </comp>
-    <comp lib="1" loc="(440,700)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="1" loc="(1740,280)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2290,510)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(840,770)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
     </comp>
     <comp lib="0" loc="(730,560)" name="Splitter">
       <a name="facing" val="north"/>
@@ -1131,24 +834,467 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
+    <comp lib="0" loc="(570,280)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+      <a name="bit11" val="2"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+      <a name="bit14" val="3"/>
+      <a name="bit15" val="3"/>
+      <a name="bit16" val="4"/>
+      <a name="bit17" val="4"/>
+      <a name="bit18" val="4"/>
+      <a name="bit19" val="4"/>
+      <a name="bit20" val="5"/>
+      <a name="bit21" val="5"/>
+      <a name="bit22" val="5"/>
+      <a name="bit23" val="5"/>
+      <a name="bit24" val="6"/>
+      <a name="bit25" val="6"/>
+      <a name="bit26" val="6"/>
+      <a name="bit27" val="6"/>
+      <a name="bit28" val="7"/>
+      <a name="bit29" val="7"/>
+      <a name="bit30" val="7"/>
+      <a name="bit31" val="7"/>
+    </comp>
+    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="1" loc="(440,700)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(220,1280)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
     <comp lib="2" loc="(1000,690)" name="Multiplexer">
       <a name="width" val="5"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(390,1290)" name="NOT Gate">
+    <comp lib="0" loc="(1140,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(840,770)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1630,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="14" loc="(1370,140)" name="ID/EX"/>
+    <comp lib="3" loc="(1590,1150)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(490,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="0" loc="(620,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="6" loc="(584,110)" name="Text">
+      <a name="text" val="Screen"/>
+    </comp>
+    <comp lib="6" loc="(860,688)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(970,820)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="0" loc="(1560,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(1090,500)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rs"/>
+    </comp>
+    <comp lib="0" loc="(920,520)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(950,450)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="0" loc="(2220,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="0" loc="(1490,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="2" loc="(480,560)" name="Demultiplexer">
+      <a name="width" val="9"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1110,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="0" loc="(340,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="0" loc="(330,660)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="5" loc="(600,760)" name="Button">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="6" loc="(859,501)" name="Text">
+      <a name="text" val="RS"/>
+    </comp>
+    <comp lib="0" loc="(550,1270)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1780,1120)" name="Constant">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(700,370)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
+    <comp lib="0" loc="(930,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(220,1270)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1520,350)" name="Tunnel">
+      <a name="label" val="JumpEX"/>
+    </comp>
+    <comp lib="0" loc="(460,710)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1030,760)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(550,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1760,60)" name="Tunnel">
+      <a name="label" val="BranchSuccess"/>
+    </comp>
+    <comp lib="0" loc="(2100,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0MEM"/>
+    </comp>
+    <comp lib="0" loc="(1480,1170)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(920,1070)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="HasExp"/>
+    </comp>
+    <comp lib="6" loc="(2439,1205)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="0" loc="(580,860)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(1040,920)" name="Tunnel">
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="3" loc="(1530,1160)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(230,1330)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="3" loc="(640,850)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="6" loc="(1347,1084)" name="Text">
+      <a name="text" val="IsEret"/>
+    </comp>
+    <comp lib="7" loc="(1670,590)" name="ALU"/>
+    <comp lib="6" loc="(1214,627)" name="Text">
+      <a name="text" val="Shamt"/>
+    </comp>
+    <comp lib="0" loc="(1670,1110)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
+    </comp>
+    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2190,1110)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(430,650)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1160,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(840,630)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="14" loc="(2160,140)" name="MEM/WB"/>
+    <comp lib="4" loc="(2100,590)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="13" loc="(980,990)" name="CP0"/>
+    <comp lib="6" loc="(857,539)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(1670,1130)" name="Tunnel">
+      <a name="label" val="IsJALEX"/>
+    </comp>
+    <comp lib="12" loc="(1120,490)" name="Regfile"/>
+    <comp lib="2" loc="(2410,580)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="8" loc="(890,150)" name="Control"/>
+    <comp lib="0" loc="(980,920)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ExpSrc1"/>
+    </comp>
+    <comp lib="2" loc="(160,520)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1980,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(1070,770)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="1"/>
       <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+      <a name="bit11" val="1"/>
+      <a name="bit12" val="1"/>
+      <a name="bit13" val="1"/>
+      <a name="bit14" val="1"/>
+      <a name="bit15" val="1"/>
+      <a name="bit16" val="1"/>
+      <a name="bit17" val="1"/>
+      <a name="bit18" val="1"/>
+      <a name="bit19" val="1"/>
+      <a name="bit20" val="1"/>
+      <a name="bit21" val="1"/>
+      <a name="bit22" val="1"/>
+      <a name="bit23" val="1"/>
+      <a name="bit24" val="1"/>
+      <a name="bit25" val="1"/>
+      <a name="bit26" val="1"/>
+      <a name="bit27" val="1"/>
+      <a name="bit28" val="2"/>
+      <a name="bit29" val="2"/>
+      <a name="bit30" val="2"/>
+      <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1120,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsCOP0"/>
+    </comp>
+    <comp lib="0" loc="(350,1350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(840,250)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="2" loc="(2460,590)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(830,880)" name="Splitter">
       <a name="facing" val="north"/>
@@ -1188,10 +1334,6 @@
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(2250,460)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
     <comp lib="0" loc="(840,850)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -1228,14 +1370,90 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(2190,1110)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(1720,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
     </comp>
-    <comp lib="2" loc="(2460,590)" name="Multiplexer">
+    <comp lib="2" loc="(1600,630)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1190,630)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1090,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rs"/>
+    </comp>
+    <comp lib="0" loc="(650,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ExpSrc2"/>
+    </comp>
+    <comp lib="6" loc="(1579,1326)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="1" loc="(1740,280)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2290,510)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(2010,750)" name="Tunnel">
+      <a name="label" val="MemtoRegMEM"/>
+    </comp>
+    <comp lib="0" loc="(980,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="4" loc="(610,310)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="1" loc="(1640,1190)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+    </comp>
+    <comp lib="4" loc="(390,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
+    </comp>
+    <comp lib="6" loc="(1437,1244)" name="Text">
+      <a name="text" val="ALU Result"/>
+    </comp>
+    <comp lib="2" loc="(1340,590)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1320,640)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="RtOutput"/>
+    </comp>
+    <comp lib="0" loc="(400,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="2" loc="(1530,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1880,160)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(1640,1090)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="BranchSuccess"/>
     </comp>
     <comp lib="0" loc="(840,550)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1274,537 +1492,32 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="2" loc="(160,520)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="0" loc="(1280,150)" name="Tunnel">
+      <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="4" loc="(670,650)" name="ROM">
+      <a name="addrWidth" val="9"/>
+      <a name="dataWidth" val="32"/>
+      <a name="contents">addr/data: 9 32
+201a0001 409a0800 201c0400 39df020 401a0000 afda0000 23de0004 23bd0004
+401b1000 401a1800 409a1000 afd00000 23bd0004 23de0004 afd40000 23bd0004
+23de0004 afd50000 23bd0004 23de0004 afd60000 23bd0004 23de0004 afc40000
+23bd0004 23de0004 afc20000 23bd0004 23de0004 afdb0000 23bd0004 23de0004
+1ab020 22d60001 201a0000 409a0800 20140005 20150001 168020 102020
+20020022 c 108100 1600fffb 295a022 1680fff8 201a0001 409a0800
+23defffc 23bdfffc 8fdb0000 23defffc 23bdfffc 8fc20000 23defffc 23bdfffc
+8fc40000 23defffc 23bdfffc 8fd60000 23defffc 23bdfffc 8fd50000 23defffc
+23bdfffc 8fd40000 23defffc 23bdfffc 8fd00000 409b1000 23defffc 23bdfffc
+8fda0000 409a0000 201a0000 409a0800 42000018
+</a>
+    </comp>
+    <comp lib="4" loc="(450,560)" name="Register">
       <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1090,500)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rs"/>
-    </comp>
-    <comp lib="2" loc="(2360,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(210,530)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1720,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(610,310)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(1980,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(1630,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="0" loc="(1160,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="3" loc="(1590,1150)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(1443,1265)" name="Text">
-      <a name="text" val="Memory Result"/>
+      <a name="label" val="PC"/>
     </comp>
     <comp lib="0" loc="(930,920)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ExpSrc0"/>
-    </comp>
-    <comp lib="0" loc="(1570,1060)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsEretEX"/>
-    </comp>
-    <comp lib="0" loc="(460,560)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="10" loc="(2230,460)" name="syscall_decoder"/>
-    <comp lib="0" loc="(920,540)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(650,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="0" loc="(840,510)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(310,550)" name="Multiplexer">
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(340,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="IsCOP0EX"/>
-    </comp>
-    <comp lib="13" loc="(980,990)" name="CP0"/>
-    <comp lib="0" loc="(680,1290)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Load/Use"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp loc="(740,140)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
-    </comp>
-    <comp lib="0" loc="(1610,1110)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="JumpEX"/>
-    </comp>
-    <comp lib="0" loc="(1040,920)" name="Tunnel">
-      <a name="label" val="ExpSrc2"/>
-    </comp>
-    <comp lib="5" loc="(590,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(460,710)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="2" loc="(430,650)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(1290,180)" name="RegWrite_Decider"/>
-    <comp lib="2" loc="(480,560)" name="Demultiplexer">
-      <a name="width" val="9"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1314,841)" name="Text">
-      <a name="text" val="Immediate"/>
-    </comp>
-    <comp lib="5" loc="(470,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(430,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(570,280)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-      <a name="bit16" val="4"/>
-      <a name="bit17" val="4"/>
-      <a name="bit18" val="4"/>
-      <a name="bit19" val="4"/>
-      <a name="bit20" val="5"/>
-      <a name="bit21" val="5"/>
-      <a name="bit22" val="5"/>
-      <a name="bit23" val="5"/>
-      <a name="bit24" val="6"/>
-      <a name="bit25" val="6"/>
-      <a name="bit26" val="6"/>
-      <a name="bit27" val="6"/>
-      <a name="bit28" val="7"/>
-      <a name="bit29" val="7"/>
-      <a name="bit30" val="7"/>
-      <a name="bit31" val="7"/>
-    </comp>
-    <comp lib="0" loc="(2100,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0MEM"/>
-    </comp>
-    <comp lib="0" loc="(840,250)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1030,710)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="5" loc="(550,760)" name="Button">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1030,760)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1120,160)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="IsCOP0"/>
-    </comp>
-    <comp lib="5" loc="(550,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(670,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1110,540)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="Rt"/>
-    </comp>
-    <comp lib="5" loc="(710,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(420,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(550,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1640,1090)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="0" loc="(510,1300)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="5" loc="(510,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(1520,290)" name="Tunnel">
-      <a name="label" val="IsJREX"/>
-    </comp>
-    <comp lib="6" loc="(584,110)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp loc="(2160,140)" name="MEM/WB"/>
-    <comp lib="0" loc="(1760,60)" name="Tunnel">
-      <a name="label" val="BranchSuccess"/>
-    </comp>
-    <comp lib="2" loc="(1340,500)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(857,539)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="6" loc="(2010,695)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="6" loc="(2166,1226)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="2" loc="(2410,580)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1800,1120)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(950,470)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="0" loc="(840,630)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="4" loc="(390,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="6" loc="(1214,627)" name="Text">
-      <a name="text" val="Shamt"/>
-    </comp>
-    <comp lib="2" loc="(1950,770)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1640,1190)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="6" loc="(1579,1326)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="0" loc="(1320,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="RsOutput"/>
-    </comp>
-    <comp lib="0" loc="(400,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="6" loc="(1316,692)" name="Text">
-      <a name="text" val="WriteReg#"/>
-    </comp>
-    <comp lib="2" loc="(1730,1060)" name="Multiplexer">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(1530,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(1340,590)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(470,340)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(210,1330)" name="Clock">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="6" loc="(863,316)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="0" loc="(870,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(620,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(550,1270)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(930,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="2" loc="(220,1280)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1315,765)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(1490,1310)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="MemReadEX"/>
     </comp>
     <comp lib="4" loc="(670,550)" name="ROM">
       <a name="addrWidth" val="9"/>
@@ -1854,1371 +1567,322 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="0" loc="(920,1070)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
+    <comp lib="0" loc="(1870,1310)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
     </comp>
-    <comp lib="0" loc="(330,660)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="HasExp"/>
+    <comp lib="0" loc="(870,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRs"/>
     </comp>
-    <comp lib="5" loc="(650,760)" name="Button">
+    <comp loc="(1290,180)" name="RegWrite_Decider"/>
+    <comp lib="0" loc="(210,1330)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1520,290)" name="Tunnel">
+      <a name="label" val="IsJREX"/>
+    </comp>
+    <comp lib="0" loc="(280,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp lib="6" loc="(863,316)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
+    <comp lib="0" loc="(700,370)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(840,330)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(2030,630)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="5" loc="(550,760)" name="Button">
       <a name="facing" val="south"/>
     </comp>
-    <comp lib="6" loc="(1317,872)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="2" loc="(1960,1070)" name="Multiplexer">
+    <comp lib="0" loc="(1490,1310)" name="Tunnel">
       <a name="facing" val="south"/>
+      <a name="label" val="MemReadEX"/>
+    </comp>
+    <comp lib="2" loc="(1500,550)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1780,1120)" name="Constant">
+    <comp lib="6" loc="(1316,692)" name="Text">
+      <a name="text" val="WriteReg#"/>
+    </comp>
+    <comp lib="1" loc="(380,670)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(480,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(920,540)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(1110,540)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="Rt"/>
+    </comp>
+    <comp lib="6" loc="(862,240)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp lib="0" loc="(1610,1110)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="JumpEX"/>
+    </comp>
+    <comp lib="0" loc="(1570,1060)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="IsEretEX"/>
+    </comp>
+    <comp lib="0" loc="(2250,460)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(840,510)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="14" loc="(1770,150)" name="EX/MEM"/>
+    <comp lib="0" loc="(1380,1130)" name="Constant">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(2220,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
+    <comp lib="0" loc="(1030,710)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="14" loc="(740,140)" name="IF/ID"/>
+    <comp lib="1" loc="(750,1290)" name="NOT Gate">
+      <a name="facing" val="north"/>
     </comp>
     <comp lib="6" loc="(682,877)" name="Text">
       <a name="text" val="PCPlus4IF"/>
     </comp>
-  </circuit>
-  <circuit name="IF/ID">
-    <a name="circuit" val="IF/ID"/>
-    <a name="clabel" val="IF/ID"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#83f9ff" height="963" stroke="none" width="43" x="220" y="0"/>
-      <circ-port height="8" pin="310,370" width="8" x="216" y="416"/>
-      <circ-port height="10" pin="410,370" width="10" x="255" y="415"/>
-      <circ-port height="8" pin="160,350" width="8" x="236" y="-4"/>
-      <circ-port height="8" pin="340,590" width="8" x="226" y="956"/>
-      <circ-port height="8" pin="570,350" width="8" x="246" y="956"/>
-      <circ-port height="8" pin="310,470" width="8" x="216" y="736"/>
-      <circ-port height="10" pin="410,470" width="10" x="255" y="735"/>
-      <circ-anchor facing="east" height="6" width="6" x="217" y="-3"/>
-    </appear>
-    <wire from="(340,380)" to="(340,480)"/>
-    <wire from="(160,350)" to="(160,420)"/>
-    <wire from="(160,420)" to="(160,520)"/>
-    <wire from="(380,370)" to="(410,370)"/>
-    <wire from="(380,470)" to="(410,470)"/>
-    <wire from="(340,480)" to="(340,590)"/>
-    <wire from="(570,420)" to="(570,520)"/>
-    <wire from="(570,350)" to="(570,420)"/>
-    <wire from="(340,380)" to="(350,380)"/>
-    <wire from="(340,480)" to="(350,480)"/>
-    <wire from="(160,420)" to="(360,420)"/>
-    <wire from="(160,520)" to="(360,520)"/>
-    <wire from="(360,390)" to="(360,420)"/>
-    <wire from="(360,490)" to="(360,520)"/>
-    <wire from="(370,490)" to="(370,520)"/>
-    <wire from="(370,390)" to="(370,420)"/>
-    <wire from="(310,370)" to="(350,370)"/>
-    <wire from="(310,470)" to="(350,470)"/>
-    <wire from="(370,520)" to="(570,520)"/>
-    <wire from="(370,420)" to="(570,420)"/>
-    <comp lib="0" loc="(340,590)" name="Pin">
+    <comp lib="5" loc="(710,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="5" loc="(630,180)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(1080,700)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(2166,1226)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="0" loc="(250,1300)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="2" loc="(360,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(460,560)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="6" loc="(1175,1145)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="4" loc="(470,340)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(2170,1110)" name="Constant">
       <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(410,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="2" loc="(310,550)" name="Multiplexer">
       <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4IF"/>
-      <a name="labelloc" val="east"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="4" loc="(380,370)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(410,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="InstID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(160,350)" name="Pin">
+    <comp lib="1" loc="(1180,490)" name="NOT Gate">
       <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
+    </comp>
+    <comp lib="0" loc="(840,700)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="11" loc="(950,830)" name="Immediate Extender"/>
+    <comp lib="6" loc="(1165,1186)" name="Text">
+      <a name="text" val="Branch Addr"/>
+    </comp>
+    <comp lib="6" loc="(1314,841)" name="Text">
+      <a name="text" val="Immediate"/>
+    </comp>
+    <comp lib="2" loc="(720,560)" name="Multiplexer">
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1690,1040)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="IsCOP0EX"/>
+    </comp>
+    <comp lib="0" loc="(420,760)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(310,370)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="InstIF"/>
-    </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(310,470)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-  </circuit>
-  <circuit name="ID/EX">
-    <a name="circuit" val="ID/EX"/>
-    <a name="clabel" val="ID/EX"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#ffe05d" height="980" stroke="none" width="42" x="110" y="31"/>
-      <circ-port height="8" pin="60,290" width="8" x="126" y="26"/>
-      <circ-port height="8" pin="860,360" width="8" x="106" y="56"/>
-      <circ-port height="8" pin="860,780" width="8" x="106" y="156"/>
-      <circ-port height="8" pin="860,420" width="8" x="106" y="296"/>
-      <circ-port height="8" pin="1180,350" width="8" x="106" y="136"/>
-      <circ-port height="8" pin="860,480" width="8" x="106" y="96"/>
-      <circ-port height="8" pin="1180,410" width="8" x="106" y="236"/>
-      <circ-port height="8" pin="860,540" width="8" x="106" y="76"/>
-      <circ-port height="8" pin="1180,470" width="8" x="106" y="196"/>
-      <circ-port height="8" pin="860,600" width="8" x="106" y="216"/>
-      <circ-port height="8" pin="860,660" width="8" x="106" y="276"/>
-      <circ-port height="8" pin="1180,530" width="8" x="106" y="176"/>
-      <circ-port height="8" pin="860,720" width="8" x="106" y="116"/>
-      <circ-port height="10" pin="920,360" width="10" x="145" y="55"/>
-      <circ-port height="10" pin="930,780" width="10" x="145" y="155"/>
-      <circ-port height="10" pin="930,420" width="10" x="145" y="295"/>
-      <circ-port height="10" pin="1250,350" width="10" x="145" y="135"/>
-      <circ-port height="10" pin="930,480" width="10" x="145" y="95"/>
-      <circ-port height="10" pin="1250,410" width="10" x="145" y="235"/>
-      <circ-port height="10" pin="930,540" width="10" x="145" y="75"/>
-      <circ-port height="10" pin="1250,470" width="10" x="145" y="195"/>
-      <circ-port height="10" pin="930,600" width="10" x="145" y="215"/>
-      <circ-port height="10" pin="930,660" width="10" x="145" y="275"/>
-      <circ-port height="10" pin="1250,530" width="10" x="145" y="175"/>
-      <circ-port height="10" pin="930,720" width="10" x="145" y="115"/>
-      <circ-port height="8" pin="1180,650" width="8" x="106" y="256"/>
-      <circ-port height="10" pin="1240,650" width="10" x="145" y="255"/>
-      <circ-port height="8" pin="1180,710" width="8" x="106" y="586"/>
-      <circ-port height="10" pin="1240,710" width="10" x="145" y="585"/>
-      <circ-port height="8" pin="170,360" width="8" x="106" y="736"/>
-      <circ-port height="10" pin="240,360" width="10" x="145" y="735"/>
-      <circ-port height="8" pin="170,460" width="8" x="106" y="426"/>
-      <circ-port height="10" pin="240,460" width="10" x="145" y="425"/>
-      <circ-port height="8" pin="170,560" width="8" x="106" y="446"/>
-      <circ-port height="10" pin="240,560" width="10" x="145" y="445"/>
-      <circ-port height="8" pin="520,560" width="8" x="106" y="766"/>
-      <circ-port height="10" pin="590,560" width="10" x="145" y="765"/>
-      <circ-port height="8" pin="520,360" width="8" x="106" y="516"/>
-      <circ-port height="10" pin="590,360" width="10" x="145" y="515"/>
-      <circ-port height="8" pin="520,460" width="8" x="106" y="656"/>
-      <circ-port height="10" pin="590,460" width="10" x="145" y="655"/>
-      <circ-port height="8" pin="1180,590" width="8" x="106" y="316"/>
-      <circ-port height="10" pin="1250,590" width="10" x="145" y="315"/>
-      <circ-port height="8" pin="100,290" width="8" x="136" y="1006"/>
-      <circ-port height="8" pin="180,830" width="8" x="116" y="1006"/>
-      <circ-port height="8" pin="170,670" width="8" x="106" y="906"/>
-      <circ-port height="10" pin="240,670" width="10" x="145" y="905"/>
-      <circ-port height="8" pin="1180,780" width="8" x="106" y="976"/>
-      <circ-port height="10" pin="1250,780" width="10" x="145" y="975"/>
-      <circ-anchor facing="east" height="6" width="6" x="107" y="27"/>
-    </appear>
-    <wire from="(900,740)" to="(900,750)"/>
-    <wire from="(900,500)" to="(900,510)"/>
-    <wire from="(180,820)" to="(180,830)"/>
-    <wire from="(1190,790)" to="(1190,820)"/>
-    <wire from="(100,300)" to="(340,300)"/>
-    <wire from="(870,790)" to="(870,820)"/>
-    <wire from="(560,480)" to="(560,510)"/>
-    <wire from="(1210,490)" to="(1210,500)"/>
-    <wire from="(1210,730)" to="(1210,740)"/>
-    <wire from="(760,310)" to="(760,390)"/>
-    <wire from="(210,690)" to="(210,720)"/>
-    <wire from="(910,540)" to="(930,540)"/>
-    <wire from="(910,780)" to="(930,780)"/>
-    <wire from="(1220,680)" to="(1300,680)"/>
-    <wire from="(1220,440)" to="(1300,440)"/>
-    <wire from="(1070,680)" to="(1210,680)"/>
-    <wire from="(570,360)" to="(590,360)"/>
-    <wire from="(1230,710)" to="(1240,710)"/>
-    <wire from="(1070,440)" to="(1210,440)"/>
-    <wire from="(60,410)" to="(60,510)"/>
-    <wire from="(180,370)" to="(180,470)"/>
-    <wire from="(340,610)" to="(340,720)"/>
-    <wire from="(170,360)" to="(190,360)"/>
-    <wire from="(1300,500)" to="(1300,560)"/>
-    <wire from="(870,550)" to="(870,610)"/>
-    <wire from="(870,430)" to="(880,430)"/>
-    <wire from="(870,670)" to="(880,670)"/>
-    <wire from="(1180,410)" to="(1200,410)"/>
-    <wire from="(530,570)" to="(540,570)"/>
-    <wire from="(1180,650)" to="(1200,650)"/>
-    <wire from="(1230,780)" to="(1250,780)"/>
-    <wire from="(890,380)" to="(890,390)"/>
-    <wire from="(890,620)" to="(890,630)"/>
-    <wire from="(1300,740)" to="(1300,810)"/>
-    <wire from="(690,300)" to="(980,300)"/>
-    <wire from="(1220,550)" to="(1220,560)"/>
-    <wire from="(210,580)" to="(210,610)"/>
-    <wire from="(860,540)" to="(880,540)"/>
-    <wire from="(860,780)" to="(880,780)"/>
-    <wire from="(180,820)" to="(530,820)"/>
-    <wire from="(1220,810)" to="(1300,810)"/>
-    <wire from="(520,360)" to="(540,360)"/>
-    <wire from="(1190,480)" to="(1200,480)"/>
-    <wire from="(1190,720)" to="(1200,720)"/>
-    <wire from="(1070,810)" to="(1210,810)"/>
-    <wire from="(1070,560)" to="(1070,620)"/>
-    <wire from="(530,370)" to="(530,470)"/>
-    <wire from="(1190,360)" to="(1190,420)"/>
-    <wire from="(1190,600)" to="(1190,660)"/>
-    <wire from="(220,460)" to="(240,460)"/>
-    <wire from="(980,630)" to="(980,690)"/>
-    <wire from="(980,390)" to="(980,450)"/>
-    <wire from="(760,510)" to="(890,510)"/>
-    <wire from="(760,750)" to="(890,750)"/>
-    <wire from="(760,570)" to="(760,630)"/>
-    <wire from="(910,360)" to="(920,360)"/>
-    <wire from="(900,570)" to="(980,570)"/>
-    <wire from="(1230,350)" to="(1250,350)"/>
-    <wire from="(1230,590)" to="(1250,590)"/>
-    <wire from="(900,810)" to="(980,810)"/>
-    <wire from="(1180,780)" to="(1200,780)"/>
-    <wire from="(900,680)" to="(900,690)"/>
-    <wire from="(900,440)" to="(900,450)"/>
-    <wire from="(870,820)" to="(1190,820)"/>
-    <wire from="(560,580)" to="(560,610)"/>
-    <wire from="(1210,670)" to="(1210,680)"/>
-    <wire from="(1210,430)" to="(1210,440)"/>
-    <wire from="(200,380)" to="(200,410)"/>
-    <wire from="(910,480)" to="(930,480)"/>
-    <wire from="(910,720)" to="(930,720)"/>
-    <wire from="(1220,620)" to="(1300,620)"/>
-    <wire from="(1220,380)" to="(1300,380)"/>
-    <wire from="(1070,380)" to="(1210,380)"/>
-    <wire from="(570,460)" to="(590,460)"/>
-    <wire from="(1230,650)" to="(1240,650)"/>
-    <wire from="(1070,620)" to="(1210,620)"/>
-    <wire from="(60,510)" to="(60,610)"/>
-    <wire from="(180,470)" to="(180,570)"/>
-    <wire from="(1300,680)" to="(1300,740)"/>
-    <wire from="(170,460)" to="(190,460)"/>
-    <wire from="(1300,440)" to="(1300,500)"/>
-    <wire from="(220,670)" to="(240,670)"/>
-    <wire from="(870,490)" to="(870,550)"/>
-    <wire from="(870,730)" to="(870,790)"/>
-    <wire from="(60,410)" to="(200,410)"/>
-    <wire from="(870,370)" to="(880,370)"/>
-    <wire from="(870,610)" to="(880,610)"/>
-    <wire from="(210,410)" to="(340,410)"/>
-    <wire from="(1180,350)" to="(1200,350)"/>
-    <wire from="(1180,590)" to="(1200,590)"/>
-    <wire from="(890,560)" to="(890,570)"/>
-    <wire from="(890,800)" to="(890,810)"/>
-    <wire from="(370,410)" to="(550,410)"/>
-    <wire from="(60,310)" to="(370,310)"/>
-    <wire from="(60,290)" to="(60,310)"/>
-    <wire from="(550,380)" to="(550,410)"/>
-    <wire from="(1220,730)" to="(1220,740)"/>
-    <wire from="(1220,490)" to="(1220,500)"/>
-    <wire from="(1210,800)" to="(1210,810)"/>
-    <wire from="(860,480)" to="(880,480)"/>
-    <wire from="(860,720)" to="(880,720)"/>
-    <wire from="(370,310)" to="(370,410)"/>
-    <wire from="(520,460)" to="(540,460)"/>
-    <wire from="(1190,420)" to="(1200,420)"/>
-    <wire from="(1190,660)" to="(1200,660)"/>
-    <wire from="(1070,500)" to="(1070,560)"/>
-    <wire from="(530,470)" to="(530,570)"/>
-    <wire from="(1190,540)" to="(1190,600)"/>
-    <wire from="(170,670)" to="(190,670)"/>
-    <wire from="(220,560)" to="(240,560)"/>
-    <wire from="(980,570)" to="(980,630)"/>
-    <wire from="(180,370)" to="(190,370)"/>
-    <wire from="(760,450)" to="(890,450)"/>
-    <wire from="(760,690)" to="(890,690)"/>
-    <wire from="(560,410)" to="(690,410)"/>
-    <wire from="(760,510)" to="(760,570)"/>
-    <wire from="(760,750)" to="(760,810)"/>
-    <wire from="(900,510)" to="(980,510)"/>
-    <wire from="(1230,530)" to="(1250,530)"/>
-    <wire from="(900,750)" to="(980,750)"/>
-    <wire from="(900,620)" to="(900,630)"/>
-    <wire from="(900,380)" to="(900,390)"/>
-    <wire from="(180,680)" to="(180,820)"/>
-    <wire from="(1070,740)" to="(1070,810)"/>
-    <wire from="(1210,610)" to="(1210,620)"/>
-    <wire from="(1210,370)" to="(1210,380)"/>
-    <wire from="(200,480)" to="(200,510)"/>
-    <wire from="(910,420)" to="(930,420)"/>
-    <wire from="(340,410)" to="(340,510)"/>
-    <wire from="(910,660)" to="(930,660)"/>
-    <wire from="(1220,560)" to="(1300,560)"/>
-    <wire from="(570,560)" to="(590,560)"/>
-    <wire from="(1070,560)" to="(1210,560)"/>
-    <wire from="(1190,790)" to="(1200,790)"/>
-    <wire from="(180,570)" to="(180,680)"/>
-    <wire from="(170,560)" to="(190,560)"/>
-    <wire from="(1300,620)" to="(1300,680)"/>
-    <wire from="(1300,380)" to="(1300,440)"/>
-    <wire from="(60,610)" to="(60,720)"/>
-    <wire from="(870,430)" to="(870,490)"/>
-    <wire from="(870,670)" to="(870,730)"/>
-    <wire from="(60,510)" to="(200,510)"/>
-    <wire from="(870,550)" to="(880,550)"/>
-    <wire from="(870,790)" to="(880,790)"/>
-    <wire from="(210,510)" to="(340,510)"/>
-    <wire from="(1180,530)" to="(1200,530)"/>
-    <wire from="(530,370)" to="(540,370)"/>
-    <wire from="(760,310)" to="(1070,310)"/>
-    <wire from="(1300,300)" to="(1300,380)"/>
-    <wire from="(890,500)" to="(890,510)"/>
-    <wire from="(890,740)" to="(890,750)"/>
-    <wire from="(370,510)" to="(550,510)"/>
-    <wire from="(980,300)" to="(980,390)"/>
-    <wire from="(550,480)" to="(550,510)"/>
-    <wire from="(1070,310)" to="(1070,380)"/>
-    <wire from="(1220,670)" to="(1220,680)"/>
-    <wire from="(1220,430)" to="(1220,440)"/>
-    <wire from="(210,380)" to="(210,410)"/>
-    <wire from="(200,690)" to="(200,720)"/>
-    <wire from="(860,420)" to="(880,420)"/>
-    <wire from="(370,410)" to="(370,510)"/>
-    <wire from="(860,660)" to="(880,660)"/>
-    <wire from="(520,560)" to="(540,560)"/>
-    <wire from="(1190,360)" to="(1200,360)"/>
-    <wire from="(1190,600)" to="(1200,600)"/>
-    <wire from="(530,820)" to="(870,820)"/>
-    <wire from="(340,300)" to="(690,300)"/>
-    <wire from="(340,300)" to="(340,410)"/>
-    <wire from="(1070,440)" to="(1070,500)"/>
-    <wire from="(1070,680)" to="(1070,740)"/>
-    <wire from="(690,410)" to="(690,510)"/>
-    <wire from="(1190,480)" to="(1190,540)"/>
-    <wire from="(980,750)" to="(980,810)"/>
-    <wire from="(980,510)" to="(980,570)"/>
-    <wire from="(180,470)" to="(190,470)"/>
-    <wire from="(760,390)" to="(890,390)"/>
-    <wire from="(760,630)" to="(890,630)"/>
-    <wire from="(60,720)" to="(200,720)"/>
-    <wire from="(560,510)" to="(690,510)"/>
-    <wire from="(760,450)" to="(760,510)"/>
-    <wire from="(760,690)" to="(760,750)"/>
-    <wire from="(900,690)" to="(980,690)"/>
-    <wire from="(900,450)" to="(980,450)"/>
-    <wire from="(210,720)" to="(340,720)"/>
-    <wire from="(1230,470)" to="(1250,470)"/>
-    <wire from="(900,800)" to="(900,810)"/>
-    <wire from="(900,560)" to="(900,570)"/>
-    <wire from="(1190,720)" to="(1190,790)"/>
-    <wire from="(560,380)" to="(560,410)"/>
-    <wire from="(1210,550)" to="(1210,560)"/>
-    <wire from="(1220,800)" to="(1220,810)"/>
-    <wire from="(200,580)" to="(200,610)"/>
-    <wire from="(340,510)" to="(340,610)"/>
-    <wire from="(910,600)" to="(930,600)"/>
-    <wire from="(1220,740)" to="(1300,740)"/>
-    <wire from="(1220,500)" to="(1300,500)"/>
-    <wire from="(690,300)" to="(690,410)"/>
-    <wire from="(1070,500)" to="(1210,500)"/>
-    <wire from="(1070,740)" to="(1210,740)"/>
-    <wire from="(60,310)" to="(60,410)"/>
-    <wire from="(1300,560)" to="(1300,620)"/>
-    <wire from="(870,370)" to="(870,430)"/>
-    <wire from="(870,610)" to="(870,670)"/>
-    <wire from="(60,610)" to="(200,610)"/>
-    <wire from="(180,680)" to="(190,680)"/>
-    <wire from="(870,490)" to="(880,490)"/>
-    <wire from="(870,730)" to="(880,730)"/>
-    <wire from="(210,610)" to="(340,610)"/>
-    <wire from="(1180,470)" to="(1200,470)"/>
-    <wire from="(530,470)" to="(540,470)"/>
-    <wire from="(1180,710)" to="(1200,710)"/>
-    <wire from="(370,310)" to="(760,310)"/>
-    <wire from="(890,440)" to="(890,450)"/>
-    <wire from="(890,680)" to="(890,690)"/>
-    <wire from="(370,610)" to="(550,610)"/>
-    <wire from="(100,290)" to="(100,300)"/>
-    <wire from="(980,300)" to="(1300,300)"/>
-    <wire from="(550,580)" to="(550,610)"/>
-    <wire from="(1220,610)" to="(1220,620)"/>
-    <wire from="(1220,370)" to="(1220,380)"/>
-    <wire from="(210,480)" to="(210,510)"/>
-    <wire from="(370,510)" to="(370,610)"/>
-    <wire from="(860,360)" to="(880,360)"/>
-    <wire from="(860,600)" to="(880,600)"/>
-    <wire from="(1190,540)" to="(1200,540)"/>
-    <wire from="(1070,620)" to="(1070,680)"/>
-    <wire from="(1070,380)" to="(1070,440)"/>
-    <wire from="(690,510)" to="(690,610)"/>
-    <wire from="(1190,420)" to="(1190,480)"/>
-    <wire from="(1190,660)" to="(1190,720)"/>
-    <wire from="(220,360)" to="(240,360)"/>
-    <wire from="(530,570)" to="(530,820)"/>
-    <wire from="(980,690)" to="(980,750)"/>
-    <wire from="(980,450)" to="(980,510)"/>
-    <wire from="(760,570)" to="(890,570)"/>
-    <wire from="(760,810)" to="(890,810)"/>
-    <wire from="(180,570)" to="(190,570)"/>
-    <wire from="(560,610)" to="(690,610)"/>
-    <wire from="(760,390)" to="(760,450)"/>
-    <wire from="(760,630)" to="(760,690)"/>
-    <wire from="(900,630)" to="(980,630)"/>
-    <wire from="(900,390)" to="(980,390)"/>
-    <wire from="(1230,410)" to="(1250,410)"/>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,670)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
-    </comp>
-    <comp lib="0" loc="(240,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R2EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(180,830)" name="Pin">
+    <comp lib="0" loc="(600,770)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
+      <a name="label" val="ExpSrc1"/>
     </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
-    </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,590)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
-    </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R1EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
-    </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="PCPlusEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(240,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ImmEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(930,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1240,650)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
-    </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
-    </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,420)" name="Pin">
-      <a name="label" val="IsShamtID"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(930,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(1700,160)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="label" val="MemReadEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,470)" name="Pin">
-      <a name="label" val="BranchID"/>
-    </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,480)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,720)" name="Pin">
-      <a name="label" val="IsExceptionID"/>
-    </comp>
-    <comp lib="0" loc="(930,660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrcEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,540)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="0" loc="(1250,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsEret"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(520,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="0" loc="(1180,780)" name="Pin">
-      <a name="label" val="IsEret"/>
-    </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(930,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
-    </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
-    </comp>
-    <comp lib="0" loc="(170,670)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(240,670)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-  </circuit>
-  <circuit name="EX/MEM">
-    <a name="circuit" val="EX/MEM"/>
-    <a name="clabel" val="EX/MEM"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#ff8045" height="961" stroke="none" width="37" x="52" y="50"/>
-      <circ-port height="8" pin="430,350" width="8" x="46" y="166"/>
-      <circ-port height="10" pin="500,350" width="10" x="85" y="165"/>
-      <circ-port height="8" pin="430,410" width="8" x="46" y="146"/>
-      <circ-port height="10" pin="500,410" width="10" x="85" y="145"/>
-      <circ-port height="8" pin="430,290" width="8" x="46" y="126"/>
-      <circ-port height="10" pin="500,290" width="10" x="85" y="125"/>
-      <circ-port height="8" pin="430,110" width="8" x="46" y="66"/>
-      <circ-port height="10" pin="500,110" width="10" x="85" y="65"/>
-      <circ-port height="8" pin="430,230" width="8" x="46" y="86"/>
-      <circ-port height="10" pin="500,230" width="10" x="85" y="85"/>
-      <circ-port height="8" pin="430,170" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="500,170" width="10" x="85" y="105"/>
-      <circ-port height="8" pin="300,60" width="8" x="66" y="46"/>
-      <circ-port height="8" pin="430,470" width="8" x="46" y="326"/>
-      <circ-port height="10" pin="500,470" width="10" x="85" y="325"/>
-      <circ-port height="8" pin="820,140" width="8" x="46" y="486"/>
-      <circ-port height="10" pin="890,140" width="10" x="85" y="485"/>
-      <circ-port height="8" pin="820,240" width="8" x="46" y="576"/>
-      <circ-port height="10" pin="890,240" width="10" x="85" y="575"/>
-      <circ-port height="8" pin="820,340" width="8" x="46" y="776"/>
-      <circ-port height="10" pin="890,340" width="10" x="85" y="775"/>
-      <circ-port height="8" pin="430,530" width="8" x="46" y="596"/>
-      <circ-port height="10" pin="500,530" width="10" x="85" y="595"/>
-      <circ-port height="8" pin="350,60" width="8" x="76" y="1006"/>
-      <circ-port height="8" pin="440,590" width="8" x="56" y="1006"/>
-      <circ-port height="8" pin="820,450" width="8" x="46" y="916"/>
-      <circ-port height="10" pin="890,450" width="10" x="85" y="915"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="47"/>
-    </appear>
-    <wire from="(470,550)" to="(470,560)"/>
-    <wire from="(470,430)" to="(470,440)"/>
-    <wire from="(470,310)" to="(470,320)"/>
-    <wire from="(470,190)" to="(470,200)"/>
-    <wire from="(560,70)" to="(560,140)"/>
-    <wire from="(300,60)" to="(300,80)"/>
-    <wire from="(860,260)" to="(860,290)"/>
-    <wire from="(820,450)" to="(840,450)"/>
-    <wire from="(470,560)" to="(560,560)"/>
-    <wire from="(470,440)" to="(560,440)"/>
-    <wire from="(870,140)" to="(890,140)"/>
-    <wire from="(870,340)" to="(890,340)"/>
-    <wire from="(470,320)" to="(560,320)"/>
-    <wire from="(470,200)" to="(560,200)"/>
-    <wire from="(640,190)" to="(850,190)"/>
-    <wire from="(640,390)" to="(850,390)"/>
-    <wire from="(640,390)" to="(640,500)"/>
-    <wire from="(980,290)" to="(980,390)"/>
-    <wire from="(480,110)" to="(500,110)"/>
-    <wire from="(480,230)" to="(500,230)"/>
-    <wire from="(480,350)" to="(500,350)"/>
-    <wire from="(480,470)" to="(500,470)"/>
-    <wire from="(640,190)" to="(640,290)"/>
-    <wire from="(440,120)" to="(450,120)"/>
-    <wire from="(440,240)" to="(450,240)"/>
-    <wire from="(440,360)" to="(450,360)"/>
-    <wire from="(440,480)" to="(450,480)"/>
-    <wire from="(560,440)" to="(560,500)"/>
-    <wire from="(560,320)" to="(560,380)"/>
-    <wire from="(560,200)" to="(560,260)"/>
-    <wire from="(830,460)" to="(830,580)"/>
-    <wire from="(300,500)" to="(300,560)"/>
-    <wire from="(300,380)" to="(300,440)"/>
-    <wire from="(300,260)" to="(300,320)"/>
-    <wire from="(300,140)" to="(300,200)"/>
-    <wire from="(440,240)" to="(440,300)"/>
-    <wire from="(440,120)" to="(440,180)"/>
-    <wire from="(440,360)" to="(440,420)"/>
-    <wire from="(440,480)" to="(440,540)"/>
-    <wire from="(830,150)" to="(840,150)"/>
-    <wire from="(830,350)" to="(840,350)"/>
-    <wire from="(860,290)" to="(980,290)"/>
-    <wire from="(460,550)" to="(460,560)"/>
-    <wire from="(460,430)" to="(460,440)"/>
-    <wire from="(460,310)" to="(460,320)"/>
-    <wire from="(460,190)" to="(460,200)"/>
-    <wire from="(850,260)" to="(850,290)"/>
-    <wire from="(860,470)" to="(860,500)"/>
-    <wire from="(820,140)" to="(840,140)"/>
-    <wire from="(820,340)" to="(840,340)"/>
-    <wire from="(830,350)" to="(830,460)"/>
-    <wire from="(300,380)" to="(460,380)"/>
-    <wire from="(300,500)" to="(460,500)"/>
-    <wire from="(300,260)" to="(460,260)"/>
-    <wire from="(300,140)" to="(460,140)"/>
-    <wire from="(640,80)" to="(640,190)"/>
-    <wire from="(830,150)" to="(830,250)"/>
-    <wire from="(430,110)" to="(450,110)"/>
-    <wire from="(430,230)" to="(450,230)"/>
-    <wire from="(430,350)" to="(450,350)"/>
-    <wire from="(430,470)" to="(450,470)"/>
-    <wire from="(350,70)" to="(560,70)"/>
-    <wire from="(860,500)" to="(980,500)"/>
-    <wire from="(440,580)" to="(440,590)"/>
-    <wire from="(470,490)" to="(470,500)"/>
-    <wire from="(470,370)" to="(470,380)"/>
-    <wire from="(470,250)" to="(470,260)"/>
-    <wire from="(470,130)" to="(470,140)"/>
-    <wire from="(860,360)" to="(860,390)"/>
-    <wire from="(860,160)" to="(860,190)"/>
-    <wire from="(850,470)" to="(850,500)"/>
-    <wire from="(560,70)" to="(980,70)"/>
-    <wire from="(470,500)" to="(560,500)"/>
-    <wire from="(980,390)" to="(980,500)"/>
-    <wire from="(470,140)" to="(560,140)"/>
-    <wire from="(470,380)" to="(560,380)"/>
-    <wire from="(870,240)" to="(890,240)"/>
-    <wire from="(470,260)" to="(560,260)"/>
-    <wire from="(640,290)" to="(850,290)"/>
-    <wire from="(300,80)" to="(640,80)"/>
-    <wire from="(980,190)" to="(980,290)"/>
-    <wire from="(480,290)" to="(500,290)"/>
-    <wire from="(480,170)" to="(500,170)"/>
-    <wire from="(480,410)" to="(500,410)"/>
-    <wire from="(480,530)" to="(500,530)"/>
-    <wire from="(640,290)" to="(640,390)"/>
-    <wire from="(440,540)" to="(440,580)"/>
-    <wire from="(440,180)" to="(450,180)"/>
-    <wire from="(440,300)" to="(450,300)"/>
-    <wire from="(440,420)" to="(450,420)"/>
-    <wire from="(440,540)" to="(450,540)"/>
-    <wire from="(560,500)" to="(560,560)"/>
-    <wire from="(560,380)" to="(560,440)"/>
-    <wire from="(560,260)" to="(560,320)"/>
-    <wire from="(560,140)" to="(560,200)"/>
-    <wire from="(980,70)" to="(980,190)"/>
-    <wire from="(300,440)" to="(300,500)"/>
-    <wire from="(300,320)" to="(300,380)"/>
-    <wire from="(300,200)" to="(300,260)"/>
-    <wire from="(300,80)" to="(300,140)"/>
-    <wire from="(830,250)" to="(840,250)"/>
-    <wire from="(440,180)" to="(440,240)"/>
-    <wire from="(440,300)" to="(440,360)"/>
-    <wire from="(440,420)" to="(440,480)"/>
-    <wire from="(440,580)" to="(830,580)"/>
-    <wire from="(860,390)" to="(980,390)"/>
-    <wire from="(860,190)" to="(980,190)"/>
-    <wire from="(460,370)" to="(460,380)"/>
-    <wire from="(460,490)" to="(460,500)"/>
-    <wire from="(460,250)" to="(460,260)"/>
-    <wire from="(460,130)" to="(460,140)"/>
-    <wire from="(350,60)" to="(350,70)"/>
-    <wire from="(850,160)" to="(850,190)"/>
-    <wire from="(850,360)" to="(850,390)"/>
-    <wire from="(820,240)" to="(840,240)"/>
-    <wire from="(870,450)" to="(890,450)"/>
-    <wire from="(300,440)" to="(460,440)"/>
-    <wire from="(300,560)" to="(460,560)"/>
-    <wire from="(300,320)" to="(460,320)"/>
-    <wire from="(300,200)" to="(460,200)"/>
-    <wire from="(640,500)" to="(850,500)"/>
-    <wire from="(830,250)" to="(830,350)"/>
-    <wire from="(430,170)" to="(450,170)"/>
-    <wire from="(430,290)" to="(450,290)"/>
-    <wire from="(430,530)" to="(450,530)"/>
-    <wire from="(430,410)" to="(450,410)"/>
-    <wire from="(830,460)" to="(840,460)"/>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
-    </comp>
-    <comp lib="0" loc="(500,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(820,450)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-    </comp>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(890,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(480,170)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(870,340)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(350,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(870,450)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,530)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(500,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
-    </comp>
-    <comp lib="0" loc="(890,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="CP0Dout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,530)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-  </circuit>
-  <circuit name="MEM/WB">
-    <a name="circuit" val="MEM/WB"/>
-    <a name="clabel" val="MEM/WBN"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#d075ff" height="959" stroke="none" width="41" x="160" y="61"/>
-      <circ-port height="8" pin="360,260" width="8" x="156" y="86"/>
-      <circ-port height="8" pin="250,180" width="8" x="176" y="56"/>
-      <circ-port height="8" pin="360,320" width="8" x="156" y="126"/>
-      <circ-port height="8" pin="360,380" width="8" x="156" y="106"/>
-      <circ-port height="8" pin="360,440" width="8" x="156" y="146"/>
-      <circ-port height="10" pin="430,260" width="10" x="195" y="85"/>
-      <circ-port height="10" pin="430,320" width="10" x="195" y="125"/>
-      <circ-port height="10" pin="430,380" width="10" x="195" y="105"/>
-      <circ-port height="10" pin="430,440" width="10" x="195" y="145"/>
-      <circ-port height="8" pin="720,290" width="8" x="156" y="446"/>
-      <circ-port height="10" pin="790,290" width="10" x="195" y="445"/>
-      <circ-port height="8" pin="720,500" width="8" x="156" y="506"/>
-      <circ-port height="10" pin="790,500" width="10" x="195" y="505"/>
-      <circ-port height="8" pin="720,390" width="8" x="156" y="796"/>
-      <circ-port height="10" pin="790,390" width="10" x="195" y="795"/>
-      <circ-port height="8" pin="360,560" width="8" x="156" y="616"/>
-      <circ-port height="10" pin="430,560" width="10" x="195" y="615"/>
-      <circ-port height="8" pin="360,500" width="8" x="156" y="346"/>
-      <circ-port height="10" pin="430,500" width="10" x="195" y="345"/>
-      <circ-port height="8" pin="290,180" width="8" x="186" y="1016"/>
-      <circ-port height="8" pin="370,720" width="8" x="166" y="1016"/>
-      <circ-port height="8" pin="720,610" width="8" x="156" y="936"/>
-      <circ-port height="10" pin="790,610" width="10" x="195" y="935"/>
-      <circ-anchor facing="east" height="6" width="6" x="157" y="57"/>
-    </appear>
-    <wire from="(400,520)" to="(400,530)"/>
-    <wire from="(400,400)" to="(400,410)"/>
-    <wire from="(400,280)" to="(400,290)"/>
-    <wire from="(750,310)" to="(750,340)"/>
-    <wire from="(760,520)" to="(760,550)"/>
-    <wire from="(750,630)" to="(750,660)"/>
-    <wire from="(250,210)" to="(540,210)"/>
-    <wire from="(490,200)" to="(490,290)"/>
-    <wire from="(370,710)" to="(730,710)"/>
-    <wire from="(400,530)" to="(490,530)"/>
-    <wire from="(400,410)" to="(490,410)"/>
-    <wire from="(400,290)" to="(490,290)"/>
-    <wire from="(910,340)" to="(910,450)"/>
-    <wire from="(730,400)" to="(730,510)"/>
-    <wire from="(540,450)" to="(750,450)"/>
-    <wire from="(720,390)" to="(740,390)"/>
-    <wire from="(410,320)" to="(430,320)"/>
-    <wire from="(410,440)" to="(430,440)"/>
-    <wire from="(410,560)" to="(430,560)"/>
-    <wire from="(540,450)" to="(540,550)"/>
-    <wire from="(370,330)" to="(380,330)"/>
-    <wire from="(370,450)" to="(380,450)"/>
-    <wire from="(370,570)" to="(380,570)"/>
-    <wire from="(250,530)" to="(250,590)"/>
-    <wire from="(370,330)" to="(370,390)"/>
-    <wire from="(370,450)" to="(370,510)"/>
-    <wire from="(490,530)" to="(490,590)"/>
-    <wire from="(490,410)" to="(490,470)"/>
-    <wire from="(490,290)" to="(490,350)"/>
-    <wire from="(250,410)" to="(250,470)"/>
-    <wire from="(250,290)" to="(250,350)"/>
-    <wire from="(540,210)" to="(540,340)"/>
-    <wire from="(390,520)" to="(390,530)"/>
-    <wire from="(390,400)" to="(390,410)"/>
-    <wire from="(390,280)" to="(390,290)"/>
-    <wire from="(290,180)" to="(290,200)"/>
-    <wire from="(250,210)" to="(250,290)"/>
-    <wire from="(750,520)" to="(750,550)"/>
-    <wire from="(250,180)" to="(250,210)"/>
-    <wire from="(910,550)" to="(910,660)"/>
-    <wire from="(760,450)" to="(910,450)"/>
-    <wire from="(760,410)" to="(760,450)"/>
-    <wire from="(540,340)" to="(750,340)"/>
-    <wire from="(540,340)" to="(540,450)"/>
-    <wire from="(540,660)" to="(750,660)"/>
-    <wire from="(770,290)" to="(790,290)"/>
-    <wire from="(770,610)" to="(790,610)"/>
-    <wire from="(360,320)" to="(380,320)"/>
-    <wire from="(360,560)" to="(380,560)"/>
-    <wire from="(360,440)" to="(380,440)"/>
-    <wire from="(250,590)" to="(390,590)"/>
-    <wire from="(250,470)" to="(390,470)"/>
-    <wire from="(250,350)" to="(390,350)"/>
-    <wire from="(730,300)" to="(740,300)"/>
-    <wire from="(730,620)" to="(740,620)"/>
-    <wire from="(370,570)" to="(370,710)"/>
-    <wire from="(400,580)" to="(400,590)"/>
-    <wire from="(400,460)" to="(400,470)"/>
-    <wire from="(400,340)" to="(400,350)"/>
-    <wire from="(370,710)" to="(370,720)"/>
-    <wire from="(730,620)" to="(730,710)"/>
-    <wire from="(490,200)" to="(910,200)"/>
-    <wire from="(400,590)" to="(490,590)"/>
-    <wire from="(400,470)" to="(490,470)"/>
-    <wire from="(400,350)" to="(490,350)"/>
-    <wire from="(760,340)" to="(910,340)"/>
-    <wire from="(760,660)" to="(910,660)"/>
-    <wire from="(750,410)" to="(750,450)"/>
-    <wire from="(540,550)" to="(750,550)"/>
-    <wire from="(540,550)" to="(540,660)"/>
-    <wire from="(720,290)" to="(740,290)"/>
-    <wire from="(770,500)" to="(790,500)"/>
-    <wire from="(720,610)" to="(740,610)"/>
-    <wire from="(410,260)" to="(430,260)"/>
-    <wire from="(410,380)" to="(430,380)"/>
-    <wire from="(410,500)" to="(430,500)"/>
-    <wire from="(730,300)" to="(730,400)"/>
-    <wire from="(370,270)" to="(380,270)"/>
-    <wire from="(370,390)" to="(380,390)"/>
-    <wire from="(370,510)" to="(380,510)"/>
-    <wire from="(250,470)" to="(250,530)"/>
-    <wire from="(370,270)" to="(370,330)"/>
-    <wire from="(370,390)" to="(370,450)"/>
-    <wire from="(370,510)" to="(370,570)"/>
-    <wire from="(490,470)" to="(490,530)"/>
-    <wire from="(490,350)" to="(490,410)"/>
-    <wire from="(730,510)" to="(740,510)"/>
-    <wire from="(250,350)" to="(250,410)"/>
-    <wire from="(910,200)" to="(910,340)"/>
-    <wire from="(390,580)" to="(390,590)"/>
-    <wire from="(390,460)" to="(390,470)"/>
-    <wire from="(390,340)" to="(390,350)"/>
-    <wire from="(760,310)" to="(760,340)"/>
-    <wire from="(760,630)" to="(760,660)"/>
-    <wire from="(760,550)" to="(910,550)"/>
-    <wire from="(730,510)" to="(730,620)"/>
-    <wire from="(770,390)" to="(790,390)"/>
-    <wire from="(720,500)" to="(740,500)"/>
-    <wire from="(360,260)" to="(380,260)"/>
-    <wire from="(360,380)" to="(380,380)"/>
-    <wire from="(360,500)" to="(380,500)"/>
-    <wire from="(910,450)" to="(910,550)"/>
-    <wire from="(250,530)" to="(390,530)"/>
-    <wire from="(250,410)" to="(390,410)"/>
-    <wire from="(250,290)" to="(390,290)"/>
-    <wire from="(290,200)" to="(490,200)"/>
-    <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="0" loc="(720,390)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
-    </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
-    </comp>
-    <comp lib="4" loc="(410,560)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(370,720)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(290,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(720,610)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="4" loc="(770,610)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,380)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(410,380)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(770,290)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(790,610)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrWB"/>
-      <a name="labelloc" val="east"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">
@@ -3337,117 +2001,84 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(860,600)" to="(1000,600)"/>
     <wire from="(900,550)" to="(910,550)"/>
     <wire from="(900,530)" to="(910,530)"/>
-    <comp lib="0" loc="(160,290)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="0" loc="(1420,450)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,340)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteEX"/>
-    </comp>
     <comp lib="0" loc="(130,170)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWriteMEM"/>
     </comp>
-    <comp lib="0" loc="(900,550)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(570,250)" name="Tunnel">
+    <comp lib="0" loc="(740,250)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="width" val="5"/>
-      <a name="label" val="RS"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="0" loc="(170,50)" name="Tunnel">
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(140,250)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="0" loc="(1550,150)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(840,220)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(1540,510)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="4" loc="(1480,510)" name="Counter">
       <a name="width" val="32"/>
-      <a name="label" val="BubbleNum"/>
-      <a name="labelloc" val="east"/>
+      <a name="max" val="0xffffffff"/>
     </comp>
     <comp lib="0" loc="(980,350)" name="Constant">
       <a name="width" val="2"/>
     </comp>
-    <comp lib="0" loc="(1210,410)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="IsLW"/>
-    </comp>
-    <comp lib="6" loc="(909,590)" name="Text">
-      <a name="text" val="Rt Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(360,200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="2" loc="(1020,550)" name="Multiplexer">
+    <comp lib="0" loc="(900,340)" name="Constant">
       <a name="width" val="2"/>
-      <a name="enable" val="false"/>
+      <a name="value" val="0x2"/>
     </comp>
-    <comp lib="0" loc="(640,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="1" loc="(1540,150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate0" val="true"/>
-    </comp>
-    <comp loc="(800,570)" name="Hazard_Detector"/>
-    <comp lib="0" loc="(820,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="2" loc="(1020,340)" name="Multiplexer">
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(160,330)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(900,320)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(1350,160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(130,210)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="RS"/>
     </comp>
-    <comp lib="0" loc="(130,50)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(160,250)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="0" loc="(900,340)" name="Constant">
+    <comp lib="0" loc="(380,240)" name="Tunnel">
+      <a name="label" val="ReadWriteEX"/>
+    </comp>
+    <comp lib="1" loc="(1160,450)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(840,220)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="0" loc="(900,530)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(900,550)" name="Constant">
       <a name="width" val="2"/>
       <a name="value" val="0x2"/>
     </comp>
-    <comp lib="0" loc="(1350,180)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
+    <comp lib="0" loc="(160,330)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RT"/>
     </comp>
-    <comp loc="(800,270)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(790,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="1" loc="(1290,430)" name="AND Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(170,50)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
     <comp lib="6" loc="(1204,445)" name="Text">
       <a name="text" val="hasHazard"/>
+    </comp>
+    <comp lib="2" loc="(940,330)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(1040,340)" name="Pin">
       <a name="facing" val="west"/>
@@ -3456,81 +2087,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RsOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(130,330)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RT"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(150,170)" name="Tunnel">
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(900,530)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(150,130)" name="Tunnel">
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(790,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(1460,550)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(790,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(130,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(530,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="RT"/>
-    </comp>
-    <comp lib="0" loc="(160,250)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp loc="(800,370)" name="Hazard_Detector"/>
-    <comp lib="6" loc="(917,390)" name="Text">
-      <a name="text" val="Rs Hazard in EX"/>
-    </comp>
-    <comp lib="0" loc="(740,250)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="2" loc="(940,330)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(912,490)" name="Text">
-      <a name="text" val="Rt Hazard in MEM"/>
-    </comp>
-    <comp lib="0" loc="(360,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="1" loc="(1290,430)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp loc="(800,470)" name="Hazard_Detector"/>
-    <comp lib="6" loc="(922,290)" name="Text">
-      <a name="text" val="Rs Hazard in MEM"/>
-    </comp>
     <comp lib="0" loc="(1040,550)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -3538,23 +2094,168 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RtOutput"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="2" loc="(940,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="0" loc="(130,330)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RT"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="2" loc="(1020,550)" name="Multiplexer">
       <a name="width" val="2"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(380,240)" name="Tunnel">
+    <comp lib="0" loc="(130,290)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="6" loc="(912,490)" name="Text">
+      <a name="text" val="Rt Hazard in MEM"/>
+    </comp>
+    <comp lib="0" loc="(1420,450)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="StallID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp loc="(800,270)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(150,170)" name="Tunnel">
+      <a name="label" val="ReadWriteMEM"/>
+    </comp>
+    <comp lib="6" loc="(917,390)" name="Text">
+      <a name="text" val="Rs Hazard in EX"/>
+    </comp>
+    <comp lib="4" loc="(1500,350)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(150,210)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp lib="4" loc="(1430,160)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="6" loc="(909,590)" name="Text">
+      <a name="text" val="Rt Hazard in EX"/>
+    </comp>
+    <comp lib="0" loc="(790,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(790,460)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(1550,150)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(790,540)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="ReadWriteEX"/>
     </comp>
+    <comp loc="(800,470)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(980,560)" name="Constant">
+      <a name="width" val="2"/>
+    </comp>
+    <comp lib="0" loc="(530,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(130,50)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(922,290)" name="Text">
+      <a name="text" val="Rs Hazard in MEM"/>
+    </comp>
+    <comp lib="0" loc="(790,360)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(1350,180)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="2" loc="(1020,340)" name="Multiplexer">
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(570,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="RS"/>
+    </comp>
+    <comp loc="(800,370)" name="Hazard_Detector"/>
     <comp lib="0" loc="(1420,410)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="StallIF"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(1540,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="32"/>
+      <a name="label" val="BubbleNum"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(900,320)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp loc="(800,570)" name="Hazard_Detector"/>
+    <comp lib="0" loc="(360,240)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(1460,550)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(360,200)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="0" loc="(640,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(1390,350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(820,250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ReadRs"/>
+    </comp>
+    <comp lib="0" loc="(160,290)" name="Tunnel">
+      <a name="width" val="5"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="2" loc="(940,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
     <comp lib="1" loc="(1550,340)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(380,200)" name="Tunnel">
+      <a name="label" val="ReadRt"/>
+    </comp>
+    <comp lib="1" loc="(1540,150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate0" val="true"/>
+    </comp>
+    <comp lib="0" loc="(130,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="ReadRs"/>
     </comp>
     <comp lib="0" loc="(1570,340)" name="Pin">
       <a name="facing" val="west"/>
@@ -3562,53 +2263,16 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="FlushID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(790,360)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRs"/>
-    </comp>
-    <comp lib="0" loc="(1350,160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(140,250)" name="Pin">
-      <a name="width" val="5"/>
+    <comp lib="0" loc="(1210,410)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
+      <a name="label" val="IsLW"/>
     </comp>
-    <comp lib="1" loc="(1160,450)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(980,560)" name="Constant">
-      <a name="width" val="2"/>
-    </comp>
-    <comp lib="0" loc="(380,200)" name="Tunnel">
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(790,540)" name="Tunnel">
+    <comp lib="0" loc="(790,340)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="ReadWriteEX"/>
     </comp>
-    <comp lib="0" loc="(790,460)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ReadRt"/>
-    </comp>
-    <comp lib="0" loc="(130,290)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="4" loc="(1480,510)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(150,210)" name="Tunnel">
-      <a name="width" val="5"/>
-      <a name="label" val="RS"/>
-    </comp>
-    <comp lib="0" loc="(1390,350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(150,130)" name="Tunnel">
+      <a name="label" val="ReadRs"/>
     </comp>
   </circuit>
   <circuit name="RegisterRead_Detector">
@@ -4607,29 +3271,265 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(360,3430)" to="(360,3470)"/>
     <wire from="(220,3150)" to="(300,3150)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,950)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,180)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
+      <a name="label" val="op3"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,4320)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2850)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,250)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(410,690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1260)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,2860)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="7"/>
+    </comp>
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3910)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2390)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,80)" name="Pin">
@@ -4637,275 +3537,144 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op1"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
     <comp lib="1" loc="(320,4000)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1260)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4550)" name="OR Gate">
-      <a name="size" val="30"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,830)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="9"/>
-    </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2850)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2390)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,4260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,3160)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(40,430)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct2"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3040)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
     <comp lib="1" loc="(410,3780)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,210)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+    <comp lib="1" loc="(320,2910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2160)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2420)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,580)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,4550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,4790)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3920)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,950)" name="AND Gate">
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,530)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,430)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -4915,65 +3684,66 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="ReadRs"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2460)" name="NOT Gate">
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,910)" name="NOT Gate">
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3640)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(600,2570)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2500)" name="NOT Gate">
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,330)" name="Pin">
@@ -4981,20 +3751,35 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct0"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1290)" name="AND Gate">
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2540)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,480)" name="Pin">
@@ -5002,244 +3787,123 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct3"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,2860)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,3220)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
     <comp lib="1" loc="(510,1840)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(610,4550)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,530)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3920)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(710,1960)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(510,2310)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3910)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,250)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(510,2090)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,4190)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(690,4550)" name="OR Gate">
+      <a name="size" val="30"/>
     </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(520,4830)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,580)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(730,4550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(510,2580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
   </circuit>
@@ -5275,13 +3939,33 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,300)" to="(610,300)"/>
     <wire from="(590,290)" to="(600,290)"/>
     <wire from="(600,340)" to="(610,340)"/>
+    <comp lib="0" loc="(400,340)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg"/>
+    </comp>
     <comp lib="0" loc="(400,380)" name="Pin">
       <a name="width" val="5"/>
       <a name="tristate" val="false"/>
       <a name="label" val="Register#"/>
     </comp>
+    <comp lib="1" loc="(660,320)" name="AND Gate">
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="1" loc="(530,330)" name="NOT Gate"/>
+    <comp lib="0" loc="(590,290)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Read"/>
+    </comp>
     <comp lib="3" loc="(490,370)" name="Comparator">
       <a name="width" val="5"/>
+    </comp>
+    <comp lib="3" loc="(490,330)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(430,320)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
     </comp>
     <comp lib="0" loc="(700,320)" name="Pin">
       <a name="facing" val="west"/>
@@ -5292,26 +3976,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="0" loc="(590,310)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWrite"/>
-    </comp>
-    <comp lib="0" loc="(590,290)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Read"/>
-    </comp>
-    <comp lib="3" loc="(490,330)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="1" loc="(660,320)" name="AND Gate">
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(530,330)" name="NOT Gate"/>
-    <comp lib="0" loc="(400,340)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg"/>
     </comp>
   </circuit>
   <circuit name="RegWrite_Decider">
@@ -5332,24 +3996,24 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(390,240)" to="(420,240)"/>
     <wire from="(390,260)" to="(420,260)"/>
     <wire from="(430,270)" to="(430,310)"/>
-    <comp lib="0" loc="(460,250)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FinalRegWrite"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(390,260)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ExRegWrite"/>
+    </comp>
+    <comp lib="0" loc="(390,240)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWrite"/>
     </comp>
     <comp lib="0" loc="(430,310)" name="Pin">
       <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
       <a name="label" val="IsException"/>
     </comp>
-    <comp lib="0" loc="(390,240)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="RegWrite"/>
+    <comp lib="0" loc="(460,250)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FinalRegWrite"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="2" loc="(450,250)" name="Multiplexer">
       <a name="enable" val="false"/>

--- a/src/pipeline_cpu_bubbling.circ
+++ b/src/pipeline_cpu_bubbling.circ
@@ -101,6 +101,7 @@
   <lib desc="file#common/syscall_decoder.circ" name="10"/>
   <lib desc="file#common/immediate_extender.circ" name="11"/>
   <lib desc="file#common/regfile.circ" name="12"/>
+  <lib desc="file#common/pipeline.circ" name="13"/>
   <main name="main"/>
   <options>
     <a name="gateUndefined" val="ignore"/>
@@ -157,18 +158,21 @@
     <wire from="(590,120)" to="(1010,120)"/>
     <wire from="(660,770)" to="(660,850)"/>
     <wire from="(380,220)" to="(380,250)"/>
-    <wire from="(1440,920)" to="(1450,920)"/>
+    <wire from="(930,540)" to="(930,1260)"/>
+    <wire from="(1140,670)" to="(1510,670)"/>
     <wire from="(1420,360)" to="(1420,540)"/>
     <wire from="(540,360)" to="(540,530)"/>
     <wire from="(1310,630)" to="(1320,630)"/>
     <wire from="(520,550)" to="(540,550)"/>
+    <wire from="(1450,1130)" to="(1450,1180)"/>
     <wire from="(1120,280)" to="(1130,280)"/>
     <wire from="(2060,580)" to="(2070,580)"/>
-    <wire from="(600,900)" to="(600,1060)"/>
     <wire from="(1400,340)" to="(1400,530)"/>
-    <wire from="(1560,600)" to="(1560,660)"/>
     <wire from="(1930,690)" to="(1940,690)"/>
     <wire from="(1120,200)" to="(1510,200)"/>
+    <wire from="(20,1180)" to="(1450,1180)"/>
+    <wire from="(640,590)" to="(640,1200)"/>
+    <wire from="(2070,580)" to="(2070,1200)"/>
     <wire from="(1550,870)" to="(1890,870)"/>
     <wire from="(400,340)" to="(480,340)"/>
     <wire from="(110,550)" to="(120,550)"/>
@@ -177,25 +181,30 @@
     <wire from="(750,240)" to="(1080,240)"/>
     <wire from="(750,400)" to="(1080,400)"/>
     <wire from="(750,320)" to="(1080,320)"/>
+    <wire from="(1170,760)" to="(1170,1160)"/>
+    <wire from="(620,570)" to="(620,1220)"/>
     <wire from="(1780,150)" to="(1780,180)"/>
+    <wire from="(580,1090)" to="(580,1230)"/>
     <wire from="(810,700)" to="(810,710)"/>
     <wire from="(2020,590)" to="(2020,870)"/>
+    <wire from="(160,560)" to="(160,1140)"/>
     <wire from="(1630,260)" to="(1630,660)"/>
     <wire from="(410,220)" to="(460,220)"/>
     <wire from="(1410,180)" to="(1510,180)"/>
     <wire from="(1550,240)" to="(1650,240)"/>
     <wire from="(430,240)" to="(430,250)"/>
+    <wire from="(1560,600)" to="(1560,670)"/>
     <wire from="(420,230)" to="(420,250)"/>
     <wire from="(500,710)" to="(500,730)"/>
     <wire from="(690,620)" to="(980,620)"/>
     <wire from="(1910,120)" to="(1910,130)"/>
     <wire from="(1140,340)" to="(1390,340)"/>
+    <wire from="(1920,1090)" to="(1920,1100)"/>
     <wire from="(410,220)" to="(410,250)"/>
-    <wire from="(1090,900)" to="(1090,910)"/>
     <wire from="(660,770)" to="(830,770)"/>
     <wire from="(1220,550)" to="(1220,600)"/>
+    <wire from="(1440,1130)" to="(1450,1130)"/>
     <wire from="(860,700)" to="(880,700)"/>
-    <wire from="(1310,920)" to="(1320,920)"/>
     <wire from="(1670,520)" to="(1670,580)"/>
     <wire from="(1120,620)" to="(1260,620)"/>
     <wire from="(1550,260)" to="(1630,260)"/>
@@ -204,53 +213,50 @@
     <wire from="(1480,20)" to="(1480,270)"/>
     <wire from="(400,210)" to="(400,250)"/>
     <wire from="(1240,510)" to="(1270,510)"/>
-    <wire from="(1110,900)" to="(1110,1060)"/>
     <wire from="(2010,570)" to="(2030,570)"/>
     <wire from="(560,620)" to="(560,870)"/>
     <wire from="(1350,620)" to="(1380,620)"/>
+    <wire from="(920,500)" to="(920,1260)"/>
+    <wire from="(1310,840)" to="(1310,1130)"/>
     <wire from="(340,550)" to="(340,610)"/>
     <wire from="(1550,200)" to="(1890,200)"/>
     <wire from="(1930,870)" to="(2020,870)"/>
     <wire from="(2030,500)" to="(2060,500)"/>
     <wire from="(70,20)" to="(1480,20)"/>
-    <wire from="(1130,530)" to="(1130,930)"/>
     <wire from="(1930,520)" to="(1970,520)"/>
     <wire from="(1010,470)" to="(1010,480)"/>
     <wire from="(610,870)" to="(660,870)"/>
+    <wire from="(740,480)" to="(740,1260)"/>
+    <wire from="(1110,1110)" to="(1110,1260)"/>
     <wire from="(1410,150)" to="(1410,180)"/>
-    <wire from="(580,900)" to="(580,1030)"/>
     <wire from="(1550,180)" to="(1780,180)"/>
     <wire from="(490,670)" to="(490,680)"/>
     <wire from="(1970,100)" to="(1970,180)"/>
     <wire from="(2040,160)" to="(2040,560)"/>
     <wire from="(220,290)" to="(400,290)"/>
     <wire from="(1720,620)" to="(1720,630)"/>
-    <wire from="(110,550)" to="(110,950)"/>
     <wire from="(370,230)" to="(370,250)"/>
-    <wire from="(1750,1050)" to="(1750,1060)"/>
-    <wire from="(620,1010)" to="(1940,1010)"/>
     <wire from="(2120,500)" to="(2130,500)"/>
-    <wire from="(1920,900)" to="(1920,910)"/>
     <wire from="(850,760)" to="(1080,760)"/>
     <wire from="(1120,400)" to="(1240,400)"/>
     <wire from="(670,240)" to="(670,320)"/>
     <wire from="(1260,540)" to="(1380,540)"/>
-    <wire from="(1510,1050)" to="(1510,1060)"/>
-    <wire from="(1370,410)" to="(1370,1060)"/>
+    <wire from="(1090,1110)" to="(1090,1120)"/>
     <wire from="(130,40)" to="(130,520)"/>
+    <wire from="(1310,1130)" to="(1320,1130)"/>
     <wire from="(340,610)" to="(430,610)"/>
     <wire from="(1400,340)" to="(1410,340)"/>
     <wire from="(90,530)" to="(120,530)"/>
     <wire from="(70,510)" to="(100,510)"/>
     <wire from="(200,550)" to="(290,550)"/>
+    <wire from="(1140,550)" to="(1140,670)"/>
     <wire from="(400,210)" to="(420,210)"/>
     <wire from="(1120,220)" to="(1510,220)"/>
-    <wire from="(20,540)" to="(20,970)"/>
     <wire from="(330,350)" to="(480,350)"/>
-    <wire from="(250,560)" to="(250,1060)"/>
     <wire from="(1290,610)" to="(1320,610)"/>
     <wire from="(890,160)" to="(890,670)"/>
     <wire from="(1350,160)" to="(1510,160)"/>
+    <wire from="(180,1280)" to="(190,1280)"/>
     <wire from="(40,870)" to="(560,870)"/>
     <wire from="(1060,550)" to="(1080,550)"/>
     <wire from="(2030,470)" to="(2060,470)"/>
@@ -260,21 +266,18 @@
     <wire from="(750,180)" to="(1080,180)"/>
     <wire from="(750,420)" to="(1080,420)"/>
     <wire from="(280,410)" to="(350,410)"/>
-    <wire from="(1140,550)" to="(1140,660)"/>
     <wire from="(670,690)" to="(670,760)"/>
     <wire from="(1450,330)" to="(1490,330)"/>
-    <wire from="(420,720)" to="(420,1060)"/>
+    <wire from="(620,1220)" to="(1940,1220)"/>
     <wire from="(480,710)" to="(480,730)"/>
     <wire from="(180,60)" to="(180,530)"/>
     <wire from="(2120,470)" to="(2130,470)"/>
+    <wire from="(1900,1090)" to="(1900,1100)"/>
     <wire from="(400,310)" to="(400,340)"/>
     <wire from="(1700,690)" to="(1890,690)"/>
     <wire from="(1240,510)" to="(1240,520)"/>
-    <wire from="(1140,660)" to="(1510,660)"/>
-    <wire from="(640,990)" to="(2070,990)"/>
     <wire from="(810,750)" to="(830,750)"/>
     <wire from="(670,500)" to="(670,540)"/>
-    <wire from="(1310,940)" to="(1320,940)"/>
     <wire from="(1650,630)" to="(1720,630)"/>
     <wire from="(1970,560)" to="(1980,560)"/>
     <wire from="(750,440)" to="(780,440)"/>
@@ -306,23 +309,20 @@
     <wire from="(130,40)" to="(1140,40)"/>
     <wire from="(1130,60)" to="(1130,280)"/>
     <wire from="(1130,530)" to="(1230,530)"/>
-    <wire from="(1360,930)" to="(1400,930)"/>
     <wire from="(1040,100)" to="(1970,100)"/>
     <wire from="(360,240)" to="(360,250)"/>
     <wire from="(1120,320)" to="(1410,320)"/>
-    <wire from="(730,480)" to="(730,1060)"/>
     <wire from="(660,870)" to="(1080,870)"/>
-    <wire from="(1900,900)" to="(1900,910)"/>
     <wire from="(1830,580)" to="(1890,580)"/>
     <wire from="(910,690)" to="(1080,690)"/>
     <wire from="(1930,200)" to="(1990,200)"/>
-    <wire from="(1940,690)" to="(1940,1010)"/>
+    <wire from="(1540,1100)" to="(1540,1110)"/>
     <wire from="(1120,760)" to="(1170,760)"/>
     <wire from="(260,360)" to="(480,360)"/>
-    <wire from="(1390,910)" to="(1400,910)"/>
-    <wire from="(1460,690)" to="(1460,1060)"/>
+    <wire from="(640,1200)" to="(2070,1200)"/>
+    <wire from="(1550,670)" to="(1560,670)"/>
+    <wire from="(1310,1150)" to="(1320,1150)"/>
     <wire from="(100,710)" to="(190,710)"/>
-    <wire from="(1700,690)" to="(1700,1060)"/>
     <wire from="(320,550)" to="(340,550)"/>
     <wire from="(1120,240)" to="(1510,240)"/>
     <wire from="(920,500)" to="(950,500)"/>
@@ -335,33 +335,31 @@
     <wire from="(750,280)" to="(1080,280)"/>
     <wire from="(750,200)" to="(1080,200)"/>
     <wire from="(1120,550)" to="(1140,550)"/>
-    <wire from="(1390,870)" to="(1390,910)"/>
     <wire from="(750,160)" to="(890,160)"/>
     <wire from="(640,590)" to="(950,590)"/>
     <wire from="(830,680)" to="(880,680)"/>
     <wire from="(590,120)" to="(590,130)"/>
     <wire from="(1270,510)" to="(1270,590)"/>
-    <wire from="(2070,580)" to="(2070,990)"/>
     <wire from="(1120,360)" to="(1420,360)"/>
-    <wire from="(930,540)" to="(930,1060)"/>
     <wire from="(800,810)" to="(800,820)"/>
+    <wire from="(1370,410)" to="(1370,1260)"/>
     <wire from="(1490,300)" to="(1490,330)"/>
     <wire from="(1780,180)" to="(1890,180)"/>
     <wire from="(1380,270)" to="(1480,270)"/>
     <wire from="(1220,600)" to="(1260,600)"/>
     <wire from="(1020,620)" to="(1080,620)"/>
     <wire from="(670,550)" to="(670,620)"/>
+    <wire from="(1360,1140)" to="(1400,1140)"/>
     <wire from="(790,540)" to="(790,670)"/>
     <wire from="(220,80)" to="(220,290)"/>
     <wire from="(1930,580)" to="(1980,580)"/>
     <wire from="(690,540)" to="(790,540)"/>
     <wire from="(690,690)" to="(800,690)"/>
-    <wire from="(640,590)" to="(640,990)"/>
-    <wire from="(1540,910)" to="(1540,920)"/>
     <wire from="(40,520)" to="(40,870)"/>
-    <wire from="(110,950)" to="(1170,950)"/>
     <wire from="(1550,580)" to="(1670,580)"/>
     <wire from="(1650,240)" to="(1650,630)"/>
+    <wire from="(1390,1120)" to="(1400,1120)"/>
+    <wire from="(110,550)" to="(110,1160)"/>
     <wire from="(1120,870)" to="(1390,870)"/>
     <wire from="(1220,550)" to="(1230,550)"/>
     <wire from="(2130,80)" to="(2130,470)"/>
@@ -370,26 +368,30 @@
     <wire from="(690,240)" to="(720,240)"/>
     <wire from="(750,460)" to="(780,460)"/>
     <wire from="(1930,220)" to="(1940,220)"/>
-    <wire from="(1170,760)" to="(1170,950)"/>
-    <wire from="(160,560)" to="(160,930)"/>
     <wire from="(1360,280)" to="(1360,380)"/>
-    <wire from="(620,570)" to="(620,1010)"/>
     <wire from="(340,550)" to="(350,550)"/>
+    <wire from="(1130,530)" to="(1130,1140)"/>
+    <wire from="(250,560)" to="(250,1260)"/>
     <wire from="(1550,160)" to="(1890,160)"/>
     <wire from="(1240,400)" to="(1240,510)"/>
     <wire from="(1120,690)" to="(1460,690)"/>
     <wire from="(1990,200)" to="(1990,550)"/>
+    <wire from="(20,540)" to="(20,1180)"/>
     <wire from="(1100,120)" to="(1530,120)"/>
-    <wire from="(1310,840)" to="(1310,920)"/>
     <wire from="(1130,280)" to="(1360,280)"/>
     <wire from="(350,410)" to="(350,420)"/>
     <wire from="(1120,180)" to="(1410,180)"/>
     <wire from="(1760,620)" to="(1760,630)"/>
+    <wire from="(1750,1250)" to="(1750,1260)"/>
     <wire from="(430,240)" to="(540,240)"/>
     <wire from="(260,240)" to="(360,240)"/>
     <wire from="(670,760)" to="(670,840)"/>
     <wire from="(1100,120)" to="(1100,130)"/>
+    <wire from="(420,720)" to="(420,1260)"/>
     <wire from="(1390,870)" to="(1510,870)"/>
+    <wire from="(1510,1250)" to="(1510,1260)"/>
+    <wire from="(1520,1100)" to="(1520,1110)"/>
+    <wire from="(110,1160)" to="(1170,1160)"/>
     <wire from="(470,620)" to="(560,620)"/>
     <wire from="(930,540)" to="(950,540)"/>
     <wire from="(1560,600)" to="(1690,600)"/>
@@ -401,8 +403,6 @@
     <wire from="(390,210)" to="(390,250)"/>
     <wire from="(440,300)" to="(450,300)"/>
     <wire from="(370,550)" to="(380,550)"/>
-    <wire from="(180,1080)" to="(190,1080)"/>
-    <wire from="(160,930)" to="(1130,930)"/>
     <wire from="(790,540)" to="(930,540)"/>
     <wire from="(1380,270)" to="(1380,380)"/>
     <wire from="(1140,40)" to="(1140,340)"/>
@@ -410,19 +410,19 @@
     <wire from="(750,380)" to="(1080,380)"/>
     <wire from="(750,220)" to="(1080,220)"/>
     <wire from="(300,230)" to="(370,230)"/>
-    <wire from="(920,500)" to="(920,1060)"/>
     <wire from="(690,760)" to="(830,760)"/>
     <wire from="(620,570)" to="(950,570)"/>
     <wire from="(670,540)" to="(670,550)"/>
     <wire from="(1530,120)" to="(1530,140)"/>
     <wire from="(1310,630)" to="(1310,840)"/>
+    <wire from="(730,480)" to="(730,1260)"/>
     <wire from="(1930,420)" to="(2100,420)"/>
     <wire from="(1120,160)" to="(1350,160)"/>
     <wire from="(610,550)" to="(670,550)"/>
     <wire from="(300,570)" to="(300,580)"/>
     <wire from="(220,80)" to="(2130,80)"/>
+    <wire from="(1940,690)" to="(1940,1220)"/>
     <wire from="(890,160)" to="(1080,160)"/>
-    <wire from="(740,480)" to="(740,1060)"/>
     <wire from="(450,300)" to="(450,450)"/>
     <wire from="(400,270)" to="(400,290)"/>
     <wire from="(1530,120)" to="(1910,120)"/>
@@ -430,13 +430,13 @@
     <wire from="(1460,690)" to="(1510,690)"/>
     <wire from="(420,320)" to="(420,410)"/>
     <wire from="(340,220)" to="(380,220)"/>
-    <wire from="(1520,910)" to="(1520,920)"/>
+    <wire from="(1700,690)" to="(1700,1260)"/>
     <wire from="(1140,550)" to="(1220,550)"/>
-    <wire from="(1550,660)" to="(1560,660)"/>
-    <wire from="(1450,920)" to="(1450,970)"/>
+    <wire from="(600,1090)" to="(600,1260)"/>
     <wire from="(410,630)" to="(430,630)"/>
-    <wire from="(20,970)" to="(1450,970)"/>
+    <wire from="(1460,690)" to="(1460,1260)"/>
     <wire from="(380,170)" to="(380,210)"/>
+    <wire from="(1390,870)" to="(1390,1120)"/>
     <wire from="(400,310)" to="(410,310)"/>
     <wire from="(820,840)" to="(1080,840)"/>
     <wire from="(250,560)" to="(260,560)"/>
@@ -445,20 +445,22 @@
     <wire from="(1120,300)" to="(1470,300)"/>
     <wire from="(1040,100)" to="(1040,480)"/>
     <wire from="(460,170)" to="(460,220)"/>
+    <wire from="(160,1140)" to="(1130,1140)"/>
     <wire from="(420,230)" to="(500,230)"/>
     <wire from="(300,170)" to="(300,230)"/>
     <wire from="(1550,420)" to="(1890,420)"/>
     <wire from="(530,360)" to="(540,360)"/>
     <wire from="(560,870)" to="(570,870)"/>
     <wire from="(350,410)" to="(420,410)"/>
-    <comp lib="4" loc="(440,300)" name="Counter">
+    <comp lib="6" loc="(690,678)" name="Text">
+      <a name="text" val="RD"/>
+    </comp>
+    <comp lib="4" loc="(220,330)" name="Counter">
       <a name="width" val="32"/>
       <a name="max" val="0xffffffff"/>
+      <a name="label" val="Cycle"/>
     </comp>
-    <comp loc="(570,130)" name="IF/ID">
-      <a name="labelfont" val="Monaco bold 44"/>
-    </comp>
-    <comp lib="0" loc="(670,540)" name="Splitter">
+    <comp lib="0" loc="(670,240)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -478,11 +480,77 @@
       <a name="bit13" val="none"/>
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="0"/>
+      <a name="bit27" val="0"/>
+      <a name="bit28" val="0"/>
+      <a name="bit29" val="0"/>
+      <a name="bit30" val="0"/>
+      <a name="bit31" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1750,1250)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
+    </comp>
+    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
+    <comp lib="0" loc="(2030,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="3" loc="(470,620)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(1900,1100)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1410,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="0" loc="(2080,450)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(1090,1120)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="6" loc="(1035,833)" name="Text">
+      <a name="text" val="Immediate"/>
+    </comp>
+    <comp lib="0" loc="(670,320)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
       <a name="bit21" val="none"/>
       <a name="bit22" val="none"/>
       <a name="bit23" val="none"/>
@@ -495,18 +563,12 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1520,920)" name="Constant">
+    <comp lib="0" loc="(310,450)" name="Probe">
       <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="J"/>
+      <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="6" loc="(1953,236)" name="Text">
-      <a name="text" val="Ignored"/>
-    </comp>
-    <comp lib="4" loc="(1830,580)" name="RAM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="32"/>
-      <a name="bus" val="separate"/>
-    </comp>
-    <comp loc="(1890,130)" name="MEM/WB"/>
     <comp lib="0" loc="(350,550)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
@@ -544,17 +606,124 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
+    <comp lib="6" loc="(1953,236)" name="Text">
+      <a name="text" val="Ignored"/>
+    </comp>
+    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(480,730)" name="Clock">
-      <a name="facing" val="north"/>
+    <comp lib="12" loc="(950,480)" name="Regfile"/>
+    <comp lib="0" loc="(780,460)" name="Tunnel">
+      <a name="label" val="ZeroExtendID"/>
     </comp>
-    <comp lib="0" loc="(1410,150)" name="Tunnel">
+    <comp lib="2" loc="(1260,540)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(780,440)" name="Tunnel">
+      <a name="label" val="RegDstID"/>
+    </comp>
+    <comp lib="2" loc="(1290,610)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1540,1110)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="6" loc="(1005,1135)" name="Text">
+      <a name="text" val="JR Addr"/>
+    </comp>
+    <comp lib="6" loc="(687,529)" name="Text">
+      <a name="text" val="RT"/>
+    </comp>
+    <comp lib="0" loc="(300,580)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(670,620)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(860,700)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x1f"/>
+    </comp>
+    <comp lib="4" loc="(370,320)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(1510,1250)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="label" val="RegWriteEX"/>
+    </comp>
+    <comp lib="6" loc="(1044,617)" name="Text">
+      <a name="text" val="Shamt"/>
+    </comp>
+    <comp lib="1" loc="(1480,270)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2130,500)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="0" loc="(350,420)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(1454,665)" name="Text">
+      <a name="text" val="WriteDataEX"/>
+    </comp>
+    <comp lib="6" loc="(2028,1191)" name="Text">
+      <a name="text" val="WB_DATA"/>
+    </comp>
+    <comp lib="0" loc="(270,700)" name="Probe">
+      <a name="facing" val="west"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Branch Num"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1780,150)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="RegWriteMEM"/>
     </comp>
     <comp lib="0" loc="(670,840)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -592,35 +761,398 @@
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1750,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(810,750)" name="Constant">
-      <a name="width" val="2"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(410,630)" name="Constant">
-      <a name="width" val="32"/>
-      <a name="value" val="0x4"/>
-    </comp>
     <comp lib="5" loc="(460,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
     </comp>
-    <comp lib="0" loc="(270,700)" name="Probe">
-      <a name="facing" val="west"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Branch Num"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="2" loc="(910,690)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(200,730)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(689,491)" name="Text">
+      <a name="text" val="RS"/>
     </comp>
     <comp lib="11" loc="(780,820)" name="Immediate Extender"/>
-    <comp loc="(1080,130)" name="ID/EX"/>
+    <comp loc="(190,1260)" name="Hazard Unit"/>
+    <comp lib="0" loc="(1310,1150)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="2" loc="(200,550)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(670,760)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="0"/>
+      <a name="bit13" val="0"/>
+      <a name="bit14" val="0"/>
+      <a name="bit15" val="0"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="1" loc="(580,1230)" name="NOT Gate">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(830,680)" name="Multiplexer">
+      <a name="width" val="5"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1670,580)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1760,630)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="2" loc="(1350,620)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="32"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(490,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="6" loc="(1035,755)" name="Text">
+      <a name="text" val="JumpAddr"/>
+    </comp>
+    <comp lib="6" loc="(1040,682)" name="Text">
+      <a name="text" val="WriteReg#"/>
+    </comp>
+    <comp lib="0" loc="(230,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+      <a name="label" val="Total Cycles"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(2030,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="6" loc="(693,306)" name="Text">
+      <a name="text" val="Funct"/>
+    </comp>
     <comp lib="2" loc="(150,540)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(512,867)" name="Text">
+      <a name="text" val="PCPlus4IF"/>
+    </comp>
+    <comp lib="6" loc="(692,230)" name="Text">
+      <a name="text" val="OP"/>
+    </comp>
+    <comp lib="2" loc="(490,680)" name="Multiplexer">
+      <a name="facing" val="north"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(320,550)" name="Register">
+      <a name="width" val="32"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="10" loc="(2060,450)" name="syscall_decoder"/>
+    <comp lib="0" loc="(500,730)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(810,750)" name="Constant">
+      <a name="width" val="2"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="4" loc="(1830,580)" name="RAM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="32"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="13" loc="(1080,130)" name="ID/EX"/>
+    <comp lib="0" loc="(180,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="5" loc="(300,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(1020,620)" name="Bit Extender">
+      <a name="in_width" val="5"/>
+      <a name="out_width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(850,760)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="1"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+      <a name="bit11" val="1"/>
+      <a name="bit12" val="1"/>
+      <a name="bit13" val="1"/>
+      <a name="bit14" val="1"/>
+      <a name="bit15" val="1"/>
+      <a name="bit16" val="1"/>
+      <a name="bit17" val="1"/>
+      <a name="bit18" val="1"/>
+      <a name="bit19" val="1"/>
+      <a name="bit20" val="1"/>
+      <a name="bit21" val="1"/>
+      <a name="bit22" val="1"/>
+      <a name="bit23" val="1"/>
+      <a name="bit24" val="1"/>
+      <a name="bit25" val="1"/>
+      <a name="bit26" val="1"/>
+      <a name="bit27" val="1"/>
+      <a name="bit28" val="2"/>
+      <a name="bit29" val="2"/>
+      <a name="bit30" val="2"/>
+      <a name="bit31" val="2"/>
+    </comp>
+    <comp lib="13" loc="(1890,130)" name="MEM/WB"/>
+    <comp lib="0" loc="(1920,1100)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(480,730)" name="Clock">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="3" loc="(1360,1140)" name="Shifter">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="0" loc="(970,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="v0"/>
+    </comp>
+    <comp lib="4" loc="(440,300)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="4" loc="(220,700)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="1" loc="(1010,470)" name="NOT Gate">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(670,500)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="0"/>
+      <a name="bit22" val="0"/>
+      <a name="bit23" val="0"/>
+      <a name="bit24" val="0"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="0" loc="(380,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="R"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(530,360)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="5"/>
+      <a name="bit1" val="4"/>
+      <a name="bit2" val="3"/>
+      <a name="bit3" val="2"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="0"/>
+    </comp>
+    <comp lib="0" loc="(450,450)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10unsigned"/>
+      <a name="label" val="I"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(800,810)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="ZeroExtendID"/>
+    </comp>
+    <comp lib="13" loc="(1510,140)" name="EX/MEM"/>
+    <comp lib="0" loc="(670,540)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="32"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="0"/>
+      <a name="bit17" val="0"/>
+      <a name="bit18" val="0"/>
+      <a name="bit19" val="0"/>
+      <a name="bit20" val="0"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+      <a name="bit28" val="none"/>
+      <a name="bit29" val="none"/>
+      <a name="bit30" val="none"/>
+      <a name="bit31" val="none"/>
+    </comp>
+    <comp lib="13" loc="(570,130)" name="IF/ID"/>
+    <comp lib="1" loc="(1450,330)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1520,1110)" name="Constant">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="4" loc="(300,330)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="6" loc="(997,1154)" name="Text">
+      <a name="text" val="Jump Addr"/>
+    </comp>
+    <comp lib="6" loc="(1973,684)" name="Text">
+      <a name="text" val="WriteReg#WB"/>
+    </comp>
+    <comp lib="6" loc="(1033,862)" name="Text">
+      <a name="text" val="PCPlus4ID"/>
+    </comp>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="label" val="Halt"/>
+    </comp>
+    <comp lib="6" loc="(1840,685)" name="Text">
+      <a name="text" val="WriteReg#MEM"/>
     </comp>
     <comp lib="4" loc="(520,550)" name="ROM">
       <a name="addrWidth" val="10"/>
@@ -670,245 +1202,6 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
 102020 20020022 c 22100008 102020 20020022 c 3e00008
 </a>
     </comp>
-    <comp lib="0" loc="(780,440)" name="Tunnel">
-      <a name="label" val="RegDstID"/>
-    </comp>
-    <comp lib="3" loc="(1440,920)" name="Adder">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(1760,630)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="6" loc="(1005,925)" name="Text">
-      <a name="text" val="JR Addr"/>
-    </comp>
-    <comp lib="0" loc="(670,620)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="6" loc="(1309,1055)" name="Text">
-      <a name="text" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="10" loc="(2060,450)" name="syscall_decoder"/>
-    <comp lib="6" loc="(1035,833)" name="Text">
-      <a name="text" val="Immediate"/>
-    </comp>
-    <comp lib="2" loc="(1350,620)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(530,360)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="5"/>
-      <a name="bit1" val="4"/>
-      <a name="bit2" val="3"/>
-      <a name="bit3" val="2"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="0"/>
-    </comp>
-    <comp loc="(1510,140)" name="EX/MEM"/>
-    <comp lib="4" loc="(320,550)" name="Register">
-      <a name="width" val="32"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="0" loc="(670,500)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="1" loc="(1480,270)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(414,100)" name="Text">
-      <a name="text" val="Screen"/>
-    </comp>
-    <comp lib="12" loc="(950,480)" name="Regfile"/>
-    <comp lib="6" loc="(693,306)" name="Text">
-      <a name="text" val="Funct"/>
-    </comp>
-    <comp lib="1" loc="(1370,410)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="0" loc="(2030,500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="0" loc="(540,550)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="0"/>
-      <a name="bit27" val="0"/>
-      <a name="bit28" val="0"/>
-      <a name="bit29" val="0"/>
-      <a name="bit30" val="0"/>
-      <a name="bit31" val="0"/>
-    </comp>
-    <comp lib="0" loc="(500,730)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(1450,330)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(200,550)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1920,910)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(350,420)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(2130,500)" name="Tunnel">
-      <a name="label" val="Halt"/>
-    </comp>
-    <comp lib="0" loc="(990,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="a0"/>
-    </comp>
-    <comp lib="1" loc="(580,1030)" name="NOT Gate">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="4" loc="(220,700)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="2" loc="(1260,540)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1900,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="6" loc="(1040,682)" name="Text">
-      <a name="text" val="WriteReg#"/>
-    </comp>
-    <comp lib="6" loc="(689,491)" name="Text">
-      <a name="text" val="RS"/>
-    </comp>
-    <comp lib="2" loc="(1290,610)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(500,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
     <comp lib="0" loc="(660,870)" name="Splitter">
       <a name="facing" val="north"/>
       <a name="fanout" val="1"/>
@@ -947,208 +1240,52 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="0" loc="(450,450)" name="Probe">
+    <comp lib="0" loc="(400,270)" name="Splitter">
       <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="I"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="7" loc="(1410,580)" name="ALU"/>
-    <comp lib="2" loc="(2010,570)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="32"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(370,320)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="0" loc="(670,320)" name="Splitter">
-      <a name="fanout" val="1"/>
+      <a name="fanout" val="8"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
       <a name="bit1" val="0"/>
       <a name="bit2" val="0"/>
       <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+      <a name="bit11" val="2"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+      <a name="bit14" val="3"/>
+      <a name="bit15" val="3"/>
+      <a name="bit16" val="4"/>
+      <a name="bit17" val="4"/>
+      <a name="bit18" val="4"/>
+      <a name="bit19" val="4"/>
+      <a name="bit20" val="5"/>
+      <a name="bit21" val="5"/>
+      <a name="bit22" val="5"/>
+      <a name="bit23" val="5"/>
+      <a name="bit24" val="6"/>
+      <a name="bit25" val="6"/>
+      <a name="bit26" val="6"/>
+      <a name="bit27" val="6"/>
+      <a name="bit28" val="7"/>
+      <a name="bit29" val="7"/>
+      <a name="bit30" val="7"/>
+      <a name="bit31" val="7"/>
     </comp>
-    <comp lib="0" loc="(200,730)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="8" loc="(720,140)" name="Control"/>
-    <comp lib="0" loc="(1540,920)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="6" loc="(1840,685)" name="Text">
-      <a name="text" val="WriteReg#MEM"/>
-    </comp>
-    <comp loc="(190,1060)" name="Hazard Unit"/>
     <comp lib="2" loc="(90,530)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(2030,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="3" loc="(1360,930)" name="Shifter">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(690,678)" name="Text">
-      <a name="text" val="RD"/>
-    </comp>
-    <comp lib="0" loc="(1510,1050)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(970,480)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="32"/>
-      <a name="label" val="v0"/>
-    </comp>
-    <comp lib="1" loc="(1010,470)" name="NOT Gate">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(780,460)" name="Tunnel">
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="1" loc="(290,560)" name="NOT Gate"/>
-    <comp lib="0" loc="(800,810)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="ZeroExtendID"/>
-    </comp>
-    <comp lib="2" loc="(2060,580)" name="Multiplexer">
+    <comp lib="2" loc="(2010,570)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="32"/>
       <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1780,150)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="6" loc="(1454,655)" name="Text">
-      <a name="text" val="WriteDataEX"/>
-    </comp>
-    <comp lib="0" loc="(310,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="J"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1310,940)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(230,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-      <a name="label" val="Total Cycles"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1670,580)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="4" loc="(300,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="6" loc="(1033,862)" name="Text">
-      <a name="text" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="5" loc="(420,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="0" loc="(860,700)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x1f"/>
-    </comp>
-    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="5" loc="(380,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
-    </comp>
-    <comp lib="6" loc="(1973,684)" name="Text">
-      <a name="text" val="WriteReg#WB"/>
-    </comp>
-    <comp lib="0" loc="(1090,910)" name="Constant">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="5" loc="(300,170)" name="Hex Digit Display">
-      <a name="color" val="#7bff00"/>
-      <a name="offcolor" val="#000000"/>
-      <a name="bg" val="#000000"/>
     </comp>
     <comp lib="0" loc="(420,720)" name="Probe">
       <a name="facing" val="south"/>
@@ -1160,74 +1297,48 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="facing" val="south"/>
       <a name="label" val="clk"/>
     </comp>
-    <comp lib="9" loc="(510,350)" name="statistics"/>
-    <comp lib="6" loc="(512,867)" name="Text">
-      <a name="text" val="PCPlus4IF"/>
-    </comp>
-    <comp lib="2" loc="(490,680)" name="Multiplexer">
-      <a name="facing" val="north"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="5" loc="(340,170)" name="Hex Digit Display">
+    <comp lib="5" loc="(260,170)" name="Hex Digit Display">
       <a name="color" val="#7bff00"/>
       <a name="offcolor" val="#000000"/>
       <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="6" loc="(995,1176)" name="Text">
+      <a name="text" val="Branch Addr"/>
+    </comp>
+    <comp lib="5" loc="(540,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="3" loc="(1440,1130)" name="Adder">
+      <a name="width" val="32"/>
+    </comp>
+    <comp lib="8" loc="(720,140)" name="Control"/>
+    <comp lib="0" loc="(990,480)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="32"/>
+      <a name="label" val="a0"/>
+    </comp>
+    <comp lib="0" loc="(410,630)" name="Constant">
+      <a name="width" val="32"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="6" loc="(414,100)" name="Text">
+      <a name="text" val="Screen"/>
     </comp>
     <comp lib="0" loc="(810,710)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="RegDstID"/>
     </comp>
-    <comp lib="2" loc="(910,690)" name="Multiplexer">
+    <comp lib="5" loc="(420,170)" name="Hex Digit Display">
+      <a name="color" val="#7bff00"/>
+      <a name="offcolor" val="#000000"/>
+      <a name="bg" val="#000000"/>
+    </comp>
+    <comp lib="2" loc="(2060,580)" name="Multiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(687,529)" name="Text">
-      <a name="text" val="RT"/>
-    </comp>
-    <comp lib="3" loc="(470,620)" name="Adder">
       <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(670,760)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="0"/>
-      <a name="bit5" val="0"/>
-      <a name="bit6" val="0"/>
-      <a name="bit7" val="0"/>
-      <a name="bit8" val="0"/>
-      <a name="bit9" val="0"/>
-      <a name="bit10" val="0"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="0"/>
-      <a name="bit13" val="0"/>
-      <a name="bit14" val="0"/>
-      <a name="bit15" val="0"/>
-      <a name="bit16" val="0"/>
-      <a name="bit17" val="0"/>
-      <a name="bit18" val="0"/>
-      <a name="bit19" val="0"/>
-      <a name="bit20" val="0"/>
-      <a name="bit21" val="0"/>
-      <a name="bit22" val="0"/>
-      <a name="bit23" val="0"/>
-      <a name="bit24" val="0"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-      <a name="bit28" val="none"/>
-      <a name="bit29" val="none"/>
-      <a name="bit30" val="none"/>
-      <a name="bit31" val="none"/>
-    </comp>
-    <comp lib="0" loc="(300,580)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(670,690)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -1266,70 +1377,10 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="none"/>
       <a name="bit31" val="none"/>
     </comp>
-    <comp lib="0" loc="(1020,620)" name="Bit Extender">
-      <a name="in_width" val="5"/>
-      <a name="out_width" val="32"/>
-    </comp>
-    <comp lib="6" loc="(1035,755)" name="Text">
-      <a name="text" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(400,270)" name="Splitter">
+    <comp lib="7" loc="(1410,580)" name="ALU"/>
+    <comp lib="9" loc="(510,350)" name="statistics"/>
+    <comp lib="0" loc="(540,550)" name="Splitter">
       <a name="facing" val="north"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="0"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="2"/>
-      <a name="bit9" val="2"/>
-      <a name="bit10" val="2"/>
-      <a name="bit11" val="2"/>
-      <a name="bit12" val="3"/>
-      <a name="bit13" val="3"/>
-      <a name="bit14" val="3"/>
-      <a name="bit15" val="3"/>
-      <a name="bit16" val="4"/>
-      <a name="bit17" val="4"/>
-      <a name="bit18" val="4"/>
-      <a name="bit19" val="4"/>
-      <a name="bit20" val="5"/>
-      <a name="bit21" val="5"/>
-      <a name="bit22" val="5"/>
-      <a name="bit23" val="5"/>
-      <a name="bit24" val="6"/>
-      <a name="bit25" val="6"/>
-      <a name="bit26" val="6"/>
-      <a name="bit27" val="6"/>
-      <a name="bit28" val="7"/>
-      <a name="bit29" val="7"/>
-      <a name="bit30" val="7"/>
-      <a name="bit31" val="7"/>
-    </comp>
-    <comp lib="6" loc="(692,230)" name="Text">
-      <a name="text" val="OP"/>
-    </comp>
-    <comp lib="4" loc="(220,330)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-      <a name="label" val="Cycle"/>
-    </comp>
-    <comp lib="6" loc="(997,944)" name="Text">
-      <a name="text" val="Jump Addr"/>
-    </comp>
-    <comp lib="2" loc="(830,680)" name="Multiplexer">
-      <a name="width" val="5"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2080,450)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(670,240)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="32"/>
       <a name="appear" val="center"/>
@@ -1366,1299 +1417,13 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="bit30" val="0"/>
       <a name="bit31" val="0"/>
     </comp>
-    <comp lib="6" loc="(995,966)" name="Text">
-      <a name="text" val="Branch Addr"/>
-    </comp>
-    <comp lib="0" loc="(490,670)" name="Tunnel">
+    <comp lib="1" loc="(1370,410)" name="OR Gate">
       <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(180,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="6" loc="(2028,981)" name="Text">
-      <a name="text" val="WB_DATA"/>
-    </comp>
-    <comp lib="6" loc="(1044,617)" name="Text">
-      <a name="text" val="Shamt"/>
-    </comp>
-    <comp lib="0" loc="(380,450)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10unsigned"/>
-      <a name="label" val="R"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(850,760)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="32"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="1"/>
-      <a name="bit4" val="1"/>
-      <a name="bit5" val="1"/>
-      <a name="bit6" val="1"/>
-      <a name="bit7" val="1"/>
-      <a name="bit8" val="1"/>
-      <a name="bit9" val="1"/>
-      <a name="bit10" val="1"/>
-      <a name="bit11" val="1"/>
-      <a name="bit12" val="1"/>
-      <a name="bit13" val="1"/>
-      <a name="bit14" val="1"/>
-      <a name="bit15" val="1"/>
-      <a name="bit16" val="1"/>
-      <a name="bit17" val="1"/>
-      <a name="bit18" val="1"/>
-      <a name="bit19" val="1"/>
-      <a name="bit20" val="1"/>
-      <a name="bit21" val="1"/>
-      <a name="bit22" val="1"/>
-      <a name="bit23" val="1"/>
-      <a name="bit24" val="1"/>
-      <a name="bit25" val="1"/>
-      <a name="bit26" val="1"/>
-      <a name="bit27" val="1"/>
-      <a name="bit28" val="2"/>
-      <a name="bit29" val="2"/>
-      <a name="bit30" val="2"/>
-      <a name="bit31" val="2"/>
-    </comp>
-  </circuit>
-  <circuit name="IF/ID">
-    <a name="circuit" val="IF/ID"/>
-    <a name="clabel" val="IF/ID"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#83f9ff" height="771" stroke="none" width="41" x="220" y="0"/>
-      <circ-port height="8" pin="310,370" width="8" x="216" y="416"/>
-      <circ-port height="10" pin="410,370" width="10" x="255" y="415"/>
-      <circ-port height="8" pin="160,350" width="8" x="236" y="-4"/>
-      <circ-port height="8" pin="340,590" width="8" x="226" y="766"/>
-      <circ-port height="8" pin="570,350" width="8" x="246" y="766"/>
-      <circ-port height="8" pin="310,470" width="8" x="216" y="736"/>
-      <circ-port height="10" pin="410,470" width="10" x="255" y="735"/>
-      <circ-anchor facing="east" height="6" width="6" x="217" y="-3"/>
-    </appear>
-    <wire from="(340,380)" to="(340,480)"/>
-    <wire from="(160,350)" to="(160,420)"/>
-    <wire from="(160,420)" to="(160,520)"/>
-    <wire from="(380,370)" to="(410,370)"/>
-    <wire from="(380,470)" to="(410,470)"/>
-    <wire from="(340,480)" to="(340,590)"/>
-    <wire from="(570,420)" to="(570,520)"/>
-    <wire from="(570,350)" to="(570,420)"/>
-    <wire from="(340,380)" to="(350,380)"/>
-    <wire from="(340,480)" to="(350,480)"/>
-    <wire from="(160,420)" to="(360,420)"/>
-    <wire from="(160,520)" to="(360,520)"/>
-    <wire from="(360,390)" to="(360,420)"/>
-    <wire from="(360,490)" to="(360,520)"/>
-    <wire from="(370,490)" to="(370,520)"/>
-    <wire from="(370,390)" to="(370,420)"/>
-    <wire from="(310,370)" to="(350,370)"/>
-    <wire from="(310,470)" to="(350,470)"/>
-    <wire from="(370,520)" to="(570,520)"/>
-    <wire from="(370,420)" to="(570,420)"/>
-    <comp lib="0" loc="(410,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4IF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(160,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(380,470)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(310,370)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="InstIF"/>
-    </comp>
-    <comp lib="0" loc="(310,470)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="0" loc="(340,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(570,350)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(410,370)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="InstID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(380,370)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-  </circuit>
-  <circuit name="ID/EX">
-    <a name="circuit" val="ID/EX"/>
-    <a name="clabel" val="ID/EX"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#ffe05d" height="771" stroke="none" width="40" x="111" y="31"/>
-      <circ-port height="8" pin="60,290" width="8" x="126" y="26"/>
-      <circ-port height="8" pin="860,360" width="8" x="106" y="56"/>
-      <circ-port height="8" pin="860,780" width="8" x="106" y="156"/>
-      <circ-port height="8" pin="860,420" width="8" x="106" y="296"/>
-      <circ-port height="8" pin="1180,350" width="8" x="106" y="136"/>
-      <circ-port height="8" pin="860,480" width="8" x="106" y="96"/>
-      <circ-port height="8" pin="1180,410" width="8" x="106" y="236"/>
-      <circ-port height="8" pin="860,540" width="8" x="106" y="76"/>
-      <circ-port height="8" pin="1180,470" width="8" x="106" y="196"/>
-      <circ-port height="8" pin="860,600" width="8" x="106" y="216"/>
-      <circ-port height="8" pin="860,660" width="8" x="106" y="276"/>
-      <circ-port height="8" pin="1180,530" width="8" x="106" y="176"/>
-      <circ-port height="8" pin="860,720" width="8" x="106" y="116"/>
-      <circ-port height="10" pin="920,360" width="10" x="145" y="55"/>
-      <circ-port height="10" pin="930,780" width="10" x="145" y="155"/>
-      <circ-port height="10" pin="930,420" width="10" x="145" y="295"/>
-      <circ-port height="10" pin="1250,350" width="10" x="145" y="135"/>
-      <circ-port height="10" pin="930,480" width="10" x="145" y="95"/>
-      <circ-port height="10" pin="1250,410" width="10" x="145" y="235"/>
-      <circ-port height="10" pin="930,540" width="10" x="145" y="75"/>
-      <circ-port height="10" pin="1250,470" width="10" x="145" y="195"/>
-      <circ-port height="10" pin="930,600" width="10" x="145" y="215"/>
-      <circ-port height="10" pin="930,660" width="10" x="145" y="275"/>
-      <circ-port height="10" pin="1250,530" width="10" x="145" y="175"/>
-      <circ-port height="10" pin="930,720" width="10" x="145" y="115"/>
-      <circ-port height="8" pin="1180,650" width="8" x="106" y="256"/>
-      <circ-port height="10" pin="1240,650" width="10" x="145" y="255"/>
-      <circ-port height="8" pin="1180,710" width="8" x="106" y="586"/>
-      <circ-port height="10" pin="1240,710" width="10" x="145" y="585"/>
-      <circ-port height="8" pin="170,360" width="8" x="106" y="736"/>
-      <circ-port height="10" pin="240,360" width="10" x="145" y="735"/>
-      <circ-port height="8" pin="170,460" width="8" x="106" y="426"/>
-      <circ-port height="10" pin="240,460" width="10" x="145" y="425"/>
-      <circ-port height="8" pin="170,560" width="8" x="106" y="446"/>
-      <circ-port height="10" pin="240,560" width="10" x="145" y="445"/>
-      <circ-port height="8" pin="520,560" width="8" x="106" y="766"/>
-      <circ-port height="10" pin="590,560" width="10" x="145" y="765"/>
-      <circ-port height="8" pin="520,360" width="8" x="106" y="516"/>
-      <circ-port height="10" pin="590,360" width="10" x="145" y="515"/>
-      <circ-port height="8" pin="520,460" width="8" x="106" y="656"/>
-      <circ-port height="10" pin="590,460" width="10" x="145" y="655"/>
-      <circ-port height="8" pin="1180,590" width="8" x="106" y="316"/>
-      <circ-port height="10" pin="1250,590" width="10" x="145" y="315"/>
-      <circ-port height="8" pin="100,290" width="8" x="136" y="796"/>
-      <circ-port height="8" pin="180,640" width="8" x="116" y="796"/>
-      <circ-anchor facing="east" height="6" width="6" x="107" y="27"/>
-    </appear>
-    <wire from="(900,740)" to="(900,750)"/>
-    <wire from="(900,500)" to="(900,510)"/>
-    <wire from="(100,300)" to="(340,300)"/>
-    <wire from="(870,790)" to="(870,820)"/>
-    <wire from="(560,480)" to="(560,510)"/>
-    <wire from="(1210,490)" to="(1210,500)"/>
-    <wire from="(1210,730)" to="(1210,740)"/>
-    <wire from="(760,310)" to="(760,390)"/>
-    <wire from="(910,540)" to="(930,540)"/>
-    <wire from="(910,780)" to="(930,780)"/>
-    <wire from="(1220,680)" to="(1300,680)"/>
-    <wire from="(1220,440)" to="(1300,440)"/>
-    <wire from="(1070,680)" to="(1210,680)"/>
-    <wire from="(570,360)" to="(590,360)"/>
-    <wire from="(1230,710)" to="(1240,710)"/>
-    <wire from="(1070,440)" to="(1210,440)"/>
-    <wire from="(60,410)" to="(60,510)"/>
-    <wire from="(180,370)" to="(180,470)"/>
-    <wire from="(170,360)" to="(190,360)"/>
-    <wire from="(1300,500)" to="(1300,560)"/>
-    <wire from="(870,550)" to="(870,610)"/>
-    <wire from="(870,430)" to="(880,430)"/>
-    <wire from="(870,670)" to="(880,670)"/>
-    <wire from="(1180,410)" to="(1200,410)"/>
-    <wire from="(530,570)" to="(540,570)"/>
-    <wire from="(1180,650)" to="(1200,650)"/>
-    <wire from="(890,380)" to="(890,390)"/>
-    <wire from="(890,620)" to="(890,630)"/>
-    <wire from="(180,630)" to="(180,640)"/>
-    <wire from="(690,300)" to="(980,300)"/>
-    <wire from="(1220,550)" to="(1220,560)"/>
-    <wire from="(210,580)" to="(210,610)"/>
-    <wire from="(860,540)" to="(880,540)"/>
-    <wire from="(860,780)" to="(880,780)"/>
-    <wire from="(520,360)" to="(540,360)"/>
-    <wire from="(1190,480)" to="(1200,480)"/>
-    <wire from="(1190,720)" to="(1200,720)"/>
-    <wire from="(1070,560)" to="(1070,620)"/>
-    <wire from="(530,370)" to="(530,470)"/>
-    <wire from="(1190,360)" to="(1190,420)"/>
-    <wire from="(1190,600)" to="(1190,660)"/>
-    <wire from="(220,460)" to="(240,460)"/>
-    <wire from="(980,630)" to="(980,690)"/>
-    <wire from="(980,390)" to="(980,450)"/>
-    <wire from="(760,510)" to="(890,510)"/>
-    <wire from="(760,750)" to="(890,750)"/>
-    <wire from="(760,570)" to="(760,630)"/>
-    <wire from="(910,360)" to="(920,360)"/>
-    <wire from="(900,570)" to="(980,570)"/>
-    <wire from="(1230,350)" to="(1250,350)"/>
-    <wire from="(1230,590)" to="(1250,590)"/>
-    <wire from="(900,810)" to="(980,810)"/>
-    <wire from="(900,680)" to="(900,690)"/>
-    <wire from="(900,440)" to="(900,450)"/>
-    <wire from="(870,820)" to="(1190,820)"/>
-    <wire from="(560,580)" to="(560,610)"/>
-    <wire from="(1210,670)" to="(1210,680)"/>
-    <wire from="(1210,430)" to="(1210,440)"/>
-    <wire from="(200,380)" to="(200,410)"/>
-    <wire from="(180,630)" to="(530,630)"/>
-    <wire from="(910,480)" to="(930,480)"/>
-    <wire from="(910,720)" to="(930,720)"/>
-    <wire from="(1220,620)" to="(1300,620)"/>
-    <wire from="(1220,380)" to="(1300,380)"/>
-    <wire from="(1070,380)" to="(1210,380)"/>
-    <wire from="(570,460)" to="(590,460)"/>
-    <wire from="(1230,650)" to="(1240,650)"/>
-    <wire from="(1070,620)" to="(1210,620)"/>
-    <wire from="(60,510)" to="(60,610)"/>
-    <wire from="(180,470)" to="(180,570)"/>
-    <wire from="(1300,680)" to="(1300,740)"/>
-    <wire from="(170,460)" to="(190,460)"/>
-    <wire from="(1300,440)" to="(1300,500)"/>
-    <wire from="(870,490)" to="(870,550)"/>
-    <wire from="(870,730)" to="(870,790)"/>
-    <wire from="(60,410)" to="(200,410)"/>
-    <wire from="(870,370)" to="(880,370)"/>
-    <wire from="(870,610)" to="(880,610)"/>
-    <wire from="(210,410)" to="(340,410)"/>
-    <wire from="(1180,350)" to="(1200,350)"/>
-    <wire from="(1180,590)" to="(1200,590)"/>
-    <wire from="(890,560)" to="(890,570)"/>
-    <wire from="(890,800)" to="(890,810)"/>
-    <wire from="(370,410)" to="(550,410)"/>
-    <wire from="(60,310)" to="(370,310)"/>
-    <wire from="(60,290)" to="(60,310)"/>
-    <wire from="(550,380)" to="(550,410)"/>
-    <wire from="(1220,730)" to="(1220,740)"/>
-    <wire from="(1220,490)" to="(1220,500)"/>
-    <wire from="(860,480)" to="(880,480)"/>
-    <wire from="(860,720)" to="(880,720)"/>
-    <wire from="(370,310)" to="(370,410)"/>
-    <wire from="(520,460)" to="(540,460)"/>
-    <wire from="(1190,420)" to="(1200,420)"/>
-    <wire from="(1190,660)" to="(1200,660)"/>
-    <wire from="(1070,500)" to="(1070,560)"/>
-    <wire from="(530,470)" to="(530,570)"/>
-    <wire from="(1190,540)" to="(1190,600)"/>
-    <wire from="(220,560)" to="(240,560)"/>
-    <wire from="(980,570)" to="(980,630)"/>
-    <wire from="(180,370)" to="(190,370)"/>
-    <wire from="(760,450)" to="(890,450)"/>
-    <wire from="(760,690)" to="(890,690)"/>
-    <wire from="(560,410)" to="(690,410)"/>
-    <wire from="(760,510)" to="(760,570)"/>
-    <wire from="(760,750)" to="(760,810)"/>
-    <wire from="(900,510)" to="(980,510)"/>
-    <wire from="(1230,530)" to="(1250,530)"/>
-    <wire from="(900,750)" to="(980,750)"/>
-    <wire from="(180,570)" to="(180,630)"/>
-    <wire from="(900,620)" to="(900,630)"/>
-    <wire from="(900,380)" to="(900,390)"/>
-    <wire from="(1210,610)" to="(1210,620)"/>
-    <wire from="(1210,370)" to="(1210,380)"/>
-    <wire from="(200,480)" to="(200,510)"/>
-    <wire from="(910,420)" to="(930,420)"/>
-    <wire from="(340,410)" to="(340,510)"/>
-    <wire from="(910,660)" to="(930,660)"/>
-    <wire from="(1220,560)" to="(1300,560)"/>
-    <wire from="(570,560)" to="(590,560)"/>
-    <wire from="(1070,560)" to="(1210,560)"/>
-    <wire from="(530,630)" to="(750,630)"/>
-    <wire from="(170,560)" to="(190,560)"/>
-    <wire from="(1300,620)" to="(1300,680)"/>
-    <wire from="(1300,380)" to="(1300,440)"/>
-    <wire from="(870,430)" to="(870,490)"/>
-    <wire from="(870,670)" to="(870,730)"/>
-    <wire from="(530,570)" to="(530,630)"/>
-    <wire from="(60,510)" to="(200,510)"/>
-    <wire from="(870,550)" to="(880,550)"/>
-    <wire from="(870,790)" to="(880,790)"/>
-    <wire from="(210,510)" to="(340,510)"/>
-    <wire from="(1180,530)" to="(1200,530)"/>
-    <wire from="(530,370)" to="(540,370)"/>
-    <wire from="(760,310)" to="(1070,310)"/>
-    <wire from="(1300,300)" to="(1300,380)"/>
-    <wire from="(750,820)" to="(870,820)"/>
-    <wire from="(890,500)" to="(890,510)"/>
-    <wire from="(890,740)" to="(890,750)"/>
-    <wire from="(370,510)" to="(550,510)"/>
-    <wire from="(980,300)" to="(980,390)"/>
-    <wire from="(550,480)" to="(550,510)"/>
-    <wire from="(1070,310)" to="(1070,380)"/>
-    <wire from="(1220,670)" to="(1220,680)"/>
-    <wire from="(1220,430)" to="(1220,440)"/>
-    <wire from="(210,380)" to="(210,410)"/>
-    <wire from="(860,420)" to="(880,420)"/>
-    <wire from="(370,410)" to="(370,510)"/>
-    <wire from="(860,660)" to="(880,660)"/>
-    <wire from="(520,560)" to="(540,560)"/>
-    <wire from="(1190,360)" to="(1200,360)"/>
-    <wire from="(1190,600)" to="(1200,600)"/>
-    <wire from="(340,300)" to="(690,300)"/>
-    <wire from="(340,300)" to="(340,410)"/>
-    <wire from="(1070,440)" to="(1070,500)"/>
-    <wire from="(1070,680)" to="(1070,740)"/>
-    <wire from="(690,410)" to="(690,510)"/>
-    <wire from="(1190,480)" to="(1190,540)"/>
-    <wire from="(980,750)" to="(980,810)"/>
-    <wire from="(980,510)" to="(980,570)"/>
-    <wire from="(180,470)" to="(190,470)"/>
-    <wire from="(760,390)" to="(890,390)"/>
-    <wire from="(760,630)" to="(890,630)"/>
-    <wire from="(560,510)" to="(690,510)"/>
-    <wire from="(760,450)" to="(760,510)"/>
-    <wire from="(760,690)" to="(760,750)"/>
-    <wire from="(900,690)" to="(980,690)"/>
-    <wire from="(900,450)" to="(980,450)"/>
-    <wire from="(1230,470)" to="(1250,470)"/>
-    <wire from="(900,800)" to="(900,810)"/>
-    <wire from="(900,560)" to="(900,570)"/>
-    <wire from="(560,380)" to="(560,410)"/>
-    <wire from="(1210,550)" to="(1210,560)"/>
-    <wire from="(200,580)" to="(200,610)"/>
-    <wire from="(340,510)" to="(340,610)"/>
-    <wire from="(910,600)" to="(930,600)"/>
-    <wire from="(1220,740)" to="(1300,740)"/>
-    <wire from="(1220,500)" to="(1300,500)"/>
-    <wire from="(690,300)" to="(690,410)"/>
-    <wire from="(1070,500)" to="(1210,500)"/>
-    <wire from="(1070,740)" to="(1210,740)"/>
-    <wire from="(60,310)" to="(60,410)"/>
-    <wire from="(1300,560)" to="(1300,620)"/>
-    <wire from="(870,370)" to="(870,430)"/>
-    <wire from="(870,610)" to="(870,670)"/>
-    <wire from="(60,610)" to="(200,610)"/>
-    <wire from="(750,630)" to="(750,820)"/>
-    <wire from="(1190,720)" to="(1190,820)"/>
-    <wire from="(870,490)" to="(880,490)"/>
-    <wire from="(870,730)" to="(880,730)"/>
-    <wire from="(210,610)" to="(340,610)"/>
-    <wire from="(1180,470)" to="(1200,470)"/>
-    <wire from="(530,470)" to="(540,470)"/>
-    <wire from="(1180,710)" to="(1200,710)"/>
-    <wire from="(370,310)" to="(760,310)"/>
-    <wire from="(890,440)" to="(890,450)"/>
-    <wire from="(890,680)" to="(890,690)"/>
-    <wire from="(370,610)" to="(550,610)"/>
-    <wire from="(100,290)" to="(100,300)"/>
-    <wire from="(980,300)" to="(1300,300)"/>
-    <wire from="(550,580)" to="(550,610)"/>
-    <wire from="(1220,610)" to="(1220,620)"/>
-    <wire from="(1220,370)" to="(1220,380)"/>
-    <wire from="(210,480)" to="(210,510)"/>
-    <wire from="(370,510)" to="(370,610)"/>
-    <wire from="(860,360)" to="(880,360)"/>
-    <wire from="(860,600)" to="(880,600)"/>
-    <wire from="(1190,540)" to="(1200,540)"/>
-    <wire from="(1070,620)" to="(1070,680)"/>
-    <wire from="(1070,380)" to="(1070,440)"/>
-    <wire from="(690,510)" to="(690,610)"/>
-    <wire from="(1190,420)" to="(1190,480)"/>
-    <wire from="(1190,660)" to="(1190,720)"/>
-    <wire from="(220,360)" to="(240,360)"/>
-    <wire from="(980,690)" to="(980,750)"/>
-    <wire from="(980,450)" to="(980,510)"/>
-    <wire from="(760,570)" to="(890,570)"/>
-    <wire from="(760,810)" to="(890,810)"/>
-    <wire from="(180,570)" to="(190,570)"/>
-    <wire from="(560,610)" to="(690,610)"/>
-    <wire from="(760,390)" to="(760,450)"/>
-    <wire from="(760,630)" to="(760,690)"/>
-    <wire from="(900,630)" to="(980,630)"/>
-    <wire from="(900,390)" to="(980,390)"/>
-    <wire from="(1230,410)" to="(1250,410)"/>
-    <comp lib="0" loc="(860,780)" name="Pin">
-      <a name="label" val="MemReadID"/>
-    </comp>
-    <comp lib="4" loc="(910,360)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(100,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1250,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJREX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,480)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(930,480)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,590)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(930,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,530)" name="Pin">
-      <a name="label" val="IsJRID"/>
-    </comp>
-    <comp lib="0" loc="(170,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ImmID"/>
-    </comp>
-    <comp lib="0" loc="(860,480)" name="Pin">
-      <a name="label" val="MemtoRegID"/>
-    </comp>
-    <comp lib="4" loc="(910,720)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(180,640)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(860,600)" name="Pin">
-      <a name="label" val="BneOrBeqID"/>
-    </comp>
-    <comp lib="4" loc="(1230,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,660)" name="Pin">
-      <a name="label" val="ALUSrcID"/>
-    </comp>
-    <comp lib="0" loc="(860,720)" name="Pin">
-      <a name="label" val="IsExceptionID"/>
-    </comp>
-    <comp lib="4" loc="(1230,710)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(520,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="JumpAddr"/>
-    </comp>
-    <comp lib="0" loc="(1180,590)" name="Pin">
-      <a name="label" val="IsSyscallID"/>
-    </comp>
-    <comp lib="0" loc="(1180,470)" name="Pin">
-      <a name="label" val="BranchID"/>
-    </comp>
-    <comp lib="4" loc="(570,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(240,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R1EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(60,290)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1240,710)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,590)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BranchEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(220,560)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(930,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,460)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R1ID"/>
-    </comp>
-    <comp lib="4" loc="(570,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(930,420)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="PCPlusEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="R2ID"/>
-    </comp>
-    <comp lib="0" loc="(1180,710)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#ID"/>
-    </comp>
-    <comp lib="0" loc="(930,660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ALUSrcEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(920,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1240,650)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(930,780)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,780)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(570,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(910,600)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(910,420)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,540)" name="Pin">
-      <a name="label" val="RegWriteID"/>
-    </comp>
-    <comp lib="4" loc="(1230,530)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(240,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="R2EX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(930,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="BneOrBeqEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(860,420)" name="Pin">
-      <a name="label" val="IsShamtID"/>
-    </comp>
-    <comp lib="4" loc="(220,360)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(590,460)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(1230,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(520,560)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="PCPlus4ID"/>
-    </comp>
-    <comp lib="0" loc="(1180,650)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="label" val="ALUopID"/>
-    </comp>
-    <comp lib="4" loc="(910,660)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(860,360)" name="Pin">
-      <a name="label" val="IsJALID"/>
-    </comp>
-    <comp lib="0" loc="(1180,410)" name="Pin">
-      <a name="label" val="JumpID"/>
-    </comp>
-    <comp lib="0" loc="(1250,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="JumpEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(590,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ShamtEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1180,350)" name="Pin">
-      <a name="label" val="MemWriteID"/>
-    </comp>
-    <comp lib="4" loc="(220,460)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(240,360)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ImmEX"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(910,540)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(1230,650)" name="Register">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(520,360)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ShamtID"/>
-    </comp>
-  </circuit>
-  <circuit name="EX/MEM">
-    <a name="circuit" val="EX/MEM"/>
-    <a name="clabel" val="EX/MEM"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#ff8045" height="771" stroke="none" width="40" x="50" y="49"/>
-      <circ-port height="8" pin="430,350" width="8" x="46" y="166"/>
-      <circ-port height="10" pin="500,350" width="10" x="85" y="165"/>
-      <circ-port height="8" pin="430,410" width="8" x="46" y="146"/>
-      <circ-port height="10" pin="500,410" width="10" x="85" y="145"/>
-      <circ-port height="8" pin="430,290" width="8" x="46" y="126"/>
-      <circ-port height="10" pin="500,290" width="10" x="85" y="125"/>
-      <circ-port height="8" pin="430,110" width="8" x="46" y="66"/>
-      <circ-port height="10" pin="500,110" width="10" x="85" y="65"/>
-      <circ-port height="8" pin="430,230" width="8" x="46" y="86"/>
-      <circ-port height="10" pin="500,230" width="10" x="85" y="85"/>
-      <circ-port height="8" pin="430,170" width="8" x="46" y="106"/>
-      <circ-port height="10" pin="500,170" width="10" x="85" y="105"/>
-      <circ-port height="8" pin="300,60" width="8" x="66" y="46"/>
-      <circ-port height="8" pin="430,470" width="8" x="46" y="326"/>
-      <circ-port height="10" pin="500,470" width="10" x="85" y="325"/>
-      <circ-port height="8" pin="820,140" width="8" x="46" y="486"/>
-      <circ-port height="10" pin="890,140" width="10" x="85" y="485"/>
-      <circ-port height="8" pin="820,240" width="8" x="46" y="566"/>
-      <circ-port height="10" pin="890,240" width="10" x="85" y="565"/>
-      <circ-port height="8" pin="820,340" width="8" x="46" y="776"/>
-      <circ-port height="10" pin="890,340" width="10" x="85" y="775"/>
-      <circ-port height="8" pin="430,530" width="8" x="46" y="596"/>
-      <circ-port height="10" pin="500,530" width="10" x="85" y="595"/>
-      <circ-port height="8" pin="350,60" width="8" x="76" y="816"/>
-      <circ-port height="8" pin="440,590" width="8" x="56" y="816"/>
-      <circ-anchor facing="east" height="6" width="6" x="47" y="47"/>
-    </appear>
-    <wire from="(470,550)" to="(470,560)"/>
-    <wire from="(470,430)" to="(470,440)"/>
-    <wire from="(470,310)" to="(470,320)"/>
-    <wire from="(470,190)" to="(470,200)"/>
-    <wire from="(560,70)" to="(560,140)"/>
-    <wire from="(300,60)" to="(300,80)"/>
-    <wire from="(860,260)" to="(860,290)"/>
-    <wire from="(470,560)" to="(560,560)"/>
-    <wire from="(470,440)" to="(560,440)"/>
-    <wire from="(870,140)" to="(890,140)"/>
-    <wire from="(870,340)" to="(890,340)"/>
-    <wire from="(470,320)" to="(560,320)"/>
-    <wire from="(470,200)" to="(560,200)"/>
-    <wire from="(640,190)" to="(850,190)"/>
-    <wire from="(640,390)" to="(850,390)"/>
-    <wire from="(980,290)" to="(980,390)"/>
-    <wire from="(480,110)" to="(500,110)"/>
-    <wire from="(480,230)" to="(500,230)"/>
-    <wire from="(480,350)" to="(500,350)"/>
-    <wire from="(480,470)" to="(500,470)"/>
-    <wire from="(640,190)" to="(640,290)"/>
-    <wire from="(440,120)" to="(450,120)"/>
-    <wire from="(440,240)" to="(450,240)"/>
-    <wire from="(440,360)" to="(450,360)"/>
-    <wire from="(440,480)" to="(450,480)"/>
-    <wire from="(560,440)" to="(560,500)"/>
-    <wire from="(560,320)" to="(560,380)"/>
-    <wire from="(560,200)" to="(560,260)"/>
-    <wire from="(300,500)" to="(300,560)"/>
-    <wire from="(300,380)" to="(300,440)"/>
-    <wire from="(300,260)" to="(300,320)"/>
-    <wire from="(300,140)" to="(300,200)"/>
-    <wire from="(440,240)" to="(440,300)"/>
-    <wire from="(440,120)" to="(440,180)"/>
-    <wire from="(440,360)" to="(440,420)"/>
-    <wire from="(440,480)" to="(440,540)"/>
-    <wire from="(830,150)" to="(840,150)"/>
-    <wire from="(830,350)" to="(840,350)"/>
-    <wire from="(860,290)" to="(980,290)"/>
-    <wire from="(460,550)" to="(460,560)"/>
-    <wire from="(460,430)" to="(460,440)"/>
-    <wire from="(460,310)" to="(460,320)"/>
-    <wire from="(460,190)" to="(460,200)"/>
-    <wire from="(850,260)" to="(850,290)"/>
-    <wire from="(820,140)" to="(840,140)"/>
-    <wire from="(820,340)" to="(840,340)"/>
-    <wire from="(300,380)" to="(460,380)"/>
-    <wire from="(300,500)" to="(460,500)"/>
-    <wire from="(300,260)" to="(460,260)"/>
-    <wire from="(300,140)" to="(460,140)"/>
-    <wire from="(640,80)" to="(640,190)"/>
-    <wire from="(830,150)" to="(830,250)"/>
-    <wire from="(430,110)" to="(450,110)"/>
-    <wire from="(430,230)" to="(450,230)"/>
-    <wire from="(430,350)" to="(450,350)"/>
-    <wire from="(430,470)" to="(450,470)"/>
-    <wire from="(350,70)" to="(560,70)"/>
-    <wire from="(440,580)" to="(440,590)"/>
-    <wire from="(470,490)" to="(470,500)"/>
-    <wire from="(470,370)" to="(470,380)"/>
-    <wire from="(470,250)" to="(470,260)"/>
-    <wire from="(470,130)" to="(470,140)"/>
-    <wire from="(860,360)" to="(860,390)"/>
-    <wire from="(860,160)" to="(860,190)"/>
-    <wire from="(560,70)" to="(980,70)"/>
-    <wire from="(470,380)" to="(560,380)"/>
-    <wire from="(470,260)" to="(560,260)"/>
-    <wire from="(470,500)" to="(560,500)"/>
-    <wire from="(470,140)" to="(560,140)"/>
-    <wire from="(870,240)" to="(890,240)"/>
-    <wire from="(640,290)" to="(850,290)"/>
-    <wire from="(300,80)" to="(640,80)"/>
-    <wire from="(980,190)" to="(980,290)"/>
-    <wire from="(480,290)" to="(500,290)"/>
-    <wire from="(480,170)" to="(500,170)"/>
-    <wire from="(480,410)" to="(500,410)"/>
-    <wire from="(480,530)" to="(500,530)"/>
-    <wire from="(640,290)" to="(640,390)"/>
-    <wire from="(440,540)" to="(440,580)"/>
-    <wire from="(440,180)" to="(450,180)"/>
-    <wire from="(440,300)" to="(450,300)"/>
-    <wire from="(440,420)" to="(450,420)"/>
-    <wire from="(440,540)" to="(450,540)"/>
-    <wire from="(560,500)" to="(560,560)"/>
-    <wire from="(560,380)" to="(560,440)"/>
-    <wire from="(560,260)" to="(560,320)"/>
-    <wire from="(560,140)" to="(560,200)"/>
-    <wire from="(980,70)" to="(980,190)"/>
-    <wire from="(300,440)" to="(300,500)"/>
-    <wire from="(300,320)" to="(300,380)"/>
-    <wire from="(300,200)" to="(300,260)"/>
-    <wire from="(300,80)" to="(300,140)"/>
-    <wire from="(440,300)" to="(440,360)"/>
-    <wire from="(440,420)" to="(440,480)"/>
-    <wire from="(830,250)" to="(840,250)"/>
-    <wire from="(440,180)" to="(440,240)"/>
-    <wire from="(440,580)" to="(830,580)"/>
-    <wire from="(860,390)" to="(980,390)"/>
-    <wire from="(860,190)" to="(980,190)"/>
-    <wire from="(460,370)" to="(460,380)"/>
-    <wire from="(460,490)" to="(460,500)"/>
-    <wire from="(460,250)" to="(460,260)"/>
-    <wire from="(460,130)" to="(460,140)"/>
-    <wire from="(350,60)" to="(350,70)"/>
-    <wire from="(850,160)" to="(850,190)"/>
-    <wire from="(850,360)" to="(850,390)"/>
-    <wire from="(820,240)" to="(840,240)"/>
-    <wire from="(300,440)" to="(460,440)"/>
-    <wire from="(300,560)" to="(460,560)"/>
-    <wire from="(300,320)" to="(460,320)"/>
-    <wire from="(300,200)" to="(460,200)"/>
-    <wire from="(830,250)" to="(830,350)"/>
-    <wire from="(430,170)" to="(450,170)"/>
-    <wire from="(430,290)" to="(450,290)"/>
-    <wire from="(430,530)" to="(450,530)"/>
-    <wire from="(430,410)" to="(450,410)"/>
-    <wire from="(830,350)" to="(830,580)"/>
-    <comp lib="0" loc="(890,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,470)" name="Pin">
-      <a name="label" val="IsSyscallEX"/>
-    </comp>
-    <comp lib="4" loc="(870,340)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(890,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(480,530)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(430,530)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="0" loc="(500,410)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,230)" name="Pin">
-      <a name="label" val="RegWriteEX"/>
-    </comp>
-    <comp lib="0" loc="(430,170)" name="Pin">
-      <a name="label" val="MemtoRegEX"/>
-    </comp>
-    <comp lib="4" loc="(480,350)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemReadMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,290)" name="Pin">
-      <a name="label" val="IsExceptionEX"/>
-    </comp>
-    <comp lib="4" loc="(480,110)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,140)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultEX"/>
-    </comp>
-    <comp lib="4" loc="(480,290)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,240)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="WriteDataEX"/>
-    </comp>
-    <comp lib="0" loc="(500,230)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,110)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(440,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="4" loc="(480,230)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(820,340)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrEX"/>
-    </comp>
-    <comp lib="4" loc="(480,410)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(480,470)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,350)" name="Pin">
-      <a name="label" val="MemReadEX"/>
-    </comp>
-    <comp lib="0" loc="(430,110)" name="Pin">
-      <a name="label" val="IsJALEX"/>
-    </comp>
-    <comp lib="0" loc="(500,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#MEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(890,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(350,60)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(430,410)" name="Pin">
-      <a name="label" val="MemWriteEX"/>
-    </comp>
-    <comp lib="4" loc="(870,240)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(870,140)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(480,170)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(500,170)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegMEM"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-  </circuit>
-  <circuit name="MEM/WB">
-    <a name="circuit" val="MEM/WB"/>
-    <a name="clabel" val="MEM/WBN"/>
-    <a name="clabelup" val="east"/>
-    <a name="clabelfont" val="Dialog plain 32"/>
-    <appear>
-      <rect fill="#d075ff" height="771" stroke="none" width="40" x="160" y="61"/>
-      <circ-port height="8" pin="360,260" width="8" x="156" y="86"/>
-      <circ-port height="8" pin="250,180" width="8" x="176" y="56"/>
-      <circ-port height="8" pin="360,320" width="8" x="156" y="126"/>
-      <circ-port height="8" pin="360,380" width="8" x="156" y="106"/>
-      <circ-port height="8" pin="360,440" width="8" x="156" y="146"/>
-      <circ-port height="10" pin="430,260" width="10" x="195" y="85"/>
-      <circ-port height="10" pin="430,320" width="10" x="195" y="125"/>
-      <circ-port height="10" pin="430,380" width="10" x="195" y="105"/>
-      <circ-port height="10" pin="430,440" width="10" x="195" y="145"/>
-      <circ-port height="8" pin="720,290" width="8" x="156" y="446"/>
-      <circ-port height="10" pin="790,290" width="10" x="195" y="445"/>
-      <circ-port height="8" pin="720,500" width="8" x="156" y="506"/>
-      <circ-port height="10" pin="790,500" width="10" x="195" y="505"/>
-      <circ-port height="8" pin="720,390" width="8" x="156" y="796"/>
-      <circ-port height="10" pin="790,390" width="10" x="195" y="795"/>
-      <circ-port height="8" pin="360,560" width="8" x="156" y="616"/>
-      <circ-port height="10" pin="430,560" width="10" x="195" y="615"/>
-      <circ-port height="8" pin="360,500" width="8" x="156" y="346"/>
-      <circ-port height="10" pin="430,500" width="10" x="195" y="345"/>
-      <circ-port height="8" pin="290,180" width="8" x="186" y="826"/>
-      <circ-port height="8" pin="370,620" width="8" x="166" y="826"/>
-      <circ-anchor facing="east" height="6" width="6" x="157" y="57"/>
-    </appear>
-    <wire from="(400,520)" to="(400,530)"/>
-    <wire from="(400,400)" to="(400,410)"/>
-    <wire from="(400,280)" to="(400,290)"/>
-    <wire from="(370,610)" to="(370,620)"/>
-    <wire from="(750,310)" to="(750,340)"/>
-    <wire from="(760,520)" to="(760,550)"/>
-    <wire from="(250,210)" to="(540,210)"/>
-    <wire from="(490,200)" to="(490,290)"/>
-    <wire from="(400,530)" to="(490,530)"/>
-    <wire from="(400,410)" to="(490,410)"/>
-    <wire from="(400,290)" to="(490,290)"/>
-    <wire from="(910,340)" to="(910,450)"/>
-    <wire from="(730,400)" to="(730,510)"/>
-    <wire from="(540,450)" to="(750,450)"/>
-    <wire from="(720,390)" to="(740,390)"/>
-    <wire from="(410,320)" to="(430,320)"/>
-    <wire from="(410,440)" to="(430,440)"/>
-    <wire from="(410,560)" to="(430,560)"/>
-    <wire from="(540,450)" to="(540,550)"/>
-    <wire from="(370,570)" to="(370,610)"/>
-    <wire from="(370,330)" to="(380,330)"/>
-    <wire from="(370,450)" to="(380,450)"/>
-    <wire from="(370,570)" to="(380,570)"/>
-    <wire from="(250,530)" to="(250,590)"/>
-    <wire from="(370,330)" to="(370,390)"/>
-    <wire from="(370,450)" to="(370,510)"/>
-    <wire from="(490,530)" to="(490,590)"/>
-    <wire from="(490,410)" to="(490,470)"/>
-    <wire from="(490,290)" to="(490,350)"/>
-    <wire from="(250,410)" to="(250,470)"/>
-    <wire from="(250,290)" to="(250,350)"/>
-    <wire from="(540,210)" to="(540,340)"/>
-    <wire from="(390,520)" to="(390,530)"/>
-    <wire from="(390,400)" to="(390,410)"/>
-    <wire from="(390,280)" to="(390,290)"/>
-    <wire from="(290,180)" to="(290,200)"/>
-    <wire from="(250,210)" to="(250,290)"/>
-    <wire from="(750,520)" to="(750,550)"/>
-    <wire from="(250,180)" to="(250,210)"/>
-    <wire from="(760,450)" to="(910,450)"/>
-    <wire from="(760,410)" to="(760,450)"/>
-    <wire from="(540,340)" to="(750,340)"/>
-    <wire from="(540,340)" to="(540,450)"/>
-    <wire from="(770,290)" to="(790,290)"/>
-    <wire from="(360,320)" to="(380,320)"/>
-    <wire from="(360,560)" to="(380,560)"/>
-    <wire from="(360,440)" to="(380,440)"/>
-    <wire from="(250,590)" to="(390,590)"/>
-    <wire from="(250,470)" to="(390,470)"/>
-    <wire from="(250,350)" to="(390,350)"/>
-    <wire from="(730,300)" to="(740,300)"/>
-    <wire from="(400,580)" to="(400,590)"/>
-    <wire from="(400,460)" to="(400,470)"/>
-    <wire from="(400,340)" to="(400,350)"/>
-    <wire from="(490,200)" to="(910,200)"/>
-    <wire from="(370,610)" to="(730,610)"/>
-    <wire from="(400,590)" to="(490,590)"/>
-    <wire from="(400,470)" to="(490,470)"/>
-    <wire from="(400,350)" to="(490,350)"/>
-    <wire from="(760,340)" to="(910,340)"/>
-    <wire from="(750,410)" to="(750,450)"/>
-    <wire from="(540,550)" to="(750,550)"/>
-    <wire from="(720,290)" to="(740,290)"/>
-    <wire from="(770,500)" to="(790,500)"/>
-    <wire from="(410,260)" to="(430,260)"/>
-    <wire from="(410,380)" to="(430,380)"/>
-    <wire from="(410,500)" to="(430,500)"/>
-    <wire from="(730,300)" to="(730,400)"/>
-    <wire from="(370,270)" to="(380,270)"/>
-    <wire from="(370,390)" to="(380,390)"/>
-    <wire from="(370,510)" to="(380,510)"/>
-    <wire from="(250,470)" to="(250,530)"/>
-    <wire from="(370,270)" to="(370,330)"/>
-    <wire from="(370,390)" to="(370,450)"/>
-    <wire from="(370,510)" to="(370,570)"/>
-    <wire from="(490,470)" to="(490,530)"/>
-    <wire from="(490,350)" to="(490,410)"/>
-    <wire from="(730,510)" to="(740,510)"/>
-    <wire from="(250,350)" to="(250,410)"/>
-    <wire from="(910,200)" to="(910,340)"/>
-    <wire from="(390,580)" to="(390,590)"/>
-    <wire from="(390,460)" to="(390,470)"/>
-    <wire from="(390,340)" to="(390,350)"/>
-    <wire from="(760,310)" to="(760,340)"/>
-    <wire from="(760,550)" to="(910,550)"/>
-    <wire from="(770,390)" to="(790,390)"/>
-    <wire from="(720,500)" to="(740,500)"/>
-    <wire from="(360,260)" to="(380,260)"/>
-    <wire from="(360,380)" to="(380,380)"/>
-    <wire from="(360,500)" to="(380,500)"/>
-    <wire from="(910,450)" to="(910,550)"/>
-    <wire from="(730,510)" to="(730,610)"/>
-    <wire from="(250,530)" to="(390,530)"/>
-    <wire from="(250,410)" to="(390,410)"/>
-    <wire from="(250,290)" to="(390,290)"/>
-    <wire from="(290,200)" to="(490,200)"/>
-    <wire from="(730,400)" to="(740,400)"/>
-    <comp lib="4" loc="(410,560)" name="Register">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(250,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(790,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsSyscallWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,440)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(410,260)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(430,260)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsJALWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(790,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,380)" name="Pin">
-      <a name="label" val="RegWriteMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,260)" name="Pin">
-      <a name="label" val="IsJALMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IsExceptionWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(410,500)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="4" loc="(770,500)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(290,180)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="4" loc="(410,380)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,440)" name="Pin">
-      <a name="label" val="IsExceptionMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="5"/>
-      <a name="label" val="WriteReg#WB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,390)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataMEM"/>
-    </comp>
-    <comp lib="0" loc="(370,620)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="En"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(720,290)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="ALUResultMEM"/>
-    </comp>
-    <comp lib="4" loc="(770,290)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="0" loc="(720,500)" name="Pin">
-      <a name="width" val="32"/>
-      <a name="label" val="JumpAddrMEM"/>
-    </comp>
-    <comp lib="0" loc="(360,500)" name="Pin">
-      <a name="label" val="IsSyscallMEM"/>
-    </comp>
-    <comp lib="0" loc="(430,380)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="RegWriteWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(430,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="MemtoRegWB"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(770,390)" name="Register">
-      <a name="width" val="32"/>
-    </comp>
-    <comp lib="4" loc="(410,320)" name="Register">
-      <a name="width" val="1"/>
-    </comp>
-    <comp lib="0" loc="(360,560)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="label" val="MemtoRegMEM"/>
-    </comp>
-    <comp lib="0" loc="(790,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="32"/>
-      <a name="label" val="ReadDataWB"/>
-      <a name="labelloc" val="east"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="6" loc="(1309,1255)" name="Text">
+      <a name="text" val="IsToBranchOrJump"/>
     </comp>
   </circuit>
   <circuit name="Hazard Unit">
@@ -2781,38 +1546,22 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(600,390)" to="(610,390)"/>
     <wire from="(600,470)" to="(610,470)"/>
     <wire from="(600,510)" to="(610,510)"/>
-    <comp lib="0" loc="(820,310)" name="Pin">
+    <comp lib="0" loc="(540,270)" name="Pin">
+      <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="RegWriteMEM"/>
+      <a name="label" val="ReadRt"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
-    <comp lib="1" loc="(740,450)" name="AND Gate">
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(320,340)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#MEM"/>
     </comp>
-    <comp lib="4" loc="(1120,400)" name="Counter">
-      <a name="width" val="32"/>
-      <a name="max" val="0xffffffff"/>
-    </comp>
-    <comp lib="3" loc="(470,350)" name="Comparator">
+    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
+    <comp lib="3" loc="(470,510)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="1" loc="(660,370)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(600,350)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1030,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(1100,440)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(1190,230)" name="AND Gate">
+    <comp lib="1" loc="(870,320)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
@@ -2823,81 +1572,26 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="RT"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="0" loc="(730,130)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(930,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="FlushIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(730,150)" name="Pin">
-      <a name="label" val="IsToBranchOrJump"/>
-    </comp>
-    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(320,340)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#MEM"/>
-    </comp>
     <comp lib="3" loc="(470,430)" name="Comparator">
       <a name="width" val="5"/>
     </comp>
-    <comp lib="1" loc="(600,510)" name="AND Gate">
-      <a name="size" val="30"/>
+    <comp lib="1" loc="(760,330)" name="AND Gate">
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="3" loc="(470,310)" name="Comparator">
+    <comp lib="1" loc="(660,490)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="3" loc="(470,390)" name="Comparator">
       <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(730,130)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="0" loc="(510,270)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="ReadRs"/>
       <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1060,340)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallID"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(540,270)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1060,300)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="StallIF"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(760,330)" name="AND Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(470,470)" name="Comparator">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(410,420)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(340,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(920,120)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-      <a name="negate0" val="true"/>
     </comp>
     <comp lib="0" loc="(1210,240)" name="Pin">
       <a name="facing" val="west"/>
@@ -2905,50 +1599,35 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="FlushID"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(320,460)" name="Pin">
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="WriteReg#EX"/>
-    </comp>
-    <comp lib="1" loc="(510,310)" name="NOT Gate"/>
-    <comp lib="1" loc="(660,490)" name="OR Gate">
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(140,300)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="width" val="5"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="RS"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(410,300)" name="Constant">
-      <a name="width" val="5"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(980,320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(600,390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(470,510)" name="Comparator">
-      <a name="width" val="5"/>
+    <comp lib="4" loc="(810,130)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
     </comp>
     <comp lib="1" loc="(870,400)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(380,130)" name="Tunnel">
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="1" loc="(600,470)" name="AND Gate">
+    <comp lib="1" loc="(600,390)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="3" loc="(470,390)" name="Comparator">
+    <comp lib="0" loc="(730,150)" name="Pin">
+      <a name="label" val="IsToBranchOrJump"/>
+    </comp>
+    <comp lib="1" loc="(920,120)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+      <a name="negate0" val="true"/>
+    </comp>
+    <comp lib="1" loc="(600,510)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(1140,240)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(410,420)" name="Constant">
       <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
     </comp>
     <comp lib="0" loc="(1180,400)" name="Pin">
       <a name="facing" val="west"/>
@@ -2957,14 +1636,100 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="BubbleNum"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="3" loc="(470,350)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(1100,440)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(980,320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(410,300)" name="Constant">
+      <a name="width" val="5"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(600,350)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1190,230)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(510,430)" name="NOT Gate"/>
+    <comp lib="3" loc="(470,470)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(1060,300)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="StallIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(600,470)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(930,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="FlushIF"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(740,450)" name="AND Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1030,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+    </comp>
     <comp lib="0" loc="(820,390)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="RegWriteEX"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(870,320)" name="AND Gate">
-      <a name="size" val="30"/>
+    <comp lib="3" loc="(470,310)" name="Comparator">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(340,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="1" loc="(660,370)" name="OR Gate">
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(380,130)" name="Tunnel">
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(320,460)" name="Pin">
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="WriteReg#EX"/>
+    </comp>
+    <comp lib="0" loc="(140,300)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="width" val="5"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="RS"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="4" loc="(1120,400)" name="Counter">
+      <a name="width" val="32"/>
+      <a name="max" val="0xffffffff"/>
+    </comp>
+    <comp lib="0" loc="(1060,340)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="StallID"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(820,310)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RegWriteMEM"/>
+      <a name="labelloc" val="north"/>
     </comp>
   </circuit>
   <circuit name="Hazard_Detector">
@@ -3940,26 +2705,114 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <wire from="(100,2410)" to="(490,2410)"/>
     <wire from="(160,2470)" to="(550,2470)"/>
     <wire from="(280,980)" to="(280,1100)"/>
-    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+    <comp lib="1" loc="(510,1780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+    <comp lib="1" loc="(600,1450)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,2980)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1550)" name="NOT Gate">
+    <comp lib="0" loc="(40,580)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2350)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3640)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,2040)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(520,2660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,2750)" name="NOT Gate">
+    <comp lib="1" loc="(600,1610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,1170)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1930)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,600)" name="NOT Gate">
+    <comp lib="1" loc="(320,3520)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3460)" name="NOT Gate">
+    <comp lib="1" loc="(320,1020)" name="NOT Gate">
       <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1980)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4320)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,110)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3740)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3070)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3770)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1300)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,1960)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRs"/>
+      <a name="labelloc" val="north"/>
     </comp>
     <comp lib="1" loc="(410,250)" name="AND Gate">
       <a name="size" val="30"/>
@@ -3969,10 +2822,148 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(520,4480)" name="NOT Gate">
+    <comp lib="1" loc="(410,3500)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4270)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1870)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(710,1960)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="10"/>
+    </comp>
+    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,830)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="9"/>
+    </comp>
+    <comp lib="1" loc="(510,1520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4040)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(410,3160)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,370)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,860)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,1230)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,600)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2560)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,80)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,1900)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(600,2550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3490)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,2720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,1290)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,650)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,570)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4000)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3120)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4660)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4380)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(690,4470)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="4"/>
+    </comp>
+    <comp lib="0" loc="(40,330)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,1100)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,750)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,2520)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(730,4470)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="ReadRt"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(520,3640)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="11"/>
+    </comp>
+    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3010)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,3780)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -3980,74 +2971,34 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4510)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,830)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="9"/>
-    </comp>
-    <comp lib="1" loc="(320,540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2250)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
     <comp lib="1" loc="(510,1390)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2520)" name="NOT Gate">
+    <comp lib="0" loc="(40,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct1"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,440)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,2130)" name="AND Gate">
+    <comp lib="1" loc="(320,1330)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(520,4620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,110)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+      <a name="inputs" val="7"/>
     </comp>
-    <comp lib="1" loc="(320,4110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1650)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,790)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,860)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2100)" name="NOT Gate">
+    <comp lib="1" loc="(320,4230)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,180)" name="Pin">
@@ -4055,149 +3006,46 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op3"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(410,3020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(600,1750)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2040)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4150)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3700)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1330)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,240)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1230)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,230)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op4"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,3010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1870)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3430)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,2720)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="7"/>
-    </comp>
-    <comp lib="1" loc="(520,3640)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="11"/>
-    </comp>
-    <comp lib="1" loc="(520,4380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,80)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,480)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct3"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(520,2690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,140)" name="NOT Gate">
+    <comp lib="1" loc="(520,2750)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,1260)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,210)" name="NOT Gate">
+    <comp lib="1" loc="(320,3460)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3400)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1840)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1420)" name="NOT Gate">
+    <comp lib="1" loc="(320,1180)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,2850)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1100)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3370)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,1360)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1580)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,550)" name="AND Gate">
+    <comp lib="1" loc="(410,690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3660)" name="NOT Gate">
+    <comp lib="1" loc="(520,4480)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3640)" name="AND Gate">
+    <comp lib="1" loc="(510,2410)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,1050)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(40,330)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct0"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(320,300)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,410)" name="AND Gate">
+    <comp lib="1" loc="(600,1750)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3310)" name="NOT Gate">
+    <comp lib="1" loc="(520,4690)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3520)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4270)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4320)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,20)" name="NOT Gate">
+    <comp lib="1" loc="(320,470)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,430)" name="Pin">
@@ -4205,71 +3053,37 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct2"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(410,3320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(320,1360)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(610,4670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
+    <comp lib="1" loc="(520,4450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,280)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op5"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,50)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,4190)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,110)" name="AND Gate">
+    <comp lib="1" loc="(610,2720)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="7"/>
     </comp>
-    <comp lib="1" loc="(320,510)" name="NOT Gate">
+    <comp lib="1" loc="(320,3430)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3800)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,2780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2880)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1450)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2260)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,940)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3780)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1980)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,2020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,1460)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3740)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3340)" name="NOT Gate">
+    <comp lib="1" loc="(510,170)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(40,530)" name="Pin">
@@ -4277,16 +3091,55 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="Funct4"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,3220)" name="NOT Gate">
+    <comp lib="1" loc="(320,3660)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3630)" name="NOT Gate">
+    <comp lib="1" loc="(320,3280)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4750)" name="NOT Gate">
+    <comp lib="1" loc="(410,3020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1650)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(600,2550)" name="AND Gate">
+    <comp lib="1" loc="(510,2140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,3190)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,140)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,480)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="Funct3"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,510)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,30)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op0"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(410,550)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(510,1580)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,4260)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
@@ -4295,136 +3148,43 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
       <a name="label" val="op1"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(320,3950)" name="NOT Gate">
+    <comp lib="1" loc="(320,3570)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct1"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="0" loc="(40,280)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op5"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(410,4140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,440)" name="NOT Gate">
+    <comp lib="1" loc="(520,4510)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1060)" name="NOT Gate">
+    <comp lib="1" loc="(510,1460)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(610,4390)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3250)" name="NOT Gate">
+    <comp lib="1" loc="(510,2010)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2380)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,1690)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(690,4470)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="4"/>
-    </comp>
-    <comp lib="1" loc="(320,1020)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(510,2190)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,110)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1050)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,3120)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,750)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,4040)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,710)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(600,1900)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(410,830)" name="AND Gate">
+    <comp lib="1" loc="(410,3320)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
     <comp lib="1" loc="(320,3910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4420)" name="NOT Gate">
+    <comp lib="1" loc="(320,3220)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,170)" name="NOT Gate">
+    <comp lib="1" loc="(510,1550)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3770)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,680)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4660)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3070)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,3490)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(40,30)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op0"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,300)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,3160)" name="AND Gate">
+    <comp lib="1" loc="(600,2130)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2220)" name="NOT Gate">
+    <comp lib="1" loc="(600,2020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,2880)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1930)" name="NOT Gate">
+    <comp lib="1" loc="(510,2290)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(610,4550)" name="AND Gate">
@@ -4434,136 +3194,141 @@ c 2011ffff 118c00 2020 24840064 2484ff9c 14800017 2020
     <comp lib="1" loc="(510,2320)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,470)" name="NOT Gate">
+    <comp lib="1" loc="(520,2780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2410)" name="NOT Gate">
+    <comp lib="1" loc="(510,1720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,270)" name="NOT Gate">
+    <comp lib="1" loc="(320,1060)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,2560)" name="NOT Gate">
+    <comp lib="1" loc="(520,4720)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3840)" name="NOT Gate">
+    <comp lib="1" loc="(510,1840)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(410,3500)" name="AND Gate">
+    <comp lib="1" loc="(520,2690)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4150)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,790)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(600,2420)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(510,2140)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,570)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2600)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,4470)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRt"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(510,2350)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(510,2010)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+    <comp lib="1" loc="(320,3800)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3880)" name="NOT Gate">
+    <comp lib="1" loc="(510,2600)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,1180)" name="NOT Gate">
+    <comp lib="1" loc="(510,2100)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,3150)" name="NOT Gate">
+    <comp lib="1" loc="(600,2260)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,3400)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,4350)" name="NOT Gate">
+    <comp lib="1" loc="(320,3340)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,650)" name="NOT Gate">
+    <comp lib="1" loc="(610,4390)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(610,4670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(520,2630)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,240)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,680)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,4030)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(410,410)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
+    </comp>
+    <comp lib="1" loc="(320,710)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,540)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(510,20)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,2940)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(40,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op4"/>
+      <a name="labelloc" val="north"/>
+    </comp>
+    <comp lib="1" loc="(320,3700)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(320,210)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,3040)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(320,330)" name="NOT Gate">
+    <comp lib="1" loc="(520,4350)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(40,580)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="Funct5"/>
-      <a name="labelloc" val="north"/>
+    <comp lib="1" loc="(410,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="6"/>
     </comp>
-    <comp lib="0" loc="(40,130)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="op2"/>
-      <a name="labelloc" val="north"/>
-    </comp>
-    <comp lib="1" loc="(320,820)" name="NOT Gate">
+    <comp lib="1" loc="(320,270)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(410,2860)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="6"/>
     </comp>
-    <comp lib="1" loc="(320,3280)" name="NOT Gate">
+    <comp lib="1" loc="(320,400)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(710,1960)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="10"/>
-    </comp>
-    <comp lib="1" loc="(600,2420)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(520,4540)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(520,4720)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(730,1960)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="ReadRs"/>
+    <comp lib="0" loc="(40,130)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="op2"/>
       <a name="labelloc" val="north"/>
     </comp>
-    <comp lib="1" loc="(510,50)" name="NOT Gate">
+    <comp lib="1" loc="(320,3880)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(520,2630)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(320,4000)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(410,1170)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="6"/>
-    </comp>
-    <comp lib="1" loc="(320,400)" name="NOT Gate">
+    <comp lib="1" loc="(320,3370)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
     <comp lib="1" loc="(320,2910)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="1" loc="(510,1620)" name="NOT Gate">
+    <comp lib="1" loc="(510,2450)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
   </circuit>


### PR DESCRIPTION
This PR moves pipeline-related buffer set components (i.e., "IF/ID", "ID/EX", "EX/MEM", and "MEM/WBN") to a separate library `common/pipeline.circ` to be shared between `pipelined_cpu.circ` and `pipeline_bubbling.circ`.

The pipelined CPU with bubbling needs a few tweaks since the buffer set for pipelined CPU is a bit longer (due to CP0 and handling of exceptions). Specifically, the hazard unit components are moved downwards to make room for the longer buffer set.

Before:
![bubble_before](https://user-images.githubusercontent.com/10323518/179404445-c7376f80-8e29-473c-b541-d1419d753597.png)

After:
![bubble_after](https://user-images.githubusercontent.com/10323518/179404446-2b25458d-bfac-460c-a2df-3b4b15557e0a.png)

